### PR TITLE
Fix when using both qtime and audio

### DIFF
--- a/include/cinder/audio/Output.h
+++ b/include/cinder/audio/Output.h
@@ -28,8 +28,10 @@
 
 namespace cinder { namespace audio {
 
+class Track;
+
 typedef int32_t					TrackId;
-typedef std::shared_ptr<class Track> TrackRef;
+typedef std::shared_ptr<class cinder::audio::Track> TrackRef;
 
 class OutputImpl;
 


### PR DESCRIPTION
When using the both QuickTime and audio in the same app, I ran into a conflict with the headers in audio/Output.h.  By giving it a quick forward reference and using the full namespace below that, I resolved the problems I was having.  Hope this helps someone else.
