### PR TITLE
Added simple method that forces the application gain focus

### DIFF
--- a/include/cinder/app/AppBasic.h
+++ b/include/cinder/app/AppBasic.h
@@ -144,6 +144,8 @@ class AppBasic : public App {
 	void				hideCursor();
 	//! Shows the mouse cursor
 	void				showCursor();
+	//! Forces the application to become 'focused'
+	void				getFocus();
 
 	const Settings&		getSettings() const { return mSettings; }
 	const Display&		getDisplay();

--- a/src/cinder/app/AppBasic.cpp
+++ b/src/cinder/app/AppBasic.cpp
@@ -192,6 +192,15 @@ void AppBasic::setFullScreen( bool aFullScreen )
 #endif
 	}
 }
+	
+void AppBasic::getFocus()
+{
+#if defined( CINDER_COCOA )
+	return [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
+#elif defined( CINDER_MSW )
+	// Something else
+#endif
+}
 
 Vec2i AppBasic::getMousePos() const
 {


### PR DESCRIPTION
Just a tiny method

    void AppBasic::getFocus()
	{
	#if defined( CINDER_COCOA )
		[[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
	#elif defined( CINDER_MSW )
		// Something else
	#endif
	}