### PR TITLE
Tentative fixes for iOS 5 SDK.

### DIFF
--- a/include/cinder/cocoa/CinderCocoa.h
+++ b/include/cinder/cocoa/CinderCocoa.h
@@ -58,7 +58,7 @@ class SafeNsString {
   public:
 	SafeNsString() {}
 	//! Creates a SafeNsString using an existing NSString. This constructor automatically increments the retain count.
-	SafeNsString( const NSString *str );
+	SafeNsString( NSString *str );
 	//! Creates a SafeNsString by converting a std::string.
 	SafeNsString( const std::string &str );
 	
@@ -66,7 +66,7 @@ class SafeNsString {
 	operator std::string() const;
 	
   private:
-	static void safeRelease( const NSString *ptr );
+	static void safeRelease( NSString *ptr );
 	
 	std::shared_ptr<NSString>	mPtr;
 };

--- a/include/rapidxml/rapidxml_print.hpp
+++ b/include/rapidxml/rapidxml_print.hpp
@@ -102,67 +102,9 @@ namespace rapidxml
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
     
-        // Print node
+        // Print node (foreward declare for print_children, implementation below)
         template<class OutIt, class Ch>
-        inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent)
-        {
-            // Print proper node type
-            switch (node->type())
-            {
-
-            // Document
-            case node_document:
-                out = print_children(out, node, flags, indent);
-                break;
-
-            // Element
-            case node_element:
-                out = print_element_node(out, node, flags, indent);
-                break;
-            
-            // Data
-            case node_data:
-                out = print_data_node(out, node, flags, indent);
-                break;
-            
-            // CDATA
-            case node_cdata:
-                out = print_cdata_node(out, node, flags, indent);
-                break;
-
-            // Declaration
-            case node_declaration:
-                out = print_declaration_node(out, node, flags, indent);
-                break;
-
-            // Comment
-            case node_comment:
-                out = print_comment_node(out, node, flags, indent);
-                break;
-            
-            // Doctype
-            case node_doctype:
-                out = print_doctype_node(out, node, flags, indent);
-                break;
-
-            // Pi
-            case node_pi:
-                out = print_pi_node(out, node, flags, indent);
-                break;
-
-                // Unknown
-            default:
-                assert(0);
-                break;
-            }
-            
-            // If indenting not disabled, add line break after node
-            if (!(flags & print_no_indenting))
-                *out = Ch('\n'), ++out;
-
-            // Return modified iterator
-            return out;
-        }
+        inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
         
         // Print children of the node                               
         template<class OutIt, class Ch>
@@ -373,6 +315,68 @@ namespace rapidxml
             return out;
         }
 
+        // Print node
+        template<class OutIt, class Ch>
+        inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent)
+        {
+            // Print proper node type
+            switch (node->type())
+            {
+                    
+                    // Document
+                case node_document:
+                    out = print_children(out, node, flags, indent);
+                    break;
+                    
+                    // Element
+                case node_element:
+                    out = print_element_node(out, node, flags, indent);
+                    break;
+                    
+                    // Data
+                case node_data:
+                    out = print_data_node(out, node, flags, indent);
+                    break;
+                    
+                    // CDATA
+                case node_cdata:
+                    out = print_cdata_node(out, node, flags, indent);
+                    break;
+                    
+                    // Declaration
+                case node_declaration:
+                    out = print_declaration_node(out, node, flags, indent);
+                    break;
+                    
+                    // Comment
+                case node_comment:
+                    out = print_comment_node(out, node, flags, indent);
+                    break;
+                    
+                    // Doctype
+                case node_doctype:
+                    out = print_doctype_node(out, node, flags, indent);
+                    break;
+                    
+                    // Pi
+                case node_pi:
+                    out = print_pi_node(out, node, flags, indent);
+                    break;
+                    
+                    // Unknown
+                default:
+                    assert(0);
+                    break;
+            }
+            
+            // If indenting not disabled, add line break after node
+            if (!(flags & print_no_indenting))
+                *out = Ch('\n'), ++out;
+            
+            // Return modified iterator
+            return out;
+        }
+        
     }
     //! \endcond
 

--- a/src/cinder/cocoa/CinderCocoa.mm
+++ b/src/cinder/cocoa/CinderCocoa.mm
@@ -39,7 +39,7 @@ using namespace std;
 
 namespace cinder { namespace cocoa {
 
-SafeNsString::SafeNsString( const NSString *str )
+SafeNsString::SafeNsString( NSString *str )
 {
 	[str retain];
 	mPtr = shared_ptr<NSString>( str, safeRelease );
@@ -51,7 +51,7 @@ SafeNsString::SafeNsString( const std::string &str )
 	[mPtr.get() retain];
 }
 
-void SafeNsString::safeRelease( const NSString *ptr )
+void SafeNsString::safeRelease( NSString *ptr )
 {
 	if( ptr )
 		[ptr release];


### PR DESCRIPTION
These fixes are tested with XCode 4.2 (4D199) on Mac OS Lion
10.7.2 and an iPad 1 running iOS 5.0 (9A334).

Apple's LLVM compiler is the default for iOS development now and
it seems to be a bit picky about certain things.
- In CinderCocoa.mm, SafeNsString gives errors in the shared_ptr
  template instantiation. This is fixed by removing the use of
  const. Not sure how correct the fix is though.
- In rapidxml_print.hpp, the internal printings operations
  couldn't all find each other. This is fixed by moving
  print_node to last place and foreward declaring it before the
  other print functions.

Thanks to @notlion for figuring out the SafeNsString fix.
