### PR TITLE
OpenGL changes to enable Nsight debugging

### DIFF
--- a/include/cinder/gl/Vbo.h
+++ b/include/cinder/gl/Vbo.h
@@ -73,6 +73,7 @@ typedef std::shared_ptr<VboMesh>	VboMeshRef;
 class VboMesh {
  public:
 	enum { NONE, STATIC, DYNAMIC };
+	static enum { VERTICES, NORMALS, COLORS, TEXCOORDS, TOTAL_PREDEFINED_POSITIONS};
 	enum { ATTR_INDICES, ATTR_POSITIONS, ATTR_NORMALS, ATTR_COLORS_RGB, ATTR_COLORS_RGBA, ATTR_TEXCOORDS2D_0, ATTR_TEXCOORDS2D_1, ATTR_TEXCOORDS2D_2, ATTR_TEXCOORDS2D_3, ATTR_TEXCOORDS3D_0, ATTR_TEXCOORDS3D_1, ATTR_TEXCOORDS3D_2, ATTR_TEXCOORDS3D_3, ATTR_TOTAL };
 	enum { ATTR_MAX_TEXTURE_UNIT = 3 };
 
@@ -130,6 +131,10 @@ class VboMesh {
 		void	setStaticPositions() { mAttributes[ATTR_POSITIONS] = STATIC; }
 		void	setDynamicPositions() { mAttributes[ATTR_POSITIONS] = DYNAMIC; }
 		
+		
+		static GLint sPredefinedAttrNumComponents[TOTAL_PREDEFINED_POSITIONS];
+		static GLenum sPredefinedAttrTypes[TOTAL_PREDEFINED_POSITIONS];
+
 		enum CustomAttr { CUSTOM_ATTR_FLOAT, CUSTOM_ATTR_FLOAT2, CUSTOM_ATTR_FLOAT3, CUSTOM_ATTR_FLOAT4, TOTAL_CUSTOM_ATTR_TYPES };
 		static int sCustomAttrSizes[TOTAL_CUSTOM_ATTR_TYPES];
 		static GLint sCustomAttrNumComponents[TOTAL_CUSTOM_ATTR_TYPES];
@@ -138,6 +143,10 @@ class VboMesh {
 		void	addDynamicCustomVec2f() { mCustomDynamic.push_back( std::make_pair( CUSTOM_ATTR_FLOAT2, 0 ) ); }
 		void	addDynamicCustomVec3f() { mCustomDynamic.push_back( std::make_pair( CUSTOM_ATTR_FLOAT3, 0 ) ); }
 		void	addDynamicCustomVec4f() { mCustomDynamic.push_back( std::make_pair( CUSTOM_ATTR_FLOAT4, 0 ) ); }
+		void	addStaticCustomFloat() { mCustomStatic.push_back( std::make_pair( CUSTOM_ATTR_FLOAT, 0 ) ); }
+		void	addStaticCustomVec2f() { mCustomStatic.push_back( std::make_pair( CUSTOM_ATTR_FLOAT2, 0 ) ); }
+		void	addStaticCustomVec3f() { mCustomStatic.push_back( std::make_pair( CUSTOM_ATTR_FLOAT3, 0 ) ); }
+		void	addStaticCustomVec4f() { mCustomStatic.push_back( std::make_pair( CUSTOM_ATTR_FLOAT4, 0 ) ); }
 
 		int												mAttributes[ATTR_TOTAL];
 		std::vector<std::pair<CustomAttr,size_t> >		mCustomDynamic, mCustomStatic; // pair of <types,offset>

--- a/src/cinder/app/AppImplMswRendererGl.cpp
+++ b/src/cinder/app/AppImplMswRendererGl.cpp
@@ -27,6 +27,9 @@
 #include "cinder/Camera.h"
 #include <windowsx.h>
 
+#define CINDER_DISABLE_OLD_OPENGL
+
+
 namespace cinder { namespace app {
 
 bool sMultisampleSupported = false;
@@ -62,8 +65,14 @@ void AppImplMswRendererGl::defaultResize() const
 	int height = clientRect.bottom - clientRect.top;
 
 	glViewport( 0, 0, width, height );
-	cinder::CameraPersp cam( width, height, 60.0f );
 
+	// GL matrix mode is deprecated and prevents Nsight debugging
+	// The code below is needed if easy cinder drawing functions are used
+	// (which use old OpenGL calls)
+
+#ifndef CINDER_DISABLE_OLD_OPENGL 
+	cinder::CameraPersp cam( width, height, 60.0f );
+	
 	glMatrixMode( GL_PROJECTION );
 	glLoadMatrixf( cam.getProjectionMatrix().m );
 
@@ -71,6 +80,7 @@ void AppImplMswRendererGl::defaultResize() const
 	glLoadMatrixf( cam.getModelViewMatrix().m );
 	glScalef( 1.0f, -1.0f, 1.0f );           // invert Y axis so increasing Y goes down.
 	glTranslatef( 0.0f, (float)-height, 0.0f );       // shift origin up to upper-left corner.
+#endif
 }
 
 void AppImplMswRendererGl::swapBuffers() const

--- a/src/cinder/gl/Fbo.cpp
+++ b/src/cinder/gl/Fbo.cpp
@@ -70,11 +70,11 @@ Renderbuffer::Obj::Obj( int aWidth, int aHeight, GLenum internalFormat, int msaa
 #if ! defined( CINDER_GLES )
   #if defined( CINDER_MSW )
 	if( mCoverageSamples ) // create a CSAA buffer
-		glRenderbufferStorageMultisampleCoverageNV( GL_RENDERBUFFER_EXT, mCoverageSamples, mSamples, mInternalFormat, mWidth, mHeight );
+		glRenderbufferStorageMultisampleCoverageNV( GL_RENDERBUFFER, mCoverageSamples, mSamples, mInternalFormat, mWidth, mHeight );
 	else
   #endif
 	if( mSamples ) // create a regular MSAA buffer
-		glRenderbufferStorageMultisampleEXT( GL_RENDERBUFFER_EXT, mSamples, mInternalFormat, mWidth, mHeight );
+		glRenderbufferStorageMultisample( GL_RENDERBUFFER, mSamples, mInternalFormat, mWidth, mHeight );
 	else
 #endif
 		GL_SUFFIX(glRenderbufferStorage)( GL_SUFFIX(GL_RENDERBUFFER_), mInternalFormat, mWidth, mHeight );
@@ -233,7 +233,7 @@ void Fbo::init()
 				glTexParameteri( getTarget(), GL_TEXTURE_MAG_FILTER, mObj->mFormat.mMagFilter );
 				glTexParameteri( getTarget(), GL_TEXTURE_WRAP_S, mObj->mFormat.mWrapS );
 				glTexParameteri( getTarget(), GL_TEXTURE_WRAP_T, mObj->mFormat.mWrapT );
-				glTexParameteri( getTarget(), GL_DEPTH_TEXTURE_MODE, GL_LUMINANCE );
+				//glTexParameteri( getTarget(), GL_DEPTH_TEXTURE_MODE, GL_LUMINANCE );
 				mObj->mDepthTexture = Texture( getTarget(), depthTextureId, mObj->mWidth, mObj->mHeight, true );
 
 				glFramebufferTexture2DEXT( GL_FRAMEBUFFER_EXT, GL_DEPTH_ATTACHMENT_EXT, getTarget(), mObj->mDepthTexture.getId(), 0 );

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -254,8 +254,7 @@ void Texture::init( const unsigned char *data, int unpackRowLength, GLenum dataF
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_WRAP_T, format.mWrapT );
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_MIN_FILTER, format.mMinFilter );	
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_MAG_FILTER, format.mMagFilter );
-	if( format.mMipmapping )
-		glTexParameteri( mObj->mTarget, GL_GENERATE_MIPMAP, GL_TRUE );
+	
 	if( mObj->mTarget == GL_TEXTURE_2D ) {
 		mObj->mMaxU = mObj->mMaxV = 1.0f;
 	}
@@ -272,6 +271,9 @@ void Texture::init( const unsigned char *data, int unpackRowLength, GLenum dataF
 #if ! defined( CINDER_GLES )
 	glPixelStorei( GL_UNPACK_ROW_LENGTH, 0 );
 #endif	
+
+	if( format.mMipmapping )
+		glGenerateMipmap( GL_TEXTURE_2D );
 }
 
 void Texture::init( const float *data, GLint dataFormat, const Format &format )
@@ -285,8 +287,7 @@ void Texture::init( const float *data, GLint dataFormat, const Format &format )
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_WRAP_T, format.mWrapT );
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_MIN_FILTER, format.mMinFilter );	
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_MAG_FILTER, format.mMagFilter );
-	if( format.mMipmapping )
-		glTexParameteri( mObj->mTarget, GL_GENERATE_MIPMAP, GL_TRUE );
+	
 	if( mObj->mTarget == GL_TEXTURE_2D ) {
 		mObj->mMaxU = mObj->mMaxV = 1.0f;
 	}
