### PR TITLE
SVG: Closing Rect::getShape() with missing line to the beginning

### DIFF
--- a/src/cinder/svg/Svg.cpp
+++ b/src/cinder/svg/Svg.cpp
@@ -1567,6 +1567,7 @@ Shape2d	Rect::getShape() const
 	result.lineTo( mRect.x2, mRect.y1 );
 	result.lineTo( mRect.x2, mRect.y2 );
 	result.lineTo( mRect.x1, mRect.y2 );	
+	result.lineTo( mRect.x1, mRect.y1 );	// ROGER
 	return result;
 }
 


### PR DESCRIPTION
Closing Rect::getShape() with missing line to the beginning
