### PR TITLE
Notify main app of iOS active/inactive events

### DIFF
--- a/include/cinder/app/AppCocoaTouch.h
+++ b/include/cinder/app/AppCocoaTouch.h
@@ -160,11 +160,12 @@ class AppCocoaTouch : public App {
 	void		privateAccelerated__( const Vec3f &direction );
 	//! \endcond
 
+	// The state is contained in a struct in order to avoid this .h needing to be compiled as Objective-C++
+	std::shared_ptr<AppCocoaTouchState>		mState;
+
   private:
 	friend void		setupCocoaTouchWindow( AppCocoaTouch *app );
 	
-	// The state is contained in a struct in order to avoid this .h needing to be compiled as Objective-C++
-	std::shared_ptr<AppCocoaTouchState>		mState;
 	
 	static AppCocoaTouch	*sInstance;	
 	Settings				mSettings;

--- a/src/cinder/app/AppCocoaTouch.mm
+++ b/src/cinder/app/AppCocoaTouch.mm
@@ -70,15 +70,27 @@ void setupCocoaTouchWindow( AppCocoaTouch *app )
 	setupCocoaTouchWindow( app );
 }
 
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+	[app->mState->mCinderView stopAnimation];
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application
+{
+	[app->mState->mCinderView startAnimation];
+}
+
 - (void) applicationWillResignActive:(UIApplication *)application
 {
 //	[cinderView stopAnimation];
+    [app->mState->mCinderView stopAnimation];
     app->willResignActive();
 }
 
 - (void) applicationDidBecomeActive:(UIApplication *)application
 {
 //	[cinderView startAnimation];
+    [app->mState->mCinderView startAnimation];
     app->didBecomeActive();
 }
 


### PR DESCRIPTION
This is a partial implementation of iOS system event responders in the iOS app. Useful for starting/stopping things within your c++ code, and timing the reading of user config files.

Handles:
applicationDidBecomeActive
applicationWillResignActive
