### PR TITLE
Fixed an issue with IORead. 

### DIFF
--- a/src/cinder/Stream.cpp
+++ b/src/cinder/Stream.cpp
@@ -235,7 +235,7 @@ void IStreamFile::IORead( void *t, size_t size )
 	}
 	else if( size > mDefaultBufferSize ) { // entirely outside of buffer, and too big to buffer anyway
 		fseek( mFile, static_cast<long>( mBufferOffset ), SEEK_SET );
-		if ( fread( t, size, 1, mFile ) != 1 )
+		if ( fread( t, 1, size, mFile ) == 0 )
 			throw StreamExc();
 		mBufferOffset += size;
 	}


### PR DESCRIPTION
It was impossible to use IStreamFile::readData() to read the remaining data of a file, after having read portions of the file already. I noticed the call to fread() didn't look right to me. It's working for me now, but I would like a peer review.
