### PR TITLE
Utilities: getUniquePath and leftPaddedString

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include "cinder/Cinder.h"
 #include "cinder/Url.h"
+#include "cinder/Filesystem.h"
 #include <boost/lexical_cast.hpp>
 
 namespace cinder {
@@ -46,6 +47,10 @@ std::string getPathDirectory( const std::string &path );
 std::string getPathFileName( const std::string &path );
 //! Returns the file extension of the file located at \a path
 std::string getPathExtension( const std::string &path );
+//! Returns a unique pathname, numbered sequentially to avoid conflicts with files of the same/similar name.
+std::string getUniquePath( const std::string &path, const std::string &sep = "-", int padding = 2, bool initialNumbering = true );
+//! Returns a left-padded string based on the input string
+std::string leftPaddedString( const std::string &input, int padding=2, const std::string pad="0" );
 //! Creates a directory at \a path and optionally creates any missing parent directories when \a createParents is \c true. Returns \c true upon success.
 bool createDirectories( const std::string &path, bool createParents = true );
 

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -186,6 +186,38 @@ std::string getPathExtension( const std::string &path )
 		return std::string();
 }
 
+
+std::string getUniquePath( const std::string &path, const std::string &sep, int padding, bool initialNumbering ) 
+{
+	fs::path p( path );
+	string extension = p.extension().string();
+	string stem = p.stem().string();
+	fs::path parent_path = p.parent_path();
+	
+	int count = 0;
+	if( initialNumbering )
+		p = parent_path / ( stem + sep + leftPaddedString( toString(count), padding ) + extension );
+	
+	while ( fs::exists( p ) )
+	{
+		p = parent_path / ( stem + sep + leftPaddedString( toString(count), padding ) + extension );
+		++count;
+	}
+	
+	return p.generic_string();
+}
+
+std::string leftPaddedString( const std::string &input, int padding, const std::string pad )
+{
+	std::string output(input);
+	while ( output.size() < padding )
+	{
+		output = pad + output;
+	}
+	
+	return output;
+}
+	
 bool createDirectories( const std::string &path, bool createParents )
 {
 	if( path.empty() )


### PR DESCRIPTION
Adds a dependency on cinder/Filesystem.h to cinder/Utilities.h

Enables stuff like this:
writeImage( getUniquePath("../../someFilename.png"), copyWindowSurface() );

when called sequentially, outputs files to
../../someFilename-00.png
../../someFilename-01.png
../../someFilename-02.png
...
../../someFilename-22.png

leftPaddedString is used to pad the numbers.
