### PR TITLE
fix for mac path resolution

### DIFF
--- a/src/cinder/app/App.cpp
+++ b/src/cinder/app/App.cpp
@@ -295,7 +295,7 @@ fs::path App::getResourcePath( const fs::path &rsrcRelativePath )
 	
 	NSString *resultPath = [[NSBundle mainBundle] pathForResource:[NSString stringWithUTF8String:fileName.c_str()] ofType:nil inDirectory:pathNS];
 	if( ! resultPath )
-		return string();
+		return rsrcRelativePath; // return the incoming path because caller is going to try to open it
 	
 	return fs::path([resultPath cStringUsingEncoding:NSUTF8StringEncoding]);
 }


### PR DESCRIPTION
When programs have shaders as resources on the mac, and a line such as the following from the GeomShader demo is executed,

```
// Load shader
mShader = gl::GlslProg(loadResource(RES_SHADER_DRAW_VERT), loadResource(RES_SHADER_DRAW_FRAG), loadResource(RES_SHADER_DRAW_GEOM), GL_POINTS, GL_TRIANGLE_STRIP, maxGeomOutputVertices);
```

the program will fail in the timeline branch because it will attempt to open a stream from an empty string().

This pull request modifies the mac path resolution request to return the incoming string instead of an empty string in the case that the requested file is an embedded resource. The GeomShader demo then executes properly. (I used TinderBox to create a new xcode project for GeomShader, then patched App.cpp to get it working - very straight forward... It appears that this demo has perhaps been removed... Nonetheless I think this patch is necessary in general).
