### PR TITLE
Added findByIdContains search method to Svg

### DIFF
--- a/include/cinder/svg/Svg.h
+++ b/include/cinder/svg/Svg.h
@@ -735,10 +735,13 @@ class Group : public Node {
 	//! Recursively searches for a child element of type <tt>svg::T</tt> named \a id. Returns NULL on failure to find the object or if it is not of type T.
     template<typename T>
 	const T*				find( const std::string &id ) { return dynamic_cast<const T*>( findNode( id ) ); }
-	//! Recursively searches for a child element whose name contains \a idPartial. Returns NULL on failure. (null_ptr later?)
-	const Node*				findFuzzy( const std::string &idPartial, bool recurse = true ) const;
 	//! Recursively searches for a child element named \a id. Returns NULL on failure.
 	const Node*				findNode( const std::string &id, bool recurse = true ) const;
+	//! Recursively searches for a child element of type <tt>svg::T</tt> whose name contains \a idPartial. Returns NULL on failure to find the object or if it is not of type T.
+    template<typename T>
+	const T*				findByIdContains( const std::string &idPartial ) { return dynamic_cast<const T*>( findNodeByIdContains( idPartial ) ); }
+	//! Recursively searches for a child element whose name contains \a idPartial. Returns NULL on failure. (null_ptr later?)
+	const Node*				findNodeByIdContains( const std::string &idPartial, bool recurse = true ) const;
 	virtual const Node*		findInAncestors( const std::string &elementId ) const;
 	//! Returns a reference to the child named \a id. Throws svg::ExcChildNotFound if not found.
 	const Node&				getChild( const std::string &id ) const;

--- a/src/cinder/svg/Svg.cpp
+++ b/src/cinder/svg/Svg.cpp
@@ -1754,7 +1754,7 @@ void Group::parse( const XmlTree &xml )
 	}
 }
 
-const Node* Group::findFuzzy( const std::string &idPartial, bool recurse ) const
+const Node* Group::findNodeByIdContains( const std::string &idPartial, bool recurse ) const
 {
 	for( list<Node*>::const_iterator childIt = mChildren.begin(); childIt != mChildren.end(); ++childIt ) {
 		if( (*childIt)->getId().find( idPartial ) != string::npos ) {
@@ -1763,7 +1763,7 @@ const Node* Group::findFuzzy( const std::string &idPartial, bool recurse ) const
 	}
 
 	if( mDefs ) {
-		const Node *result = mDefs->findFuzzy( idPartial, recurse );
+		const Node *result = mDefs->findNodeByIdContains( idPartial, recurse );
 		if( result )
 			return result;
 	}
@@ -1772,7 +1772,7 @@ const Node* Group::findFuzzy( const std::string &idPartial, bool recurse ) const
 		for( list<Node*>::const_iterator childIt = mChildren.begin(); childIt != mChildren.end(); ++childIt ) {
 			if( typeid(**childIt) == typeid(Group) ) {
 				Group* group = static_cast<Group*>(*childIt);
-				const Node* result = group->findFuzzy( idPartial );
+				const Node* result = group->findNodeByIdContains( idPartial );
 				if( result )
 					return result;
 			}


### PR DESCRIPTION
This matches some of the serial/camera device finding methods elsewhere in Cinder.
I'm not a huge fan of the duplication of code this introduces (adjacent to find), but don't think that it would make sense to roll into regular find as a flag.

The main rationale for this is that Illustrator loves to tack extraneous information on Svg element ids. It is also fairly useful on its own.
