### PR TITLE
reduced fragility of OSCListener sample

### DIFF
--- a/blocks/osc/samples/OSCListener/src/OSCListenerApp.cpp
+++ b/blocks/osc/samples/OSCListener/src/OSCListenerApp.cpp
@@ -79,8 +79,6 @@ void OSCListenerApp::update(){
 				catch (...) {
 					console() << "Exception reading argument as float" << std::endl;
 				}
-				
-				positionX = message.getArgAsFloat(0);
 			}else if (message.getArgType(i) == osc::TYPE_STRING){
 				try {
 					console() << "------ value: " << message.getArgAsString(i).c_str() << std::endl;
@@ -91,6 +89,11 @@ void OSCListenerApp::update(){
 							
 			}
 		}
+        
+        if( message.getNumArgs() != 0 && message.getArgType( 0 ) == osc::TYPE_FLOAT )
+        {
+            positionX = message.getArgAsFloat(0);
+        }
 		
 	}
 }


### PR DESCRIPTION
Testing the OSCListener sample with MSARemote on my iPhone led to OscExcInvalidArgumentType exceptions being thrown. This was due to argument 0 not necessarily being a float. I changed the code to test whether argument 0 is a float before using it. No more crashes, just wonderment at how smoothly OSC is working between devices.
