### PR TITLE
Fix for getEndTime() to report correct Timeline end time.

### DIFF
--- a/include/cinder/TimelineItem.h
+++ b/include/cinder/TimelineItem.h
@@ -67,7 +67,7 @@ class TimelineItem : public std::enable_shared_from_this<TimelineItem>
 	void			setInfinite( bool infinite = true ) { mInfinite = infinite; }
 
 	//! Returns the time of the item's competion, equivalent to getStartTime() + getDuration().
-	float			getEndTime() const { return mStartTime + mDuration; }
+	float			getEndTime() const { return mStartTime + getDuration(); }
 
 	//! Returns a pointer to the item's parent Timeline
 	class Timeline*		getParent() const { return mParent; }


### PR DESCRIPTION
Previously, the cached mDuration variable could be out of sync
with the actual duration of a Timeline when getEndTime is called.
We now call getDuration(), which calculates the duration if needed.
This ensures the correct end time for the timeline is returned.
