### PR TITLE
SurfaceCgBitmapContext::getSurface() returns invalid cinder::Surface

### DIFF
--- a/src/cinder/cairo/Cairo.cpp
+++ b/src/cinder/cairo/Cairo.cpp
@@ -373,8 +373,8 @@ CGContextRef SurfaceQuartz::getCgContextRef()
 SurfaceCgBitmapContext::SurfaceCgBitmapContext( int32_t width, int32_t height, bool alpha )
 	: SurfaceBase( width, height )
 {
-	cinder::Surface surface = cinder::Surface( width, height, alpha, SurfaceConstraintsCgBitmapContext() );
-	mCgContextRef = cinder::cocoa::createCgBitmapContext( surface );
+	mSurface = cinder::Surface( width, height, alpha, SurfaceConstraintsCgBitmapContext() );
+	mCgContextRef = cinder::cocoa::createCgBitmapContext( mSurface );
 	// Need to flip this vertically since Quartz is lower-left origin
 	::CGContextTranslateCTM( mCgContextRef, 0.0f, height );
 	::CGContextScaleCTM( mCgContextRef, 1.0f, -1.0f );


### PR DESCRIPTION
SurfaceCgBitmapContext does not return a valid surface because in the constructor, the new surface is not stored in the mSurface member.
