### PR TITLE
Added splitSubRect to Rect

### DIFF
--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -68,7 +68,9 @@ class RectT {
 	void		scaleCentered( T scale );
 	RectT		scaledCentered( T scale ) const;
 	void		scale( T scale );
+	void		scale( const Vec2<T> &scale );
 	RectT		scaled( T scale ) const;
+	RectT		scaled( const Vec2<T> &scale ) const;
 
 	//! Returns a copy of the Rect transformed by \a matrix. Represents the bounding box of the transformed Rect when \a matrix expresses non-scale/translate operations.
 	RectT		transformCopy( const class MatrixAffine2<T> &matrix ) const;

--- a/src/cinder/Rect.cpp
+++ b/src/cinder/Rect.cpp
@@ -178,9 +178,24 @@ void RectT<T>::scale( T s )
 }
 
 template<typename T>
+void RectT<T>::scale( const Vec2<T> &scale )
+{
+	x1 *= scale.x;
+	y1 *= scale.y;
+	x2 *= scale.x;
+	y2 *= scale.y;
+}
+
+template<typename T>
 RectT<T> RectT<T>::scaled( T s ) const
 {
 	return RectT<T>( x1 * s, y1 * s, x2 * s, y2 * s );
+}
+
+template<typename T>
+RectT<T> RectT<T>::scaled( const Vec2<T> &scale ) const
+{
+	return RectT<T>( x1 * scale.x, y1 * scale.y, x2 * scale.x, y2 * scale.y );
 }
 
 template<typename T>


### PR DESCRIPTION
Added splitSubRect to Rect. Splits the Rect to equal sized sub-rectangles.

Very useful for tiled window rendering, for example:

```
tileW = 3;
tileH = 2;

Rectf window = Rectf( getWindowBounds() );

gl::draw( mSurfRGBImage, window.splitSubRect( tileW, tileH, 0, 0 ) );
gl::draw( mChIRImage, window.splitSubRect( tileW, tileH, 1, 0 ) );
gl::draw( mChDepthImage, window.splitSubRect( tileW, tileH, 2, 0 ) );
gl::draw( mChBlobImage, window.splitSubRect( tileW, tileH, 0, 1 ) );
```
