### PR TITLE
Update window size after constrainFrameRect is called

### DIFF
--- a/src/cinder/app/AppImplCocoaBasic.mm
+++ b/src/cinder/app/AppImplCocoaBasic.mm
@@ -743,6 +743,9 @@
 	[winImpl->mWin setContentView:winImpl->mCinderView];
 
 	[winImpl->mWin makeKeyAndOrderFront:nil];
+	// after showing the window, the size may have changed (see NSWindow::constrainFrameRect) so we need to update our internal variable
+	winImpl->mSize.x = (int)winImpl->mCinderView.frame.size.width;
+	winImpl->mSize.y = (int)winImpl->mCinderView.frame.size.height;
 	[winImpl->mWin setInitialFirstResponder:winImpl->mCinderView];
 	[winImpl->mWin setAcceptsMouseMovedEvents:YES];
 	[winImpl->mWin setOpaque:YES];


### PR DESCRIPTION
**Issue**: In OSX, when a window is created with a specified window width and height that are larger than what's available on screen, the window's size will be constrained. Cinder doesn't update the window's `mSize` variable after this constraining happens. I can reproduce this behavior by setting my screen resolution to 1280x800, calling `settings->setWindowSize( 1280, 800 );` in prepareSettings, and outputting `getWindowBounds()` in the `resize()` method which gets fired automatically once during startup. This will return the incorrect value for the window height (800), even though the window has been constrained to a smaller height due to the dock and title bar showing.

**Solution**: update mSize after the window is shown during instantiation. The window is shown by the makeKeyAndOrderFront message, so in this commit, I update mSize after this happens.

**Reference**: see [NSWindow::constrainFrameRect:toScreen:](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSWindow_Class/Reference/Reference.html#jumpTo_47) and [Window crops to current resolution](https://forum.libcinder.org/topic/window-crops-to-current-resolution).
