### PR TITLE
XmlTree assignment operator

### DIFF
--- a/src/cinder/Xml.cpp
+++ b/src/cinder/Xml.cpp
@@ -161,6 +161,8 @@ XmlTree& XmlTree::operator=( const XmlTree &rhs )
 	mParent = 0;
 	mAttributes = rhs.mAttributes;
 
+	mChildren.clear();
+
 	for( XmlTree::ConstIter childIt = rhs.begin(); childIt != rhs.end(); ++childIt ) {
 		mChildren.push_back( *childIt );
 		mChildren.back().mParent = this;


### PR DESCRIPTION
In the XmlTree assignment operator mChildren needs to be cleared before pushback. Or was that behaviour intended?
