### PR TITLE
SVG: Added compatibility with "preserve illustrator editing capabilities" option

### DIFF
--- a/src/cinder/svg/Svg.cpp
+++ b/src/cinder/svg/Svg.cpp
@@ -2201,7 +2201,10 @@ void Doc::loadDoc( DataSourceRef source, fs::path filePath )
 		mTransform.setToIdentity();
 
 	// we can't parse the group w/o having parsed the viewBox, dimensions, etc, so we have to do this manually:
-	Group::parse( xml );
+	if ( xml.hasChild( "switch" ) )		// ROGER -- when saved with "preserve illustrator editing capabilities", svg data is inside a "switch"
+		Group::parse( xml.getChild( "switch" ) );
+	else
+		Group::parse( xml );
 }
 
 shared_ptr<Surface8u> Doc::loadImage( fs::path relativePath )


### PR DESCRIPTION
Added compatibility with "preserve illustrator editing capabilities" option.
When saved like this, the SVG data is inside a <switch>.
