### PR TITLE
Specifying Mac window/view opaque

### DIFF
--- a/src/cinder/app/AppImplCocoaBasic.mm
+++ b/src/cinder/app/AppImplCocoaBasic.mm
@@ -130,6 +130,7 @@
 	[win makeKeyAndOrderFront:nil];
 	[win setInitialFirstResponder:cinderView];
 	[win setAcceptsMouseMovedEvents:YES];
+	[win setOpaque:YES];
 	// we need to get told about it when the window changes screens so we can update the display link
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowChangedScreen:) name:NSWindowDidMoveNotification object:nil];
 	[cinderView setNeedsDisplay:YES];

--- a/src/cinder/app/CinderView.mm
+++ b/src/cinder/app/CinderView.mm
@@ -136,6 +136,11 @@
 	return YES;
 }
 
+- (BOOL)isOpaque
+{
+	return YES;
+}
+
 /////////////////////////////////////////////////////////////////////////////////
 // Event Handling
 - (BOOL)acceptsFirstResponder


### PR DESCRIPTION
This optimizes the redering loop for a non-fullscreen window. Up to 200% especially for a large window on my 10.7 / MBP15".

An opaque NSView can skip the background pre-rendering, which is totally unnecessary for Cinder's OpenGL drawing. It can be profiled as CGSBlt_fillBytes of CoreGraphic. NSView's default is non-opaque. 

This can also be tested by inserting the following code on an exiting Mac cinder project.

```
@interface DummyView : NSObject {
}
@end
@implementation DummyView
- (BOOL)isOpaque
{
    return YES;
}
@end

void SetCinderViewOpaque() {
    SEL isOpaqueSel = @selector(isOpaque);
    IMP imp = class_getMethodImplementation([DummyView class], isOpaqueSel);
    Method method = class_getInstanceMethod([DummyView class], isOpaqueSel);
    struct objc_method_description *desc = method_getDescription(method);
    char *types = desc->types;
    class_replaceMethod([CinderView class], isOpaqueSel, imp, types);
}
```
