### PR TITLE
Quaternion inverse fix

### DIFF
--- a/include/cinder/Quaternion.h
+++ b/include/cinder/Quaternion.h
@@ -110,18 +110,6 @@ public:
 		return w * w + v.lengthSquared();	
 	}
 
-	Quaternion<T> inverse() const
-	{
-		T norm = w * w + v.x * v.x + v.y * v.y + v.z * v.z;
-		// if we're the zero quaternion, just return identity
-		/*if( ! ( math<T>::abs( norm ) < EPSILON_VALUE ) ) {
-			return identity();
-		}*/
-
-		T normRecip = static_cast<T>( 1.0f ) / norm;
-		return Quaternion<T>( normRecip * w, -normRecip * v.x, -normRecip * v.y, -normRecip * v.z );
-	}
-
 	void normalize()
 	{
 		if( T len = length() ) {


### PR DESCRIPTION
Quaternion invert() and inverted() use the axis, angle set method and constructor with the v vector, which I think is wrong. There is an inverse() method, which does the right thing, but its naming does not match with the naming elsewhere in Cinder, e.g Matrix inverse functions, so I think it should be removed.

-Gabor
