### PR TITLE
Added Color and ColorA variants to GlslProg::uniform()

### DIFF
--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -31,6 +31,7 @@
 
 #include "cinder/gl/gl.h"
 #include "cinder/Vector.h"
+#include "cinder/Color.h"
 #include "cinder/Matrix.h"
 #include "cinder/DataSource.h"
 
@@ -61,6 +62,8 @@ class GlslProg {
 	void	uniform( const std::string &name, const Vec2f &data );
 	void	uniform( const std::string &name, const Vec3f &data );
 	void	uniform( const std::string &name, const Vec4f &data );
+	void	uniform( const std::string &name, const Color &data );
+	void	uniform( const std::string &name, const ColorA &data );
 	void	uniform( const std::string &name, const Matrix44f &data, bool transpose = false );	
 	void	uniform( const std::string &name, const float *data, int count );
 	void	uniform( const std::string &name, const Vec2f *data, int count );

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -195,6 +195,18 @@ void GlslProg::uniform( const std::string &name, const Vec4f &data )
 	glUniform4f( loc, data.x, data.y, data.z, data.w );
 }
 
+void GlslProg::uniform( const std::string &name, const Color &data )
+{
+	GLint loc = getUniformLocation( name );
+	glUniform3f( loc, data.r, data.g, data.b );
+}
+
+void GlslProg::uniform( const std::string &name, const ColorA &data )
+{
+	GLint loc = getUniformLocation( name );
+	glUniform4f( loc, data.r, data.g, data.b, data.a );
+}
+
 void GlslProg::uniform( const std::string &name, const float *data, int count )
 {
 	GLint loc = getUniformLocation( name );


### PR DESCRIPTION
I needed this for a project.. Seemed odd to only have Vec3f and Vec4f variants when Color and ColorA are basically the same.
