### PR TITLE
add getter for content scale factor to AppCocoaTouch

### DIFF
--- a/include/cinder/app/AppCocoaTouch.h
+++ b/include/cinder/app/AppCocoaTouch.h
@@ -104,6 +104,8 @@ class AppCocoaTouch : public App {
 	virtual int		getWindowWidth() const;
 	//! Returns the height of the App's window measured in pixels, or the screen when in full-screen mode.	
 	virtual int		getWindowHeight() const;
+	//! Returns the iOS resolution multiplier (typically 2.0f on retina displays, 1.0f otherwise)
+	virtual float	getContentScaleFactor() const;
 	//! Ignored on the iPhone.
 	void			setWindowWidth( int windowWidth ) {}
 	//! Ignored on the iPhone.

--- a/src/cinder/app/AppCocoaTouch.mm
+++ b/src/cinder/app/AppCocoaTouch.mm
@@ -149,6 +149,15 @@ int	AppCocoaTouch::getWindowHeight() const
 	else
 		return ::CGRectGetHeight( bounds );
 }
+    
+//! Returns the iOS resolution multiplier (2.0 for current retina displays, 1.0 otherwise).
+float AppCocoaTouch::getContentScaleFactor() const
+{
+    if ([mState->mCinderView respondsToSelector:NSSelectorFromString(@"contentScaleFactor")]) {
+        return mState->mCinderView.contentScaleFactor;
+    }
+    return 1.0f;
+}
 
 //! Enables the accelerometer
 void AppCocoaTouch::enableAccelerometer( float updateFrequency, float filterFactor )


### PR DESCRIPTION
This was useful for adapting Planetary to iPad 3's retina display, especially for creating hi-res fonts (multiply the font size) and for keeping the iPad 1's 1024x768 layout dimensions and simply scaling everything up by contentScaleFactor.
