### PR TITLE
Change variable name horizFovDegrees in CameraPersp::setPerspective() into verticalFovDegrees

### DIFF
--- a/include/cinder/Camera.h
+++ b/include/cinder/Camera.h
@@ -136,7 +136,7 @@ class CameraPersp : public Camera {
 	CameraPersp( int pixelWidth, int pixelHeight, float fov ); // constructs screen-aligned camera
 	CameraPersp( int pixelWidth, int pixelHeight, float fov, float nearPlane, float farPlane ); // constructs screen-aligned camera
 	
-	void	setPerspective( float horizFovDegrees, float aspectRatio, float nearPlane, float farPlane );
+	void	setPerspective( float verticalFovDegrees, float aspectRatio, float nearPlane, float farPlane );
 	
 	/** Returns both the horizontal and vertical lens shift. 
 		A horizontal lens shift of 1 (-1) will shift the view right (left) by half the width of the viewport.

--- a/src/cinder/Camera.cpp
+++ b/src/cinder/Camera.cpp
@@ -236,9 +236,9 @@ CameraPersp::CameraPersp()
 	setPerspective( 35.0f, 1.0f, 0.1f, 1000.0f );
 }
 
-void CameraPersp::setPerspective( float horizFovDegrees, float aspectRatio, float nearPlane, float farPlane )
+void CameraPersp::setPerspective( float verticalFovDegrees, float aspectRatio, float nearPlane, float farPlane )
 {
-	mFov			= horizFovDegrees;
+	mFov			= verticalFovDegrees;
 	mAspectRatio	= aspectRatio;
 	mNearClip		= nearPlane;
 	mFarClip		= farPlane;


### PR DESCRIPTION
In function `CameraPersp::setPerspective (float horizFovDegrees, float aspectRatio, float nearPlane, float farPlane)`, the `horizFovDegrees` appears to be vertical Fov degrees.

Discussion at the forum,
https://forum.libcinder.org/#Topic/23286000001866015
