### PR TITLE
Added App::isMinimized() (OSX)

### DIFF
--- a/include/cinder/app/AppBasic.h
+++ b/include/cinder/app/AppBasic.h
@@ -193,6 +193,9 @@ class AppBasic : public App {
 	virtual void	privateResize__( const ResizeEvent &event );
 	//! \endcond
 	
+	// ROGER
+	bool isMinimized();
+	
  private:
  
 	static AppBasic*	sInstance;

--- a/include/cinder/app/AppImplCocoaBasic.h
+++ b/include/cinder/app/AppImplCocoaBasic.h
@@ -85,4 +85,7 @@
 - (void)setActiveTouches:(std::vector<ci::app::TouchEvent::Touch>*)touches;
 #endif // MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_5
 
+	// ROGER
+	- (bool)isMinimized;
+
 @end

--- a/src/cinder/app/AppBasic.cpp
+++ b/src/cinder/app/AppBasic.cpp
@@ -298,6 +298,16 @@ void AppBasic::privateTouchesEnded__( const TouchEvent &event )
 		touchesEnded( event );
 }
 
+	// ROGER
+	bool AppBasic::isMinimized()
+	{
+#if defined( CINDER_MAC )
+		return [mImpl isMinimized];
+#else
+		return false;
+#endif
+	};
+	
 //////////////////////////////////////////////////////////////////////////////////////////////
 // AppBasic::Settings
 AppBasic::Settings::Settings()

--- a/src/cinder/app/AppImplCocoaBasic.mm
+++ b/src/cinder/app/AppImplCocoaBasic.mm
@@ -367,4 +367,10 @@
 {
 }
 
+// ROGER
+- (bool)isMinimized
+{
+	return [win isMiniaturized];
+}
+
 @end


### PR DESCRIPTION
I use this on my Syphon apps, when I don't need to draw to the screen when the app minimized, increasing my framerate a little bit.
I implemented only for OSX, sorry i have no Windows or Linux here.
But I'm not sure if you guys like this kind of pull.
Should I pull an OSX only solution, or not?
If not, please close this.