### PR TITLE
Corrected Url for paris image in tutorial

### DIFF
--- a/tour/Section 1/Chapter 1/src/TutorialApp.cpp
+++ b/tour/Section 1/Chapter 1/src/TutorialApp.cpp
@@ -26,7 +26,7 @@ void TutorialApp::prepareSettings( Settings *settings )
 
 void TutorialApp::setup()
 {
-	Url url( "http://www.libcinder.org/media/tutorial/paris.jpg" );
+	Url url( "http://libcinder.org/media/tutorial/paris.jpg" );
 	mImage = gl::Texture( loadImage( loadUrl( url ) ) );
 
 	mParticleController.addParticles( 250 );

--- a/tour/Section 1/Chapter 2/src/TutorialApp.cpp
+++ b/tour/Section 1/Chapter 2/src/TutorialApp.cpp
@@ -35,7 +35,7 @@ void TutorialApp::prepareSettings( Settings *settings )
 
 void TutorialApp::setup()
 {
-	Url url( "http://www.libcinder.org/media/tutorial/paris.jpg" );
+	Url url( "http://libcinder.org/media/tutorial/paris.jpg" );
 	mChannel = Channel32f( loadImage( loadUrl( url ) ) );
 	mTexture = mChannel;
 

--- a/tour/Section 1/Chapter 3/src/TutorialApp.cpp
+++ b/tour/Section 1/Chapter 3/src/TutorialApp.cpp
@@ -63,7 +63,7 @@ void TutorialApp::keyDown( KeyEvent event )
 
 void TutorialApp::setup()
 {	
-	Url url( "http://www.libcinder.org/media/tutorial/paris.jpg" );
+	Url url( "http://libcinder.org/media/tutorial/paris.jpg" );
 	mChannel = Channel32f( loadImage( loadUrl( url ) ) );
 	mTexture = mChannel;
 

--- a/tour/Section 1/Chapter 4/src/TutorialApp.cpp
+++ b/tour/Section 1/Chapter 4/src/TutorialApp.cpp
@@ -51,7 +51,7 @@ void TutorialApp::setup()
 {	
 	mPerlin = Perlin();
 	
-	Url url( "http://www.libcinder.org/media/tutorial/paris.jpg" );
+	Url url( "http://libcinder.org/media/tutorial/paris.jpg" );
 	mChannel = Channel32f( loadImage( loadUrl( url ) ) );
 	mTexture = mChannel;
 

--- a/tour/Section 1/Chapter 5/src/TutorialApp.cpp
+++ b/tour/Section 1/Chapter 5/src/TutorialApp.cpp
@@ -58,7 +58,7 @@ void TutorialApp::setup()
 {	
 	mPerlin = Perlin();
 	
-	Url url( "http://www.libcinder.org/media/tutorial/paris.jpg" );
+	Url url( "http://libcinder.org/media/tutorial/paris.jpg" );
 	mChannel = Channel32f( loadImage( loadUrl( url ) ) );
 	mTexture = mChannel;
 


### PR DESCRIPTION
Corrected Url for paris image in tutorial (was pointing to a permanent redirect). Addresses problem with the Cinder tour tutorial raised on the forum: http://forum.libcinder.org/#Topic/23286000000900011
