### PR TITLE
add RectT::inflate and RectT::inflated

### DIFF
--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -58,6 +58,8 @@ class RectT {
 	Area		getInteriorArea() const;
 	void		offset( const Vec2<T> &offset );
 	RectT		getOffset( const Vec2<T> &off ) const { RectT result( *this ); result.offset( off ); return result; }
+	void		inflate( const Vec2<T> &amount );
+	RectT		inflated( const Vec2<T> &amount ) const;
 	//! Translates the rectangle so that its center is at \a center
 	void		offsetCenterTo( const Vec2<T> &center ) { offset( center - getCenter() ); }
 	void		scaleCentered( const Vec2<T> &scale );

--- a/src/cinder/Rect.cpp
+++ b/src/cinder/Rect.cpp
@@ -118,6 +118,23 @@ void RectT<T>::offset( const Vec2<T> &offset )
 }
 
 template<typename T>
+void RectT<T>::inflate( const Vec2<T> &amount )
+{
+	x1 -= amount.x;
+	x2 += amount.x;
+	y1 -= amount.y; // assume canonical rect has y1 < y2
+	y2 += amount.y;
+}
+
+template<typename T>
+RectT<T> RectT<T>::inflated( const Vec2<T> &amount ) const
+{
+	RectT<T> result( *this );
+	result.inflate( amount );
+	return result;
+}
+
+template<typename T>
 void RectT<T>::scaleCentered( const Vec2<T> &scale )
 {
 	T halfWidth = getWidth() * scale.x / 2.0f;


### PR DESCRIPTION
Simple pull request, just one commit with two new methods on RectT. These are modeled on the flash Rectangle class's inflate method, for bumping up the size of a rectangle (or getting a new rectangle, bumped up in size).

I used `void inflate(...)` to match `void offset(...)` but `RectT inflated(...)` to match `RectT canonicalized()` rather than `RectT getOffset(...)`. I would also be OK with `RectT getInflated(...)` but I'm not sure it's worth worrying about one way or the other. Too late :)
