### PR TITLE
Added missing method Texture::hasAlpha()

### DIFF
--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -765,6 +765,29 @@ void Texture::setCleanTexCoords( float maxU, float maxV )
 	}
 }
 
+	// ROGER
+	bool Texture::hasAlpha() const
+	{
+		switch (mObj->mInternalFormat) {
+#if ! defined( CINDER_GLES )
+			case GL_RGBA8:
+			case GL_RGBA16:
+			case GL_RGBA32F_ARB:
+			case GL_LUMINANCE8_ALPHA8:
+			case GL_LUMINANCE16_ALPHA16:
+			case GL_LUMINANCE_ALPHA32F_ARB:
+#endif
+			case GL_RGBA:
+			case GL_LUMINANCE_ALPHA:
+				return true;
+				break;
+			default:
+				return false;
+				break;
+		}
+	}
+	
+	
 float Texture::getLeft() const
 {
 	return 0.0f;


### PR DESCRIPTION
The method is declared in the header but not implemented.

Sorry for the //ROGER tag on my commits, this is my way to keep track of my modifications.
Please erase it if my pulls are accepted.
