### PR TITLE
Fix special keys in params

### DIFF
--- a/src/cinder/params/Params.cpp
+++ b/src/cinder/params/Params.cpp
@@ -25,11 +25,44 @@
 
 #include "AntTweakBar.h"
 
+#include <boost/assign/list_of.hpp>
+
 using namespace std;
 
 namespace cinder { namespace params {
 
 namespace {
+
+#define SYNONYM(ck,ak) ((int)cinder::app::KeyEvent::KEY_ ## ck, TW_KEY_ ## ak)
+#define HOMONYM(k) SYNONYM(k,k)
+    std::map<int,TwKeySpecial> specialKeys = boost::assign::map_list_of
+        HOMONYM(RIGHT)
+        HOMONYM(LEFT)
+        HOMONYM(BACKSPACE)
+        HOMONYM(DELETE)
+        HOMONYM(TAB)
+        HOMONYM(F1)
+        HOMONYM(F2)
+        HOMONYM(F3)
+        HOMONYM(F4)
+        HOMONYM(F5)
+        HOMONYM(F6)
+        HOMONYM(F7)
+        HOMONYM(F8)
+        HOMONYM(F9)
+        HOMONYM(F10)
+        HOMONYM(F11)
+        HOMONYM(F12)
+        HOMONYM(F13)
+        HOMONYM(F14)
+        HOMONYM(F15)
+        HOMONYM(HOME)
+        HOMONYM(END)
+        SYNONYM(PAGEUP,PAGE_UP)
+        SYNONYM(PAGEDOWN,PAGE_DOWN)
+        ;
+#undef SYNONYM
+#undef HOMONYM
 
 bool mouseDown( app::MouseEvent event )
 {
@@ -76,7 +109,11 @@ bool keyDown( app::KeyEvent event )
 		kmod |= TW_KMOD_CTRL;
 	if( event.isAltDown() )
 		kmod |= TW_KMOD_ALT;
-	return TwKeyPressed( event.getChar(), kmod ) != 0;
+	return TwKeyPressed(
+            (specialKeys.count( event.getCode() ) > 0)
+                ? specialKeys[event.getCode()]
+                : event.getChar(),
+            kmod ) != 0;
 }
 
 bool resize( app::ResizeEvent event )


### PR DESCRIPTION
translate some special keys (arrows, home/end, backspace/delete) from
cinder to AntTweekBar, because they aren't passed through as characters.

without it editing numbers with a keyboard is annoyingly broken. I haven't translated all keys, just some subset. But it's easy to add more by example, if deemed necessary.
