### PR TITLE
Fixed a bug in the VboMesh constructor. 

### DIFF
--- a/src/cinder/gl/Vbo.cpp
+++ b/src/cinder/gl/Vbo.cpp
@@ -119,6 +119,8 @@ VboMesh::VboMesh( const TriMesh &triMesh, Layout layout )
 		mObj->mLayout.setStaticIndices();
 		mObj->mLayout.setStaticPositions();
 	}
+	else
+		mObj->mLayout = layout;
 
 	mObj->mPrimitiveType = GL_TRIANGLES;
 	mObj->mNumIndices = triMesh.getNumIndices();


### PR DESCRIPTION
Fixed a bug in the VboMesh constructor. When passing a non-default Layout, the layout was not used and therefor the buffers were not generated. This caused a zero-pointer assertion fail. See discussion here: http://forum.libcinder.org/#Topic/23286000000713021
