### PR TITLE
Camera::setViewDirection orientation fix

### DIFF
--- a/src/cinder/Camera.cpp
+++ b/src/cinder/Camera.cpp
@@ -43,7 +43,7 @@ void Camera::setCenterOfInterestPoint( const Vec3f &centerOfInterestPoint )
 void Camera::setViewDirection( const Vec3f &aViewDirection )
 {
 	mViewDirection = aViewDirection.normalized();
-	mOrientation = Quatf( Vec3f( 0.0f, 0.0f, -1.0f ), mViewDirection );
+	mOrientation = Quatf( Matrix44f::alignZAxisWithTarget( -mViewDirection, mWorldUp ) ).normalized();
 	mModelViewCached = false;
 }
 


### PR DESCRIPTION
setViewDirection does not take mWorldUp into account. Using the following test example the x-axis points to the right, while it should point to the left. Using setWorldUp _after_ setViewDirection gives the correct output, because setWorldUp overwrites the wrong value calculated by setViewDirection.

```
CameraPersp cam;
cam.setEyePoint( Vec3f( 0, 0, 10 ) );
cam.setWorldUp( -Vec3f::yAxis() );
cam.setViewDirection( -Vec3f::zAxis() );
gl::setMatrices( cam );
gl::drawCoordinateFrame();
```
