### PR TITLE
define std::isnan for vs2012

### DIFF
--- a/include/cinder/CinderMath.h
+++ b/include/cinder/CinderMath.h
@@ -289,14 +289,16 @@ int solveCubic( T a, T b, T c, T d, T result[3] );
 #if defined( _MSC_VER ) && ( _MSC_VER < 1800 )
 // define math.h functions that aren't defined until vc120
 namespace std {
-	inline bool isfinite( float arg )	{ return _finite( arg ) != 0; }
-	inline bool isfinite( double arg )	{ return _finite( arg ) != 0; }
-	inline bool isnan( float arg )		{ return _isnan( arg ) != 0; }
-	inline bool isnan( double arg )		{ return _isnan( arg ) != 0; }
 
-	inline double	round( double x )	{ return floor( x < 0 ? x - 0.5 : x + 0.5 ); }
-	inline float	roundf( float x )	{ return floorf( x < 0 ? x - 0.5f : x + 0.5f );	}
-	inline long int lround( double x )	{ return (long int)( x < 0 ? x - 0.5 : x + 0.5 ); }
-	inline long int lroundf( float x )	{ return (long int)( x < 0 ? x - 0.5f : x + 0.5f );	}
+inline bool isfinite( float arg )	{ return _finite( arg ) != 0; }
+inline bool isfinite( double arg )	{ return _finite( arg ) != 0; }
+inline bool isnan( float arg )		{ return _isnan( arg ) != 0; }
+inline bool isnan( double arg )		{ return _isnan( arg ) != 0; }
+
+inline double	round( double x )	{ return floor( x < 0 ? x - 0.5 : x + 0.5 ); }
+inline float	roundf( float x )	{ return floorf( x < 0 ? x - 0.5f : x + 0.5f );	}
+inline long int lround( double x )	{ return (long int)( x < 0 ? x - 0.5 : x + 0.5 ); }
+inline long int lroundf( float x )	{ return (long int)( x < 0 ? x - 0.5f : x + 0.5f );	}
+
 } // namespace std
 #endif // defined( _MSC_VER ) && ( _MSC_VER < 1800 )


### PR DESCRIPTION
This also removes the std::isfinite definition for vs2013, since it is taken care by math.h in vc120. So, all the math functions we are defining are for pre-vc120 windows compiler.

This fixes https://github.com/cinder/Cinder/issues/437
