### PR TITLE
Allow Windows to process system keystroke messages

### DIFF
--- a/src/cinder/app/AppImplMsw.cpp
+++ b/src/cinder/app/AppImplMsw.cpp
@@ -820,10 +820,8 @@ LRESULT CALLBACK WndProc(	HWND	mWnd,			// Handle For This Window
 			KeyEvent event( impl->getWindow(), KeyEvent::translateNativeKeyCode( prepNativeKeyCode( (int)wParam ) ), 
 							c, c, prepKeyEventModifiers(), (int)wParam );
 			impl->getWindow()->emitKeyDown( &event );
-			if ( uMsg == WM_KEYDOWN )
+			if ( event.isHandled() )
 				return 0;
-			else
-				return DefWindowProc( mWnd, uMsg, wParam, lParam );
 		}
 		break;
 		case WM_SYSKEYUP:
@@ -832,10 +830,8 @@ LRESULT CALLBACK WndProc(	HWND	mWnd,			// Handle For This Window
 			KeyEvent event( impl->getWindow(), KeyEvent::translateNativeKeyCode( prepNativeKeyCode( (int)wParam ) ), 
 							c, c, prepKeyEventModifiers(), (int)wParam );
 			impl->getWindow()->emitKeyUp( &event );
-			if ( uMsg == WM_KEYUP )
+			if ( event.isHandled() )
 				return 0;
-			else
-				return DefWindowProc( mWnd, uMsg, wParam, lParam );
 		}
 		break;
 		// mouse events


### PR DESCRIPTION
I need basic Windows shortcuts like ALT+F4 to function as typically expected. This change will pass the WM_SYSKEYDOWN and WM_SYSKEYUP messages to DefWindowProc after Cinder processes them, allowing such shortcuts to work.

From http://www-user.tu-chemnitz.de/~heha/petzold/ch06c.htm:

> Programs usually ignore the WM_SYSKEYUP and WM_SYSKEYDOWN messages and pass them to DefWindowProc. Because Windows takes care of all the Alt-key logic, you really have no need to trap these messages. Your window procedure will eventually receive other messages concerning the result of these keystrokes (such as a menu selection). If you want to include code in your window procedure to trap the system keystroke messages... pass the messages to DefWindowProc after you process them so that Windows can still use them for their intended purposes.
