### PR TITLE
Colors cannot be compared for equality

### DIFF
--- a/include/cinder/Color.h
+++ b/include/cinder/Color.h
@@ -109,6 +109,16 @@ class ColorT
 	const ColorT<T>&	operator*=( T rhs ) { r *= rhs; g *= rhs; b *= rhs; return *this; }
 	const ColorT<T>&	operator/=( T rhs ) { r /= rhs; g /= rhs; b /= rhs; return *this; }
 
+	bool operator==( const ColorT<T>& rhs ) const
+	{
+		return ( r == rhs.r ) && ( g == rhs.g ) && ( b == rhs.b );
+	}
+
+	bool operator!=( const ColorT<T>& rhs ) const
+	{
+		return ! ( *this == rhs );
+	}
+
 	typename CHANTRAIT<T>::Accum dot( const ColorT<T> &rhs ) const
 	{
 		return r*rhs.r + g*rhs.g + b*rhs.b;
@@ -251,6 +261,16 @@ class ColorAT {
 	const ColorAT<T>&	operator-=( T rhs ) {	r -= rhs; g -= rhs; b -= rhs; a -= rhs;	return * this; }
 	const ColorAT<T>&	operator*=( T rhs ) { r *= rhs; g *= rhs; b *= rhs; a *= rhs; return * this; }
 	const ColorAT<T>&	operator/=( T rhs ) { r /= rhs; g /= rhs; b /= rhs; a /= rhs;	return * this; }
+
+	bool operator==( const ColorAT<T>& rhs ) const
+	{
+		return ( r == rhs.r ) && ( g == rhs.g ) && ( b == rhs.b ) && ( a == rhs.a );
+	}
+
+	bool operator!=( const ColorAT<T>& rhs ) const
+	{
+	return ! ( *this == rhs );
+	}
 
 	float length() const
 	{


### PR DESCRIPTION
Comparing colors for equality or inequality yields unexpected results since the color classes do not implement <code>operator==</code> and <code>operator!=</code>.
