### PR TITLE
Added headers required to build Matrix44 in VC11

### DIFF
--- a/include/cinder/Matrix44.h
+++ b/include/cinder/Matrix44.h
@@ -27,6 +27,10 @@
 #include "cinder/CinderMath.h"
 #include "cinder/Vector.h"
 
+#include "cinder/Matrix22.h"
+#include "cinder/Matrix33.h"
+#include "cinder/MatrixAffine2.h"
+
 #include <iomanip>
 
 namespace cinder { 


### PR DESCRIPTION
I had to add includes for Matrix22, Matrix33 and MatrixAffine2 to successfully build on VC11 - these weren't required on OS X.
