### PR TITLE
Color lerp doesn't work for non-float types

### DIFF
--- a/include/cinder/Color.h
+++ b/include/cinder/Color.h
@@ -145,7 +145,7 @@ class ColorT
 		}
 	}
 
-	ColorT<T> lerp( T fact, const ColorT<T> &d ) const
+	ColorT<T> lerp( float fact, const ColorT<T> &d ) const
 	{
 		return ColorT<T>( r + ( d.r - r ) * fact, g + ( d.g - g ) * fact, b + ( d.b - b ) * fact );
 	}


### PR DESCRIPTION
Factor parameter type changed to a float. The current version is broken for Color8u, etc.
