### PR TITLE
Camera::setWorldUp fix

### DIFF
--- a/src/cinder/Camera.cpp
+++ b/src/cinder/Camera.cpp
@@ -54,6 +54,7 @@ void Camera::setOrientation( const Quatf &aOrientation )
 void Camera::setWorldUp( const Vec3f &aWorldUp )
 {
 	mWorldUp = aWorldUp;
+	mOrientation = Quatf( Matrix44f::alignZAxisWithTarget( -mViewDirection, mWorldUp ) ).normalized();
 	calcModelView();
 }
 


### PR DESCRIPTION
<code>setWorldUp</code> has no effect without changing the orientation, because <code>calcModelView()</code> doesn't use the world up vector directly.
