### PR TITLE
Add lib/cinder*.idb and lib/cinder*.pdb to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ xcuserdata/
 build/
 lib/libcinder*.a
 lib/cinder*.lib
+lib/cinder*.idb
+lib/cinder*.pdb
 
 # Windows cruft
 *.suo


### PR DESCRIPTION
As I've started to make changes and contribute to Cinder core, I noticed on Windows that there were a few files being generated (cinder_d.idb and cinder_d.pdb) during compile that as far as I can tell should be excluded from git.
