### PR TITLE
fixed Camera::calcInverseModelView()

### DIFF
--- a/src/cinder/Camera.cpp
+++ b/src/cinder/Camera.cpp
@@ -186,6 +186,8 @@ void Camera::calcModelView() const
 
 void Camera::calcInverseModelView() const
 {
+	if( ! mModelViewCached ) calcModelView();
+
 	mInverseModelViewMatrix = mModelViewMatrix.affineInverted();
 	mInverseModelViewCached = true;
 }
@@ -550,6 +552,8 @@ void CameraStereo::calcModelView() const
 
 void CameraStereo::calcInverseModelView() const
 {
+	if( ! mModelViewCached ) calcModelView();
+
 	mInverseModelViewMatrix = mModelViewMatrix.affineInverted();
 	mInverseModelViewMatrixLeft = mModelViewMatrixLeft.affineInverted();
 	mInverseModelViewMatrixRight = mModelViewMatrixRight.affineInverted();


### PR DESCRIPTION
There are some rare situations when only the inverse modelview matrix is required from the camera, eg. when calling from gl::Light::getShadowTransformationMatrix(). In these cases the current implementation returns a wrong matrix.
