### PR TITLE
Fix texture font rendering when color array is enabled before call to drawGlyphs.

### DIFF
--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -302,7 +302,9 @@ void TextureFont::drawGlyphs( const vector<pair<uint16_t,Vec2f> > &glyphMeasures
 	Vec2f baseline = baselineIn;
 
 	glEnableClientState( GL_VERTEX_ARRAY );
-	if( ! colors.empty() )
+	if ( colors.empty() )
+		glDisableClientState( GL_COLOR_ARRAY );
+	else
 		glEnableClientState( GL_COLOR_ARRAY );
 	glEnableClientState( GL_TEXTURE_COORD_ARRAY );
 	const float scale = options.getScale();
@@ -387,7 +389,9 @@ void TextureFont::drawGlyphs( const std::vector<std::pair<uint16_t,Vec2f> > &gly
 	gl::enable( mTextures[0].getTarget() );
 	const float scale = options.getScale();
 	glEnableClientState( GL_VERTEX_ARRAY );
-	if( ! colors.empty() )
+	if ( colors.empty() )
+		glDisableClientState( GL_COLOR_ARRAY );
+	else
 		glEnableClientState( GL_COLOR_ARRAY );
 	glEnableClientState( GL_TEXTURE_COORD_ARRAY );
 	for( size_t texIdx = 0; texIdx < mTextures.size(); ++texIdx ) {


### PR DESCRIPTION
If GL_COLOR_ARRAY client state is already enabled before a call to DrawGlyphs and no colors are supplied the glyphs are rendered without color data.  This caused blank rendering on some Android devices that have GL_COLOR_ARRAY enabled at initialization.

This patch disables GL_COLOR_ARRAY explicitly in the DrawGlyphs methods - the original state is still restored by a ClientBoolState instance.
