### PR TITLE
ObjLoader: importing vertex-only faces

### DIFF
--- a/src/cinder/ObjLoader.cpp
+++ b/src/cinder/ObjLoader.cpp
@@ -116,7 +116,10 @@ void ObjLoader::parseFace( Group *group, const std::string &s, bool includeUVs )
 			secondSlashOffset = string::npos;
 		
 		// process the vertex index
-		int vertexIndex = lexical_cast<int>( s.substr( offset, firstSlashOffset - offset ) );
+		int vertexIndex = (firstSlashOffset != string::npos) ? 
+            lexical_cast<int>( s.substr( offset, firstSlashOffset - offset ) ) : 
+            lexical_cast<int>( s.substr( offset, endOfTriple - offset));
+        
 		if( vertexIndex < 0 )
 			result.mVertexIndices.push_back( group->mBaseVertexOffset + vertexIndex );
 		else


### PR DESCRIPTION
This resolves a lexical cast exception that occurs when the faces do not have normal or texture coordinate info.
