### PR TITLE
OpenGL ES: Unintuitive Texture::getCleanWidth() Behavior

### DIFF
--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -829,11 +829,9 @@ GLint Texture::getCleanWidth() const
 		glGetTexLevelParameteriv( mObj->mTarget, 0, GL_TEXTURE_WIDTH, &mObj->mWidth );
 		mObj->mCleanWidth = mObj->mWidth;
 	}
+#endif // ! defined( CINDER_GLES )
 
 	return mObj->mCleanWidth;
-#else
-	return mObj->mWidth;
-#endif // ! defined( CINDER_GLES )	
 }
 
 GLint Texture::getCleanHeight() const
@@ -845,11 +843,8 @@ GLint Texture::getCleanHeight() const
 		glGetTexLevelParameteriv( mObj->mTarget, 0, GL_TEXTURE_HEIGHT, &mObj->mHeight );	
 		mObj->mCleanHeight = mObj->mHeight;		
 	}
-	
-	return mObj->mCleanHeight;
-#else
-	return mObj->mHeight;
 #endif // ! defined( CINDER_GLES )	
+	return mObj->mCleanHeight;
 }
 
 Rectf Texture::getAreaTexCoords( const Area &area ) const


### PR DESCRIPTION
For OpenGL ES, ```Texture::getCleanWidth()``` does _not_ return ```mCleanWidth```, but ```mWidth```; the same applies to ```Texture::getCleanHeight()```. This came as a little surprise to me.

The behavior was introduced in 512eb51, and I can imagine it being implemented to circumvent cases where ```mCleanWidth``` was not initialized correctly. However, this has been fixed in f6ffd88, so I think 512eb51 should now be reverted -- or did I overlook something?