### PR TITLE
Added pointer variations for buffering data in VboMesh

### DIFF
--- a/include/cinder/gl/Vbo.h
+++ b/include/cinder/gl/Vbo.h
@@ -184,10 +184,13 @@ class VboMesh {
 	static void		unbindBuffers();
 
 	void						bufferIndices( const std::vector<uint32_t> &indices );
+    void						bufferIndices( const uint32_t *indices, size_t count );
 	void						bufferPositions( const std::vector<Vec3f> &positions );
 	void						bufferPositions( const Vec3f *positions, size_t count );
 	void						bufferNormals( const std::vector<Vec3f> &normals );
+    void						bufferNormals( const Vec3f *normals, size_t count );
 	void						bufferTexCoords2d( size_t unit, const std::vector<Vec2f> &texCoords );
+    void						bufferTexCoords2d( size_t unit, const Vec2f *texCoords, size_t count );
 	class VertexIter			mapVertexBuffer();
 
 	Vbo&				getIndexVbo() const { return mObj->mBuffers[INDEX_BUFFER]; }

--- a/src/cinder/gl/Vbo.cpp
+++ b/src/cinder/gl/Vbo.cpp
@@ -507,7 +507,12 @@ void VboMesh::unbindBuffers()
 
 void VboMesh::bufferIndices( const std::vector<uint32_t> &indices )
 {
-	mObj->mBuffers[INDEX_BUFFER].bufferData( sizeof(uint32_t) * indices.size(), &(indices[0]), (mObj->mLayout.hasStaticIndices()) ? GL_STATIC_DRAW : GL_STREAM_DRAW );
+	bufferIndices( &(indices[0]), indices.size() );
+}
+    
+void VboMesh::bufferIndices( const uint32_t *indices, size_t count )
+{
+    mObj->mBuffers[INDEX_BUFFER].bufferData( sizeof(uint32_t) * count, indices, (mObj->mLayout.hasStaticIndices()) ? GL_STATIC_DRAW : GL_STREAM_DRAW );
 }
 
 void VboMesh::bufferPositions( const std::vector<Vec3f> &positions )
@@ -536,15 +541,20 @@ void VboMesh::bufferPositions( const Vec3f *positions, size_t count )
 
 void VboMesh::bufferNormals( const std::vector<Vec3f> &normals )
 {
+    bufferNormals( &(normals[0]), normals.size() );
+}
+
+void VboMesh::bufferNormals( const Vec3f *normals, size_t count )
+{
 	if( mObj->mLayout.hasDynamicNormals() ) {
 		if( mObj->mDynamicStride == 0 )
-			getDynamicVbo().bufferSubData( mObj->mNormalOffset, sizeof(Vec3f) * normals.size(), &(normals[0]) );
+			getDynamicVbo().bufferSubData( mObj->mNormalOffset, sizeof(Vec3f) * count, normals );
 		else
 			throw;
 	}
 	else if( mObj->mLayout.hasStaticNormals() ) {
 		if( mObj->mStaticStride == 0 ) { // planar data
-			getStaticVbo().bufferSubData( mObj->mNormalOffset, sizeof(Vec3f) * normals.size(), &(normals[0]) );
+			getStaticVbo().bufferSubData( mObj->mNormalOffset, sizeof(Vec3f) * count, normals );
 		}
 		else
 			throw;
@@ -555,21 +565,26 @@ void VboMesh::bufferNormals( const std::vector<Vec3f> &normals )
 
 void VboMesh::bufferTexCoords2d( size_t unit, const std::vector<Vec2f> &texCoords )
 {
-	if( mObj->mLayout.hasDynamicTexCoords2d() ) {
-		if( mObj->mDynamicStride == 0 )
-			getDynamicVbo().bufferSubData( mObj->mTexCoordOffset[unit], sizeof(Vec2f) * texCoords.size(), &(texCoords[0]) );
-		else
-			throw;
-	}
-	else if( mObj->mLayout.hasStaticTexCoords2d() ) {
-		if( mObj->mStaticStride == 0 ) { // planar data
-			getStaticVbo().bufferSubData( mObj->mTexCoordOffset[unit], sizeof(Vec2f) * texCoords.size(), &(texCoords[0]) );
-		}
-		else
-			throw;
-	}
-	else
-		throw;
+	bufferTexCoords2d( unit, &(texCoords[0]), texCoords.size() );
+}
+
+void VboMesh::bufferTexCoords2d( size_t unit, const Vec2f *texCoords, size_t count )
+{
+    if( mObj->mLayout.hasDynamicTexCoords2d() ) {
+        if( mObj->mDynamicStride == 0 )
+            getDynamicVbo().bufferSubData( mObj->mTexCoordOffset[unit], sizeof(Vec2f) * count, texCoords );
+        else
+            throw;
+    }
+    else if( mObj->mLayout.hasStaticTexCoords2d() ) {
+        if( mObj->mStaticStride == 0 ) { // planar data
+            getStaticVbo().bufferSubData( mObj->mTexCoordOffset[unit], sizeof(Vec2f) * count, texCoords );
+        }
+        else
+            throw;
+    }
+    else
+        throw;
 }
 
 


### PR DESCRIPTION
I needed this functionality when loading some static arrays into a Vbo. It didn't really make sense to use a vector.. It's also more consistent now with what bufferPositions() was doing. Hopefully the overhead of another function call is not too much..
