### PR TITLE
Grayscale Color constructors

### DIFF
--- a/include/cinder/Color.h
+++ b/include/cinder/Color.h
@@ -46,7 +46,7 @@ class ColorT
 	ColorT()
     	: r( 0 ), g( 0 ), b( 0 )
     {}
-    ColorT( T gray )
+    explicit ColorT( T gray )
     	: r( gray ), g( gray ), b( gray )
     {}
 	ColorT( T aR, T aG, T aB ) 
@@ -186,7 +186,7 @@ class ColorAT {
 	ColorAT() 
 		: r( 0 ), g( 0 ), b( 0 ), a( 0 )
 	{}
-    ColorAT( T gray, T aA )
+    explicit ColorAT( T gray, T aA )
     	: r( gray ), g( gray ), b( gray ), a( aA )
     {}
 	ColorAT( T aR, T aG, T aB, T aA = CHANTRAIT<T>::convert( 1.0f ) )


### PR DESCRIPTION
Simple grayscale constructors. Fills up rgb with the single value passed in. Makes it more obvious when you intend for a color to be gray, easier to type, less likely to mess up when tweaking parameters.
If you're working in b+w, you can:

Color darkGray( 0.25f ); // same as Color darkGray( 0.25f, 0.25f, 0.25f )
ColorA transparentBlack( 0.0f, 0.5f );
