### PR TITLE
Use getBoundsAbsolute when finding svg::Group boundaries

### DIFF
--- a/src/cinder/svg/Svg.cpp
+++ b/src/cinder/svg/Svg.cpp
@@ -1908,7 +1908,7 @@ Rectf Group::calcBoundingBox() const
 	bool empty = true;
 	Rectf result( 0, 0, 0, 0 );
 	for( list<Node*>::const_iterator childIt = mChildren.begin(); childIt != mChildren.end(); ++childIt ) {
-		Rectf childBounds = (*childIt)->getBoundingBox();
+		Rectf childBounds = (*childIt)->getBoundingBoxAbsolute();
 		// only use child area if it exists (text nodes return [0,0,0,0])
 		if( childBounds.calcArea() > 0 ) {
 			if( empty ) {


### PR DESCRIPTION
EDIT: See final comment for actual solution.

The Image element bounding box now takes into account where the image is located, using its transform.
This enables proper group bounds calculation when an svg::group contains an image.
Before, any image caused the group bounds to include 0, 0 regardless of where the group was positioned in the document.

Previously:
An image at 200, 200 with dimensions of 100, 100 would render as a 300, 300 output image, with the actual graphic drawn in the lower-right corner of those bounds.

Now:
It renders as a 100, 100 output image.

I discovered this issue as I am doing a fair amount of work generating sprite sheets directly from svgs. Having accurate bounds for each named group is essential. If you were only rendering the document as originally composed, you would never see this artifact.
