### PR TITLE
Preventing LNK4098 errors

### DIFF
--- a/docs/welcome/MSWNewProject.html
+++ b/docs/welcome/MSWNewProject.html
@@ -130,6 +130,16 @@
       <td style="vertical-align: top;">Data Execution Prevention (DEP)</td>
       <td style="vertical-align: top; font-family: monospace;">Image is not compatible with DEP (/NXCOMPAT:NO)</td>
     </tr>
+    <tr>
+      <td style="vertical-align: top;"><em>Debug: </em><br/>Linker | Input</td>
+      <td style="vertical-align: top;">Ignore Specific Default Libraries</td>
+      <td style="vertical-align: top; font-family: monospace;">libc.lib, libcmt.lib, msvcrt.lib, libcd.lib, msvcrtd.lib</td>
+    </tr>
+    <tr>
+      <td style="vertical-align: top;"><em>Release: </em><br/>Linker | Input</td>
+      <td style="vertical-align: top;">Ignore Specific Default Libraries</td>
+      <td style="vertical-align: top; font-family: monospace;">libc.lib, msvcrt.lib, libcd.lib, libcmtd.lib, msvcrtd.lib</td>
+    </tr>
   </tbody>
 </table>
 </p>


### PR DESCRIPTION
I received a number of compiler errors when creating a new Windows VS2010 project following the [Creating Windows Projects guide](http://libcinder.org/docs/welcome/MSWNewProject.html).  I was unable to compile by just following the instructions alone.

One of the errors was LNK4098.  I applied the [instructions available on MSDN](http://msdn.microsoft.com/en-us/library/aa267384%28v=vs.60%29.aspx).  This successfully resolved all the errors and the project compiled.

I've added the relevant instructions to the documentation.
