### PR TITLE
Add gzip compatiblity to decompressBuffer()

### DIFF
--- a/include/cinder/Buffer.h
+++ b/include/cinder/Buffer.h
@@ -78,6 +78,6 @@ class Buffer {
 };
 
 Buffer compressBuffer( const Buffer &aBuffer, int8_t compressionLevel = DEFAULT_COMPRESSION_LEVEL, bool resizeResult = true );
-Buffer decompressBuffer( const Buffer &aBuffer, bool useGZip = false, bool resizeResult = true );
+Buffer decompressBuffer( const Buffer &aBuffer, bool resizeResult = true, bool useGZip = false );
 
 } //namespace

--- a/src/cinder/Buffer.cpp
+++ b/src/cinder/Buffer.cpp
@@ -105,7 +105,7 @@ Buffer compressBuffer( const Buffer &aBuffer, int8_t compressionLevel, bool resi
 	return outBuffer;
 }
 
-Buffer decompressBuffer( const Buffer &aBuffer, bool useGZip, bool resizeResult )
+Buffer decompressBuffer( const Buffer &aBuffer, bool resizeResult, bool useGZip )
 {
 	int err;
 	z_stream strm;


### PR DESCRIPTION
The default behavior of zlib is to use their own header which is incompatible with gzip. I added a bool argument to decompressBuffer() for gzip files. Just tested this, and it works.
