### PR TITLE
Argument placeholders added to std:: namespace in Function.h

### DIFF
--- a/include/cinder/Function.h
+++ b/include/cinder/Function.h
@@ -38,6 +38,7 @@
 namespace std {
 	using std::tr1::function;
 	using std::tr1::bind;
+    using namespace std::tr1::placeholders;
 }
 
 namespace cinder {


### PR DESCRIPTION
Added using namespace declaration to ease use of placeholders like _1 and _2 in std::bind.

So you can write:
using namespace std;
bind( &Class::method, &instance, _1, _2 );

Instead of:
bind( &Class::method, &instance, std::tr1::placeholders::_1, std::tr1::placeholders::_2 );
