### PR TITLE
Support for loading compressed textures

### DIFF
--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -140,7 +140,7 @@ class Texture {
 	//!	Creates a new Texture from raw DirectDraw Stream data
 	static Texture	loadDds( IStreamRef ddsStream, Format format );
 	/** \brief Constructs a compressed texture of size(\a aWidth, \a aHeight), storing the data in internal format \a aInternalFormat. \a dataFormat is not used. **/
-	static Texture	withCompressedData( const unsigned char *data, int aWidth, int aHeight, int compressedDataSize, Format format = Format() );
+	static Texture	withCompressedData( const unsigned char *data, int aWidth, int aHeight, size_t compressedDataSize, Format format = Format() );
 
 	//! Converts a SurfaceChannelOrder into an appropriate OpenGL dataFormat and type
 	static void		SurfaceChannelOrderToDataFormatAndType( const SurfaceChannelOrder &sco, GLint *dataFormat, GLenum *type );

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -107,16 +107,16 @@ Texture::Texture( const unsigned char *data, int dataFormat, int aWidth, int aHe
 	init( data, 0, dataFormat, GL_UNSIGNED_BYTE, format );
 }
 
-Texture Texture::withCompressedData( const unsigned char *data, int aWidth, int aHeight, int compressedDataSize, Format format )
+Texture Texture::withCompressedData( const unsigned char *data, int aWidth, int aHeight, size_t compressedDataSize, Format format )
 {
-    Texture result;
-    result.mObj = shared_ptr<Obj>( new Obj( aWidth, aHeight ) );
-    if( format.mInternalFormat == -1 )
+	Texture result;
+	result.mObj = shared_ptr<Obj>( new Obj( aWidth, aHeight ) );
+	if( format.mInternalFormat == -1 )
 		format.mInternalFormat = GL_RGBA;
-    result.mObj->mInternalFormat = format.mInternalFormat;
+	result.mObj->mInternalFormat = format.mInternalFormat;
 	result.mObj->mTarget = format.mTarget;
 	result.init( data, compressedDataSize, format );
-    return result;
+	return result;
 }
 
 Texture::Texture( const Surface8u &surface, Format format )


### PR DESCRIPTION
This adds a way to use glCompressedTexImage2D() to load compressed texture data. I used it for PVRTC on iPad, but there's nothing specific to that in here. The one thing it's lacking is a way to handle mip-mapped textures.. but I can add that eventually if someone needs it.
