### PR TITLE
Added a WM_SETCURSOR clause to allow users to set the cursor using ::Set...

### DIFF
--- a/src/cinder/app/AppImplMsw.cpp
+++ b/src/cinder/app/AppImplMsw.cpp
@@ -945,6 +945,10 @@ LRESULT CALLBACK WndProc(	HWND	mWnd,			// Handle For This Window
 		case WM_TOUCH:
 			impl->onTouch( mWnd, wParam, lParam );
 		break;
+		case WM_SETCURSOR:
+			// allow the use of ::SetCursor()
+			return TRUE;
+        break;
 	}
 
 	// unhandled messages To DefWindowProc


### PR DESCRIPTION
...Cursor( 0, IDC_ARROW ).

If the event is not handled like this, Windows will override any cursor you set with ::SetCursor(). 
