### PR TITLE
Resize leak fix

### DIFF
--- a/src/cinder/app/AppImplMswRendererDx.cpp
+++ b/src/cinder/app/AppImplMswRendererDx.cpp
@@ -307,6 +307,7 @@ void AppImplMswRendererDx::defaultResize() const
 	ID3D11RenderTargetView *view = NULL;
 	mDeviceContext->OMSetRenderTargets(1, &view, NULL);
 	mMainFramebuffer->Release();
+	mDepthStencilTexture->Release();
 	mDepthStencilView->Release();
 	mDeviceContext->Flush();
 	const_cast<AppImplMswRendererDx*>(this)->createFramebufferResources();


### PR DESCRIPTION
Fixes a memory leak in the RenderRx when resizing a cinder app window, which can quickly eat up all available memory until cinder crashes.
