### PR TITLE
Implement audio Input::findDeviceByName and findDeviceByNameContains.

### DIFF
--- a/src/cinder/audio/Input.cpp
+++ b/src/cinder/audio/Input.cpp
@@ -53,11 +53,21 @@ InputDeviceRef Input::getDefaultDevice()
 
 InputDeviceRef Input::findDeviceByName( const std::string &name )
 {
+	const std::vector<InputDeviceRef>& devices = getDevices();
+	for (size_t i = 0; i < devices.size(); ++i) {
+		if (devices[i]->getName() == name)
+			return devices[i];
+	}
 	return InputDeviceRef();
 }
 
 InputDeviceRef Input::findDeviceByNameContains( const std::string &nameFragment )
 {
+	const std::vector<InputDeviceRef>& devices = getDevices();
+	for (size_t i = 0; i < devices.size(); ++i) {
+		if (devices[i]->getName().find(nameFragment) != std::string::npos)
+			return devices[i];
+	}
 	return InputDeviceRef();
 }
 


### PR DESCRIPTION
Nothing fancy, and works well here for what I needed.

The one question is whether you should pass true to getDevices(), to force a refresh.  I left it with the default behavior, figuring you can always call getDevices(true) before making the findDevice call, but you can't do the opposite (preventing findDevices from refreshing).

-- dean
