### PR TITLE
Fixing fromString<double>() on iOS

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -89,6 +89,11 @@ inline T fromString( const std::string &s ) { return boost::lexical_cast<T>( s )
 // This specialization seems to only be necessary with more recent versions of Boost
 template<>
 inline Url fromString( const std::string &s ) { return Url( s ); }
+#if defined(CINDER_COCOA_TOUCH)
+// Necessary because boost::lexical_cast crashes when trying to convert a string to a double on iOS
+template<>
+inline double fromString( const std::string &s ) { return atof( s.c_str() ); }
+#endif
 
 //! Returns a stack trace (aka backtrace) where \c stackTrace()[0] == caller, \c stackTrace()[1] == caller's parent, etc
 std::vector<std::string> stackTrace();

--- a/src/cinder/Json.cpp
+++ b/src/cinder/Json.cpp
@@ -607,7 +607,7 @@ Json::Value JsonTree::createNativeDoc( WriteOptions writeOptions ) const
 				value = Json::Value( fromString<bool>( mValue ) );
 				break;
 			case VALUE_DOUBLE:
-				value = Json::Value( atof( mValue.c_str() ) );
+				value = Json::Value( fromString<double>( mValue ) );
 				break;
 			case VALUE_INT:
 				value = Json::Value( fromString<int64_t>( mValue ) );


### PR DESCRIPTION
boost::lexical_cast crashes when trying to convert a string to a double on iOS.

Instead of patching the code responsible for JSON and XML parsing, I guess it's better to address the problem at the source...
