### PR TITLE
Audio2 - window functions

### DIFF
--- a/src/cinder/audio/dsp/Dsp.cpp
+++ b/src/cinder/audio/dsp/Dsp.cpp
@@ -136,7 +136,7 @@ void generateHammWindow( float *window, size_t length )
 {
 	double alpha	= 0.53836;
 	double beta	= 1.0 - alpha;
-	double mlength	= 1.0 / static_cast<double>( length - 1 );
+	double oneOverN	= 1.0 / static_cast<double>( length - 1 );
 	for( size_t i = 0; i < length; i++ ) {
 		double x = static_cast<double>(i) * oneOverN;
 		window[i] = float( alpha - beta * cos( 2.0 * M_PI * x ) );
@@ -146,7 +146,7 @@ void generateHammWindow( float *window, size_t length )
 void generateHannWindow( float *window, size_t length )
 {
 	double alpha	= 0.5;
-	double mlength	= 1.0 / static_cast<double>( length - 1 );
+	double oneOverN	= 1.0 / static_cast<double>( length - 1 );
 	for( size_t i = 0; i < length; i++ ) {
 		double x  = static_cast<double>(i) * oneOverN;
 		window[i] = float( alpha * ( 1.0 - cos( 2.0 * M_PI * x ) ) );


### PR DESCRIPTION
according to http://en.wikipedia.org/wiki/Window_function#Hamming_window
I believe oneOverN used here need to 1.0 / (length - 1) instead of 1.0 / length.
Also implemting the Hamm/Hann window function on Windows.
