### PR TITLE
Changed the default attentuation values of Light.cpp

### DIFF
--- a/src/cinder/gl/Light.cpp
+++ b/src/cinder/gl/Light.cpp
@@ -191,7 +191,8 @@ void Light::setDefaults()
 		mSpotCutoff = 180.0f;
 	else
 		mSpotCutoff = 1.0f;
-	mConstantAttenuation = mLinearAttenuation = mQuadraticAttenuation = 1.0f;
+	mConstantAttenuation = 1.0f;
+	mLinearAttenuation = mQuadraticAttenuation = 0.0f;
 }
 
 } // namespace gl


### PR DESCRIPTION
Changed the default attentuation values of Light.cpp to match those specified in http...://www.glprogramming.com/red/chapter05.html#name4 (0 for linear and quadratic factors, 1 for the constant factor).