### PR TITLE
Change signal/app::draw order in Window::emitSignalDraw().

### DIFF
--- a/src/cinder/app/Window.cpp
+++ b/src/cinder/app/Window.cpp
@@ -400,8 +400,8 @@ void Window::emitKeyUp( KeyEvent *event )
 
 void Window::emitDraw()
 {
-	mSignalDraw();
 	getApp()->draw();
+	mSignalDraw();
 	mSignalPostDraw();
 }
 


### PR DESCRIPTION
Puts both signals adjacent to each other for reading, moves the
pseudo-deprecated app::draw() out from in-between them.
Intent is not to use app::draw(), so in case someone is dipping
their toes in the SignalDraw, this prevents content from being drawn
over by the virtual method.
