### PR TITLE
Audio sample shared_ptr fix

### DIFF
--- a/samples/AudioAnalysisSample/src/AudioAnalysisSampleApp.cpp
+++ b/samples/AudioAnalysisSample/src/AudioAnalysisSampleApp.cpp
@@ -102,7 +102,7 @@ void AudioAnalysisSampleApp::drawFft()
 	if( ! mPcmBuffer ) return;
 	
 	//use the most recent Pcm data to calculate the Fft
-	boost::shared_ptr<float> fftRef = audio::calculateFft( mPcmBuffer->getChannelData( audio::CHANNEL_FRONT_LEFT ), bandCount );
+	std::shared_ptr<float> fftRef = audio::calculateFft( mPcmBuffer->getChannelData( audio::CHANNEL_FRONT_LEFT ), bandCount );
 	if( ! fftRef ) {
 		return;
 	}

--- a/samples/AudioInputSample/src/AudioInputSampleApp.cpp
+++ b/samples/AudioInputSample/src/AudioInputSampleApp.cpp
@@ -28,7 +28,7 @@ class AudioInputSampleApp : public AppBase {
 #endif
 	
 	audio::Input mInput;
-	boost::shared_ptr<float> mFftDataRef;
+	std::shared_ptr<float> mFftDataRef;
 	audio::PcmBuffer32fRef mPcmBuffer;
 };
 


### PR DESCRIPTION
Changed old boost::shared_ptr declarations to std::shared_ptr in two Audio sample .cpp files (the only two with compile problems). Fixes compilation errors, and probably alleviates confusion for people basing their audio code off of the samples.