@@ -301,6 +302,9 @@ void Texture::init( const float *data, GLint dataFormat, const Format &format )
 	}
 	else
 		glTexImage2D( mObj->mTarget, 0, mObj->mInternalFormat, mObj->mWidth, mObj->mHeight, 0, GL_LUMINANCE, GL_FLOAT, 0 );  // init to black...
+	
+	if( format.mMipmapping )
+		glGenerateMipmap( GL_TEXTURE_2D );
 }
 
 void Texture::init( ImageSourceRef imageSource, const Format &format )
@@ -385,8 +389,8 @@ void Texture::init( ImageSourceRef imageSource, const Format &format )
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_WRAP_T, format.mWrapT );
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_MIN_FILTER, format.mMinFilter );	
 	glTexParameteri( mObj->mTarget, GL_TEXTURE_MAG_FILTER, format.mMagFilter );
-	if( format.mMipmapping )
-		glTexParameteri( mObj->mTarget, GL_GENERATE_MIPMAP, GL_TRUE );
+
+	
 	if( mObj->mTarget == GL_TEXTURE_2D ) {
 		mObj->mMaxU = mObj->mMaxV = 1.0f;
 	}
@@ -412,6 +416,9 @@ void Texture::init( ImageSourceRef imageSource, const Format &format )
 		imageSource->load( target );		
 		glTexImage2D( mObj->mTarget, 0, mObj->mInternalFormat, mObj->mWidth, mObj->mHeight, 0, dataFormat, GL_FLOAT, target->getData() );
 	}
+
+	if( format.mMipmapping )
+		glGenerateMipmap( GL_TEXTURE_2D );
 }
 
 void Texture::update( const Surface &surface )


### PR DESCRIPTION
Opengl Drawing needs to be done with OpenGL Core Profile. Most of the
cinder easy drawing functions use old OpenGL functions and should not be
used. You need to pass your Mesh MVP matrix to the shader yourself.
Moreover Vertex Buffer locations need to be bound to the Shader input
variables. Afterwards one must compile the shader:

``` cpp
// bind the attribute inputs of the shader to the location defined in the VBO. 
// "vertex" is the name of the in variable  as declared in the shader
glBindAttribLocation( m_Shader.getHandle(), gl::VboMesh::VERTICES, "vertex" );

glBindAttribLocation( m_Shader.getHandle(), gl::VboMesh::NORMALS, "normal" );

// after defining the attribute position the shader needs to be linked again
glLinkProgram( m_Shader.getHandle() );
```
