### PR TITLE
ColorT::get(ColorModel) constness

### DIFF
--- a/include/cinder/Color.h
+++ b/include/cinder/Color.h
@@ -78,7 +78,7 @@ class ColorT
 		return * this;
 	}
 
-	Vec3f get( ColorModel cm );
+	Vec3f get( ColorModel cm ) const;
 
 	T& operator[]( int n )
 	{

--- a/src/cinder/Color.cpp
+++ b/src/cinder/Color.cpp
@@ -65,7 +65,7 @@ void ColorT<T>::set( ColorModel cm, const Vec3f &v )
 }
 
 template<typename T>
-Vec3f ColorT<T>::get( ColorModel cm )
+Vec3f ColorT<T>::get( ColorModel cm ) const
 {
 	switch( cm ) {
 		case CM_HSV: {


### PR DESCRIPTION
The ColorT::get() method can/should be made const.
