### PR TITLE
Display device and monitor name

### DIFF
--- a/include/cinder/Display.h
+++ b/include/cinder/Display.h
@@ -54,7 +54,9 @@ class Display {
 	int		getBitsPerPixel() const { return mBitsPerPixel; }
 
 	std::string	getDeviceString() const { return mDeviceString; }
+	std::string	getDeviceID() const { return mDeviceID; }
 	std::string	getMonitorString() const { return mMonitorString; }
+	std::string	getMonitorID() const { return mMonitorID; }
 
 	//! Returns whether the Display's coordinates contain \a pt.
 	bool	contains( const Vec2i &pt ) const { return mArea.contains( pt ); }
@@ -88,7 +90,9 @@ class Display {
 #endif
 
 	std::string		mDeviceString;
+	std::string		mDeviceID;
 	std::string		mMonitorString;
+	std::string		mMonitorID;
 	
 	static void		enumerateDisplays();
 	

--- a/src/cinder/Display.cpp
+++ b/src/cinder/Display.cpp
@@ -161,8 +161,10 @@ void Display::enumerateDisplays()
 			// device name and string should now contain information on the device
 			#ifdef UNICODE
 					sDisplays[i]->mDeviceString = toUtf8( std::wstring( device.DeviceString ) );
+					sDisplays[i]->mDeviceID = toUtf8( std::wstring( device.DeviceID ) );
 			#else
 					sDisplays[i]->mDeviceString = std::string( device.DeviceString ) );
+					sDisplays[i]->mDeviceID = std::string( device.DeviceID );
 			#endif
 
 			DISPLAY_DEVICE monitor = device;
@@ -172,8 +174,10 @@ void Display::enumerateDisplays()
 					// device name and string should now contain information on the monitor connected to the device
 					#ifdef UNICODE
 							sDisplays[i]->mMonitorString = toUtf8( std::wstring( monitor.DeviceString ) );
+							sDisplays[i]->mMonitorID = toUtf8( std::wstring( monitor.DeviceID ) );
 					#else
 							sDisplays[i]->mMonitorString = std::string( monitor.DeviceString ) );
+							sDisplays[i]->mMonitorID = std::string( monitor.DeviceID );
 					#endif
 				}
 			}


### PR DESCRIPTION
This is not a serious pull request, because it lacks functionality for the Mac. But it might be a first step at implementing something as requested in: https://forum.libcinder.org/#Topic/23286000001364339
