### PR TITLE
Fixed an issue preventing multiple sets of texture coordinates...

### DIFF
--- a/src/cinder/gl/Vbo.cpp
+++ b/src/cinder/gl/Vbo.cpp
@@ -624,13 +624,13 @@ void VboMesh::bufferNormals( const std::vector<Vec3f> &normals )
 
 void VboMesh::bufferTexCoords2d( size_t unit, const std::vector<Vec2f> &texCoords )
 {
-	if( mObj->mLayout.hasDynamicTexCoords2d() ) {
+	if( mObj->mLayout.hasDynamicTexCoords2d(unit) ) {
 		if( mObj->mDynamicStride == 0 )
 			getDynamicVbo().bufferSubData( mObj->mTexCoordOffset[unit], sizeof(Vec2f) * texCoords.size(), &(texCoords[0]) );
 		else
 			throw;
 	}
-	else if( mObj->mLayout.hasStaticTexCoords2d() ) {
+	else if( mObj->mLayout.hasStaticTexCoords2d(unit) ) {
 		if( mObj->mStaticStride == 0 ) { // planar data
 			getStaticVbo().bufferSubData( mObj->mTexCoordOffset[unit], sizeof(Vec2f) * texCoords.size(), &(texCoords[0]) );
 		}
@@ -643,13 +643,13 @@ void VboMesh::bufferTexCoords2d( size_t unit, const std::vector<Vec2f> &texCoord
 
 void VboMesh::bufferTexCoords3d( size_t unit, const std::vector<Vec3f> &texCoords )
 {
-	if( mObj->mLayout.hasDynamicTexCoords3d() ) {
+	if( mObj->mLayout.hasDynamicTexCoords3d(unit) ) {
 		if( mObj->mDynamicStride == 0 )
 			getDynamicVbo().bufferSubData( mObj->mTexCoordOffset[unit], sizeof(Vec3f) * texCoords.size(), &(texCoords[0]) );
 		else
 			throw;
 	}
-	else if( mObj->mLayout.hasStaticTexCoords3d() ) {
+	else if( mObj->mLayout.hasStaticTexCoords3d(unit) ) {
 		if( mObj->mStaticStride == 0 ) { // planar data
 			getStaticVbo().bufferSubData( mObj->mTexCoordOffset[unit], sizeof(Vec3f) * texCoords.size(), &(texCoords[0]) );
 		}


### PR DESCRIPTION
...from working. Using multiple sets of texture coordinates was not possible, due to an error in both the bufferTexCoords2d() and bufferTexCoords3d() methods of the VboMesh class.
