### PR TITLE
params window id issue

### DIFF
--- a/src/cinder/params/Params.cpp
+++ b/src/cinder/params/Params.cpp
@@ -175,10 +175,15 @@ int initAntGl( weak_ptr<app::Window> winWeak )
 {
 	static std::shared_ptr<AntMgr> sMgr;
 	static int sWindowId = 0;
+	static std::map<app::Window *, int> sWindowIds;
 	auto win = winWeak.lock();
 	if( ! sMgr )
 		sMgr = std::shared_ptr<AntMgr>( new AntMgr( (int)win->getContentScale() ) );
-	return sWindowId++;
+	app::Window *winPtr = win.get();
+	auto it = sWindowIds.find( winPtr );
+	if( it == sWindowIds.end() )
+		sWindowIds[ winPtr ] = sWindowId++;
+	return sWindowIds[ winPtr ];
 }
 
 InterfaceGl::InterfaceGl( const std::string &title, const Vec2i &size, const ColorA &color )


### PR DESCRIPTION
The AntTweakBar window id of the bars is not connected to the window, but gradually increased instead. This causes an issue that a bar cannot be dragged above an other bar, because the second bar steals the focus. The issue is illustrated in the following video:
http://youtu.be/23hYreixDjs
I attempted to fix this by connecting the window id to the window pointer. There is a seemingly unrelated issue that the font of the bars gets mixed up when the font size is changed, which also seems to be fixed by this modification.
