### PR TITLE
in Cocoa URL loader implementation, changed int datatypes to off_t datat...

### DIFF
--- a/src/cinder/UrlImplCocoa.mm
+++ b/src/cinder/UrlImplCocoa.mm
@@ -34,8 +34,8 @@
 	std::string					mUser, mPassword;
 	
 	uint8_t				*mBuffer;
-	int					mBufferSize;
-	int					mBufferOffset, mBufferedBytes;
+	off_t				mBufferSize;
+	off_t				mBufferOffset, mBufferedBytes;
 	off_t				mBufferFileOffset;	// where in the file the buffer starts
 	off_t				mSize;
 	BOOL				mStillConnected;
@@ -57,15 +57,15 @@
 - (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error;
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection;
 
-- (int)seekRelative:(off_t)relativeOffset;
+- (off_t)seekRelative:(off_t)relativeOffset;
 - (void)seekAbsolute:(off_t)absoluteOffset;
 - (off_t)tell;
-- (int)bufferRemaining;
+- (off_t)bufferRemaining;
 - (bool)isEof;
 - (off_t)getSize;
 
-- (int)IoRead:(void*)dest withSize:(size_t)size;
-- (void)fillBuffer:(int)wantBytes;
+- (off_t)IoRead:(void*)dest withSize:(size_t)size;
+- (void)fillBuffer:(off_t)wantBytes;
 - (size_t)readDataAvailable:(void*)dest withSize:(size_t)maxSize;
 
 @end
@@ -172,11 +172,11 @@
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
 {
 	@synchronized( self ) {
-		int roomInBuffer = mBufferSize - mBufferedBytes;
+		off_t roomInBuffer = mBufferSize - mBufferedBytes;
 		size_t size = [data length];	
 		if( (off_t)size > roomInBuffer ) {
 			// not enough space in buffer
-			int oldBufferSize = mBufferSize;
+			off_t oldBufferSize = mBufferSize;
 			while( mBufferSize - mBufferedBytes <= (off_t)size )
 				mBufferSize *= 2;
 			uint8_t *newBuff = reinterpret_cast<uint8_t*>( realloc( mBuffer, mBufferSize ) );
@@ -214,7 +214,7 @@
 	return mBufferFileOffset + mBufferOffset;
 }
 
-- (int)bufferRemaining
+- (off_t)bufferRemaining
 {
 	return mBufferedBytes - mBufferOffset;
 }
@@ -247,7 +247,7 @@
 }
 
 // returns 0 on success
-- (int)seekRelative:(off_t)relativeOffset
+- (off_t)seekRelative:(off_t)relativeOffset
 {
 	@synchronized( self ) {
 		// if this move stays inside the current buffer, we're good
@@ -272,7 +272,7 @@
 }
 
 // returns 0 on success
-- (int)IoRead:(void*)dest withSize:(size_t)size
+- (off_t)IoRead:(void*)dest withSize:(size_t)size
 {
 	[self fillBuffer:size];
 	
@@ -288,7 +288,7 @@
 	return 0;
 }
 
-- (void)fillBuffer:(int)wantBytes
+- (void)fillBuffer:(off_t)wantBytes
 {
 	@synchronized( self ) {
 		// do we already have the number of bytes we need, or are we disconnected?
@@ -297,7 +297,7 @@
 
 		// if we want more bytes than will fit in the rest of the buffer, let's make some room
 		if( mBufferSize - mBufferedBytes < wantBytes ) {
-			int bytesCulled = mBufferOffset;
+			off_t bytesCulled = mBufferOffset;
 			memmove( mBuffer, &mBuffer[mBufferOffset], mBufferedBytes - bytesCulled );
 			mBufferedBytes -= bytesCulled;
 			mBufferOffset = 0;
@@ -317,7 +317,7 @@
 	[self fillBuffer:maxSize];
 
 	@synchronized( self ) {	
-		int remaining = [self bufferRemaining];
+		off_t remaining = [self bufferRemaining];
 		if( remaining < (off_t)maxSize )
 			maxSize = remaining;
 			


### PR DESCRIPTION
NOTE: This is a 'duplicate' of https://github.com/cinder/Cinder/pull/439, because my fix was based on master and should be based on dev..

In Cocoa URL loader implementation, changed int datatypes to off_t datatypes to prevent int overflow when downloading large files. Without this fix, line 180-181 would overflow the int so the realloc on 182 would try to allocate a negative amount of space.
