### PR TITLE
Fix memory leak in TextureFont initializer

### DIFF
--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -224,6 +224,7 @@ TextureFont::TextureFont( const Font &font, const string &utf8Chars, const Forma
 	for( set<Font::Glyph>::const_iterator glyphIt = glyphs.begin(); glyphIt != glyphs.end(); ) {
 		DWORD dwBuffSize = ::GetGlyphOutline( Font::getGlobalDc(), *glyphIt, GGO_GRAY8_BITMAP | GGO_GLYPH_INDEX, &gm, 0, NULL, &identityMatrix );
 		if( dwBuffSize > bufferSize ) {
+			delete[] pBuff;
 			pBuff = new BYTE[dwBuffSize];
 			bufferSize = dwBuffSize;
 		}


### PR DESCRIPTION
An allocation is done in the TextureFont initializer:

```
BYTE *pBuff = new BYTE[bufferSize];
```

In the proceeding for-loop, we do:

```
if( dwBuffSize > bufferSize ) {
    pBuff = new BYTE[dwBuffSize];
    bufferSize = dwBuffSize;
}
```

The only 'delete [] pBuff' occurs at the end of the function. So the above allocation is losing the pointer to a chunk of allocated memory. 

An alternate code change would be: 

```
pBuff= (BYTE*) realloc (pBuff, dwBuffSize* sizeof(BYTE));
```

however the former is more readable. 
