### PR TITLE
Added methods to the Camera class for getting/setting horizontal FOV

### DIFF
--- a/include/cinder/Camera.h
+++ b/include/cinder/Camera.h
@@ -59,10 +59,8 @@ class Camera {
 	Quatf		getOrientation() const { return mOrientation; }
 	void		setOrientation( const Quatf &aOrientation );
 
-	float	getFov() const { return mFov; }
-	void	setFov( float aFov ) { mFov = aFov;  mProjectionCached = false; }
-	float	getFovHorizontal() const { return toDegrees( 2.0f * math<float>::atan( math<float>::tan( toRadians(mFov) * 0.5f ) * mAspectRatio ) ); }
-	void	setFovHorizontal( float aFov ) { mFov = toDegrees( 2.0f * math<float>::atan( math<float>::tan( toRadians(aFov) * 0.5f ) / mAspectRatio ) );  mProjectionCached = false; }
+	float	getFov( bool vertical = true ) const { return vertical ? mFov : toDegrees( 2.0f * math<float>::atan( math<float>::tan( toRadians(mFov) * 0.5f ) * mAspectRatio ) ); }
+	void	setFov( float aFov, bool vertical = true ) { mFov = vertical ? aFov : toDegrees( 2.0f * math<float>::atan( math<float>::tan( toRadians(aFov) * 0.5f ) / mAspectRatio ) );  mProjectionCached = false; }
 
 	float	getAspectRatio() const { return mAspectRatio; }
 	void	setAspectRatio( float aAspectRatio ) { mAspectRatio = aAspectRatio; mProjectionCached = false; }


### PR DESCRIPTION
Field of view is usually specified for the vertical angle, because it is independent of the aspect ratio. But calculating the vertical field of view for a given horizontal field of view is non-trivial. That's why I've added methods for getting/setting the horizontal field of view of the camera.
