### PR TITLE
JSON Backslash Escape Issue

### DIFF
--- a/src/cinder/Json.cpp
+++ b/src/cinder/Json.cpp
@@ -667,6 +667,7 @@ void JsonTree::write( DataTargetRef target, JsonTree::WriteOptions writeOptions 
 		// This routine serializes JsonCpp data and formats it
 		if( writeOptions.getIndented() ) {
 			jsonString = value.toStyledString();
+			boost::replace_all( jsonString, "\n", "\r\n" );
 		} else {
 			Json::FastWriter writer;
 			jsonString = writer.write( value );


### PR DESCRIPTION
Fixed a JSON issue with backslash escaped characters where writing the JSON caused the escaping backslashes to be escaped, creating invalid JSON.
