### PR TITLE
Fix for Audio Input crashes (osx)

### DIFF
--- a/src/cinder/audio/InputImplAudioUnit.cpp
+++ b/src/cinder/audio/InputImplAudioUnit.cpp
@@ -332,7 +332,7 @@ void InputImplAudioUnit::setup()
 	//AudioDeviceGetProperty( nativeDeviceId, 0, true, kAudioDevicePropertyStreamConfiguration, &param, &aBufferList);
 	
 	//setup buffer for recieving data in the callback
-	mInputBufferData = (float *)malloc( sampleCount * desiredOutFormat.mBytesPerFrame );
+	mInputBufferData = (float *)malloc( sampleCount * desiredOutFormat.mBytesPerFrame * desiredOutFormat.mChannelsPerFrame );
 	float * inputBufferChannels[desiredOutFormat.mChannelsPerFrame];
 	for( int h = 0; h < desiredOutFormat.mChannelsPerFrame; h++ ) {
 		inputBufferChannels[h] = &mInputBufferData[h * sampleCount];


### PR DESCRIPTION
While using an instance of ci::audio::Input, I was experiencing fairly frequent crashes. The same issue seems to be experienced by some other users as documented in the forums here:

http://forum.libcinder.org/topic/audio-input-crash
http://forum.libcinder.org/topic/audio-input-giving-exc-bad-access-errors
http://forum.libcinder.org/topic/audio-input-start-up-issues

Doing a test with the AudioInputSample, I experienced crashes on startup or shutdown 24/50 times I ran the application. I got similar results with the following bare-bones application: 

``` C++
#include "cinder/app/AppBasic.h"
#include "cinder/audio/Input.h"

class CinderAudioTestApp : public ci::app::AppBasic {
  void setup();
  ci::audio::Input input;
};

void CinderAudioTestApp::setup(){
  input.start();
}

CINDER_APP_BASIC( CinderAudioTestApp, ci::app::RendererGl )
```

After this fix, I was able to run the AudioInputSample 50/50 times without crashes. 

My computer is a Mid-2009 macbook pro running OSX 10.7.3 and XCode 4.2.1.
