### PR TITLE
params InterfaceGl::setOptions special keywords

### DIFF
--- a/src/cinder/params/Params.cpp
+++ b/src/cinder/params/Params.cpp
@@ -300,9 +300,14 @@ void InterfaceGl::removeParam( const std::string &name )
 void InterfaceGl::setOptions( const std::string &name, const std::string &optionsStr )
 {
 	std::string target = "`" + (std::string)TwGetBarName( mBar.get() ) + "`";
-	if( !( name.empty() ) )
-		target += "/`" + name + "`";
-
+	if( name == "GLOBAL" || name == "TW_HELP" ) {
+		target = name;
+	}
+	else {
+		target = "`" + (std::string)TwGetBarName( mBar.get() ) + "`";
+		if( !( name.empty() ) )
+			target += "/`" + name + "`";
+	}
 	TwDefine( ( target + " " + optionsStr ).c_str() );
 }
 


### PR DESCRIPTION
There are two special keywords in the AntTweakBar syntax, GLOBAL and TW_HELP, which should not be quoted when used with [TwDefine](http://www.antisphere.com/Wiki/tools:anttweakbar:twbarparamsyntax).
