### PR TITLE
(un)using namespace std::tr1::placeholders in Function.h

### DIFF
--- a/include/cinder/Function.h
+++ b/include/cinder/Function.h
@@ -38,7 +38,6 @@
 namespace std {
 	using std::tr1::function;
 	using std::tr1::bind;
-    using namespace std::tr1::placeholders;
 }
 
 namespace cinder {


### PR DESCRIPTION
Remove "using namespace std::tr1::placeholders;" which may create conflict with other libraries (eg PCL). - It's better to avoid using "using namespace" in includes -.
Rollback pull 63 https://github.com/cinder/Cinder/pull/63
