### PR TITLE
Added gl::Texture::enableAndBind(GLuint unit) 

### DIFF
--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -130,6 +130,8 @@ class Texture {
 	/**	\brief Enables the Texture's target and binds its associated texture.
 		Equivalent to calling \code glEnable( target ); glBindTexture( target, textureID ); \endcode **/
 	void			enableAndBind() const;
+	// ROGER
+	void			enableAndBind(GLuint unit) const;
 	//!	Disables the Texture's target
 	void			disable() const;
 	//!	Binds the Texture's texture to its target in the multitexturing unit \c GL_TEXTURE0 + \a textureUnit

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -908,6 +908,15 @@ void Texture::enableAndBind() const
 	glBindTexture( mObj->mTarget, mObj->mTextureID );
 }
 
+	// ROGER
+	void Texture::enableAndBind( GLuint textureUnit ) const
+	{
+		glEnable( mObj->mTarget );
+		glActiveTexture( GL_TEXTURE0 + textureUnit );
+		glBindTexture( mObj->mTarget, mObj->mTextureID );
+		glActiveTexture( GL_TEXTURE0 );
+	}
+	
 void Texture::disable() const
 {
 	glDisable( mObj->mTarget );


### PR DESCRIPTION
Useful when mixing GL_TEXTURE2D and GL_TEXTURE_RECTANGLE_ARB on the same shader.
