### PR TITLE
"Nil" conflicts with the objective c macro of the same name.

### DIFF
--- a/blocks/OSC/src/osc/OscTypes.cpp
+++ b/blocks/OSC/src/osc/OscTypes.cpp
@@ -34,7 +34,7 @@ namespace osc{
 BundleInitiator BeginBundleImmediate(1);
 BundleTerminator EndBundle;
 MessageTerminator EndMessage;
-NilType Nil;
+NilType OscNil;
 InfinitumType Infinitum;
 
 } // namespace osc

--- a/blocks/OSC/src/osc/OscTypes.h
+++ b/blocks/OSC/src/osc/OscTypes.h
@@ -120,7 +120,7 @@ extern MessageTerminator EndMessage;
 struct NilType{
 };
 
-extern NilType Nil;
+extern NilType OscNil;
 
 
 struct InfinitumType{


### PR DESCRIPTION
On OSX, If you create a new project with Tinderbox and select the OSC block you will get a compile error about expanding the Nil macro.  I'm guessing with the app rewrite/dev changes, an objective c header is getting included now.  

I'm going to arbitrarily say that not many people are using the Nil structure with the stream operators, so this is likely a safe change. ;)  
