### PR TITLE
Fixing memory leak issue in cinder::qtime

### DIFF
--- a/src/cinder/qtime/QuickTimeUtils.cpp
+++ b/src/cinder/qtime/QuickTimeUtils.cpp
@@ -106,6 +106,8 @@ bool dictionarySetPixelBufferOptions( unsigned int width, unsigned int height, b
 				}
 			}
 		}
+        
+        CFRelease( pixelBufferDict );
 	}
 	
 	return setPixelBufferOptions;


### PR DESCRIPTION
Just cleaning up dictionarySetPixelBufferOptions in QuickTimeUtils.cpp, where pixelBufferDict wasn't getting released, which was causing a small leak
