### PR TITLE
Increasing mFrameCount after draw(), not after update()

### DIFF
--- a/src/cinder/app/App.cpp
+++ b/src/cinder/app/App.cpp
@@ -150,7 +150,8 @@ void App::privateSetup__()
 void App::privateUpdate__()
 {
 	update();
-	mFrameCount++;
+	// ROGER:: Increase mFrameCount AFTER draw()
+	//mFrameCount++;
 
 	double now = mTimer.getSeconds();
 	if( now > mFpsLastSampleTime + mFpsSampleInterval ) {
@@ -166,6 +167,8 @@ void App::privateUpdate__()
 void App::privateDraw__()
 {
 	draw();
+	// ROGER:: Increase mFrameCount AFTER draw()
+	mFrameCount++;
 }
 
 void App::privateShutdown__()


### PR DESCRIPTION
Each update() / draw() pair in the main loop should belong to the same frame, don't you agree?
I had one issue where my app was out of sync because the frame number changes between update() and draw(). I was checking the frame number on both methods, and they never match.

This is my last pull for now.
Again, sorry for the //ROGER tags...
