### PR TITLE
Allow Serial to find virtual COM ports on Windows

### DIFF
--- a/src/cinder/Serial.cpp
+++ b/src/cinder/Serial.cpp
@@ -179,15 +179,13 @@ const std::vector<Serial::Device>& Serial::getDevices( bool forceRefresh )
 
 	ZeroMemory( &devInfo, sizeof( devInfo ) );
 	devInfo.cbSize = sizeof( devInfo );
-	while( ::SetupDiEnumDeviceInfo( devInfoSet, deviceIndex++, &devInfo ) )
-	{
+	while( ::SetupDiEnumDeviceInfo( devInfoSet, deviceIndex++, &devInfo ) )	{
 		devInfo.cbSize = sizeof( devInfo );
 
 		::DWORD deviceInterfaceIndex = 0;
 
 		devInterface.cbSize = sizeof( devInterface );
-		while( ::SetupDiEnumDeviceInterfaces( devInfoSet, &devInfo, &guid, deviceInterfaceIndex++, &devInterface ) )
-		{
+		while( ::SetupDiEnumDeviceInterfaces( devInfoSet, &devInfo, &guid, deviceInterfaceIndex++, &devInterface ) ) {
 			devInterface.cbSize = sizeof( devInterface );
 
 			// See how large a buffer we require for the device interface details


### PR DESCRIPTION
This fixed an issue I was having where a virtual serial device was not being found. I believe this should fix issues mentioned on the forum:

https://forum.libcinder.org/topic/serial-getdevices-always-returns-0
https://forum.libcinder.org/topic/serial-communication-with-arduino
