### PR TITLE
Fix for oversize bounds when Trimming.

### DIFF
--- a/src/cinder/ip/Trim.cpp
+++ b/src/cinder/ip/Trim.cpp
@@ -82,9 +82,11 @@ Area findNonTransparentArea( const SurfaceT<T> &surface, const Area &unclippedBo
 			break;
 		}
 	}
-	
 	// we add one to right and bottom because Area represents an inclusive range on top/left and exclusive range on bottom/right
-	return Area( leftColumn, topLine, rightColumn + 1, bottomLine + 1 );
+	rightColumn = std::min( bounds.getX2(), rightColumn + 1 );
+	bottomLine = std::min( bounds.getY2(), bottomLine + 1 );
+
+	return Area( leftColumn, topLine, rightColumn, bottomLine );
 }
 
 #define TRIM_PROTOTYPES(r,data,T)\


### PR DESCRIPTION
Take the min of start bounds and new bounds + 1 to avoid claiming
area that doesn't exist within the original image. Accomodates fix
for off-by-one when actually trimming and doesn't result in expanded
images when no trimming was necessary.
