### PR TITLE
Make AppImplCocoaBasic register for only its own NSWindow's movements

### DIFF
--- a/src/cinder/app/AppImplCocoaBasic.mm
+++ b/src/cinder/app/AppImplCocoaBasic.mm
@@ -158,7 +158,7 @@
 	if( mAlwaysOnTop )
 		[win setLevel: NSScreenSaverWindowLevel];
 	// we need to get told about it when the window changes screens so we can update the display link
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowChangedScreen:) name:NSWindowDidMoveNotification object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowChangedScreen:) name:NSWindowDidMoveNotification object:win];
 	[cinderView setNeedsDisplay:YES];
 #if MAC_OS_X_VERSION_MAX_ALLOWED > MAC_OS_X_VERSION_10_5	
 	if( app->getSettings().isMultiTouchEnabled() )


### PR DESCRIPTION
Mentioned on the forums (http://forum.libcinder.org/#Topic/23286000001363063) this is a temporary "fix" to AppImplCocoaBasic which will register it for NSWindowDidMoveNotifications on the main Cinder window only.
