### PR TITLE
Use the icon resource specified in Resources.rc in MSW

### DIFF
--- a/src/cinder/app/AppImplMsw.cpp
+++ b/src/cinder/app/AppImplMsw.cpp
@@ -449,20 +449,22 @@ void WindowImplMsw::registerWindowClass()
 	if( sRegistered )
 		return;
 
-	WNDCLASS	wc;
+	WNDCLASSEX	wc;
 	HMODULE instance	= ::GetModuleHandle( NULL );				// Grab An Instance For Our Window
+	wc.cbSize = sizeof(WNDCLASSEX);
 	wc.style			= CS_HREDRAW | CS_VREDRAW | CS_OWNDC;	// Redraw On Size, And Own DC For Window.
 	wc.lpfnWndProc		= WndProc;						// WndProc Handles Messages
 	wc.cbClsExtra		= 0;									// No Extra Window Data
 	wc.cbWndExtra		= 0;									// No Extra Window Data
 	wc.hInstance		= instance;							// Set The Instance
-	wc.hIcon			= ::LoadIcon( NULL, IDI_WINLOGO );		// Load The Default Icon
+	wc.hIcon = (HICON)::LoadImage( instance, MAKEINTRESOURCE(1), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE ); // Load The Default Cinder Icon
+	wc.hIconSm = NULL;
 	wc.hCursor			= ::LoadCursor( NULL, IDC_ARROW );		// Load The Arrow Pointer
 	wc.hbrBackground	= NULL;									// No Background Required For GL
 	wc.lpszMenuName		= NULL;									// We Don't Want A Menu
 	wc.lpszClassName	= WINDOWED_WIN_CLASS_NAME;
 
-	if( ! ::RegisterClass( &wc ) ) {								// Attempt To Register The Window Class
+	if( ! ::RegisterClassEx( &wc ) ) {								// Attempt To Register The Window Class
 		DWORD err = ::GetLastError();
 		return;							
 	}


### PR DESCRIPTION
This change allows the icon specified in Resources.rc for MSW apps to actually be used in the top left of the window, in the taskbar, etc. This is the relevant line in Resources.rc:

```
1   ICON    "..\\resources\\cinder_app_icon.ico"
```

I know very little about Win32 programming... I figured out how to do this as I needed it quickly, so there is probably a more robust solution. This would not support changing the integer id of ICON to anything besides 1, though I don't know if that's a problem.
