### PR TITLE
Avoid crash in drawStringHelper() by not drawing if string is empty

### DIFF
--- a/src/cinder/gl/gl.cpp
+++ b/src/cinder/gl/gl.cpp
@@ -1175,6 +1175,10 @@ void draw( const Texture &texture, const Area &srcArea, const Rectf &destRect )
 namespace {
 void drawStringHelper( const std::string &str, const Vec2f &pos, const ColorA &color, Font font, int justification )
 {
+	// ROGER
+	if ( str.length() == 0 )
+		return;
+	
 	// justification: { left = -1, center = 0, right = 1 }
 	SaveColorState colorState;
 


### PR DESCRIPTION
drawStringHelper() was crashing here when the string is empty.
No need to draw if empty, right?
