### PR TITLE
Prevent division by zero with default RectMapping

### DIFF
--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -129,7 +129,7 @@ typedef RectT<double>	Rectd;
 class RectMapping {
  public:
     RectMapping()
-        : mSrcRect( 0, 0, 0, 0 ), mDstRect( 0, 0, 0, 0 ) {}
+        : mSrcRect( 0, 0, 1, 1 ), mDstRect( 0, 0, 1, 1 ) {}
 	RectMapping( const Rectf &aSrcRect, const Rectf &aDstRect )
 		: mSrcRect( aSrcRect ), mDstRect( aDstRect ) {}
 	RectMapping( const Rectf &aSrcRect, const Rectf &aDstRect, bool preserveSrcAspect );


### PR DESCRIPTION
Default mapping is 1:1 with 1x1 rectangles to correct issue with previous 0x0 rectangles.
