### PR TITLE
Moved glLineWidth before glBegin otherwise it is invalid

### DIFF
--- a/samples/RetinaSample/src/RetinaSampleApp.cpp
+++ b/samples/RetinaSample/src/RetinaSampleApp.cpp
@@ -68,8 +68,8 @@ void RetinaSampleApp::draw()
 	gl::color( 1.0f, 0.5f, 0.25f );
 	
 	gl::pushMatrices();
-		gl::begin( GL_LINE_STRIP );
 		glLineWidth( getWindow()->toPixels( 1.0f ) );
+		gl::begin( GL_LINE_STRIP );
 		for( auto pointIter = mPoints.begin(); pointIter != mPoints.end(); ++pointIter ) {
 			gl::vertex( *pointIter );
 		}


### PR DESCRIPTION
While testing the RetinaSample, I noticed that changing the glLineWidth had no effect. 

"GL_INVALID_OPERATION    The glLineWidth subroutine is called between a call to glBegin and the corresponding call to glEnd."
http://publib.boulder.ibm.com/infocenter/pseries/v5r3/index.jsp?topic=/com.ibm.aix.opengl/doc/openglrf/glLineWidth.htm
