### PR TITLE
Rect and Area factory methods zero(), all()

### DIFF
--- a/include/cinder/Area.h
+++ b/include/cinder/Area.h
@@ -112,6 +112,8 @@ class Area {
 	Area&		operator+=( const Vec2i &o ) { offset( o ); return *this; }
 	Area&		operator-=( const Vec2i &o ) { offset( -o ); return *this; }
 
+	//! Constructs an Area with all values initialized to zero.
+	static	Area zero()				{ return Area( 0, 0, 0, 0 ); }
 	static Area	proportionalFit( const Area &srcArea, const Area &dstArea, bool center, bool expand = false );
 
 	friend std::ostream& operator<<( std::ostream &o, const Area &area )

--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -124,6 +124,9 @@ class RectT {
 	RectT<T>&		operator*=( T s ) { scale( s ); return *this; }
 	RectT<T>&		operator/=( T s ) { scale( ((T)1) / s ); return *this; }	
 
+	//! Constructs a rectangle with all values initialized to zero.
+	static	RectT zero()			{ return RectT( 0, 0, 0, 0 ); }
+
 	T			x1, y1, x2, y2;
 	
 	friend std::ostream& operator<<( std::ostream &o, const RectT &rect )


### PR DESCRIPTION
These are some nice convenience factor methods, especially for initializing member var Rect's or Areas.  We've talked about more involved additions, but at least these I'd like to see make it into 0.8.6.
