### PR TITLE
Add params::addText() and params::setOptions()

### DIFF
--- a/include/cinder/params/Params.h
+++ b/include/cinder/params/Params.h
@@ -35,7 +35,7 @@ namespace cinder { namespace params {
 class InterfaceGl {
  public:
 	InterfaceGl() {}
-	InterfaceGl( const std::string &title, const Vec2i &size, const ColorA = ColorA( 0.3f, 0.3f, 0.3f, 0.4f ) );
+	InterfaceGl( const std::string &title, const std::string &optionsStr = "" );
 	
 	static void		draw();
 

--- a/samples/ParamsBasic/src/ParamsBasicApp.cpp
+++ b/samples/ParamsBasic/src/ParamsBasicApp.cpp
@@ -31,15 +31,16 @@ void TweakBarApp::setup()
 	mCam.lookAt( Vec3f( -20, 0, 0 ), Vec3f::zero() );
 
 	// Setup the parameters
-	mParams = params::InterfaceGl( "App parameters", Vec2i( 200, 400 ) );
+	mParams = params::InterfaceGl( "App parameters", "size='200 350'" );
 	mParams.addParam( "Cube Size", &mObjSize, "min=0.1 max=20.5 step=0.5 keyIncr=z keyDecr=Z" );
 	mParams.addParam( "Cube Rotation", &mObjOrientation );
 	mParams.addParam( "Cube Color", &mColor, "" );	
 	mParams.addSeparator();	
 	mParams.addParam( "Light Direction", &mLightDirection, "" );
-	mParams.addButton( "Button!", std::bind( &TweakBarApp::button, this ) );
+	mParams.addSeparator();	
+	mParams.addButton( "Button", std::bind( &TweakBarApp::button, this ) );
 	mParams.addText( "text", "label=`This is a label without a parameter.`" );
-	mParams.addParam( "String ", &mString, "" );
+	mParams.addParam( "String", &mString, "" );
 }
 
 void TweakBarApp::button()

--- a/samples/Tubular/src/TubularApp.cpp
+++ b/samples/Tubular/src/TubularApp.cpp
@@ -148,7 +148,7 @@ void TubularApp::setup()
 	mArcball.setCenter( getWindowCenter() );
 	mArcball.setRadius( 150 );		
 	
-	mParams = params::InterfaceGl( "Parameters", Vec2i( 200, 200 ) );
+	mParams = params::InterfaceGl( "Parameters", "size='200 200'" );
 	mParams.addParam( "Parallel Transport", &mParallelTransport, "keyIncr=f" );
 	mParams.addParam( "Draw Curve", &mDrawCurve, "keyIncr=c" );
 	mParams.addParam( "Wireframe", &mWireframe, "keyIncr=w" );

--- a/src/cinder/params/Params.cpp
+++ b/src/cinder/params/Params.cpp
@@ -122,13 +122,13 @@ void initAntGl()
 }
 
 
-InterfaceGl::InterfaceGl( const std::string &title, const Vec2i &size, const ColorA color )
+InterfaceGl::InterfaceGl( const std::string &title, const std::string &optionsStr )
 {
 	initAntGl();
 	mBar = std::shared_ptr<TwBar>( TwNewBar( title.c_str() ), TwDeleteBar );
-	char optionsStr[1024];
-	sprintf( optionsStr, "`%s` size='%d %d' color='%d %d %d' alpha=%d", title.c_str(), size.x, size.y, (int)(color.r * 255), (int)(color.g * 255), (int)(color.b * 255), (int)(color.a * 255) );
-	TwDefine( optionsStr );
+	
+	std::string def = "`" + title + "` " + optionsStr;
+	TwDefine( def.c_str() );
 	
 	TwCopyStdStringToClientFunc( implStdStringToClient );
 }


### PR DESCRIPTION
As discussed in this thread:
http://forum.libcinder.org/topic/callback-for-twaddbutton

Andrewfb added an addButton() method on my request:
https://github.com/cinder/Cinder/commit/b56f5089312940b2e6a6f1363ecaedd0ad816c48

The TWaddButton() method in AntTweakBar doubles as a way to create a text label when called without a callback parameter. The proposed changes make this functionality into a separate method for the cinder params interface to AntTweakBar. It just makes more sense than creating a button that renders without a button.

In a similar vein, I created a params::setOptions() method that wraps the TWdefine() method in a way so that the argument syntax is similar to the other methods in the params class. The raw TWdefine() call requires you to add the bar name and optional var name in the optionsString, whereas the other methods that use optionsStrings don't. Since there's only going to be a single bar in the cinder implementation anyway, it makes more sense to be consistent with the other calls. Since the params implementation uses the caption of bars and vars as names, the names are enclosed in backticks (which are are least likely characters to be in the captions).  

NB: I don't _really_ know what I am doing yet. There might be more elegant ways to do what I did. I just poke at code until it works...
