### PR TITLE
Callback manager call() with zero-args

### DIFF
--- a/include/cinder/Function.h
+++ b/include/cinder/Function.h
@@ -71,7 +71,7 @@ class CallbackMgr {
 		return cbId;	
 	}
 
-    void call() { for( iterator it = begin(); it != end(); ++it ) it->second(); }
+	void call() { for( iterator it = begin(); it != end(); ++it ) it->second(); }
 	template<typename A1>
 	void call( A1 a1 ) { for( iterator it = begin(); it != end(); ++it ) it->second( a1 ); }
 	template<typename A1, typename A2>


### PR DESCRIPTION
CallbackMgr was missing an overload of call() that took no arguments.
