### PR TITLE
XCode project settings for Cinder whitespace.

### DIFF
--- a/xcode/cinder.xcodeproj/project.pbxproj
+++ b/xcode/cinder.xcodeproj/project.pbxproj
@@ -1575,8 +1575,11 @@
 				0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */,
 				034768DFFF38A50411DB9C8B /* Products */,
 			);
+			indentWidth = 4;
 			name = libcinder;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 1;
 		};
 		0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Helps keep Cinder source readable in case users have different
default whitespace settings in XCode.
Also helps ensure multiple contributors have the same formatting.
