### PR TITLE
Params deprecated implit conversion from const char* to bool fix

### DIFF
--- a/include/cinder/params/Params.h
+++ b/include/cinder/params/Params.h
@@ -177,21 +177,39 @@ class InterfaceGl {
 	//! \deprecated use addParam<T>() instead.
 	void	addParam( const std::string &name, bool *boolParam, const std::string &optionsStr, bool readOnly = false );
 	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, bool *boolParam, const char *optionsStr, bool readOnly = false )			{ addParam( name, boolParam, std::string( optionsStr ), readOnly ); }
+	//! \deprecated use addParam<T>() instead.
 	void	addParam( const std::string &name, float *floatParam, const std::string &optionsStr, bool readOnly = false );
+	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, float *floatParam, const char *optionsStr, bool readOnly = false )		{ addParam( name, floatParam, std::string( optionsStr ), readOnly ); }
 	//! \deprecated use addParam<T>() instead.
 	void	addParam( const std::string &name, double *doubleParam, const std::string &optionsStr, bool readOnly = false );
 	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, double *doubleParam, const char *optionsStr, bool readOnly = false )		{ addParam( name, doubleParam, std::string( optionsStr ), readOnly ); }
+	//! \deprecated use addParam<T>() instead.
 	void	addParam( const std::string &name, int32_t *intParam, const std::string &optionsStr, bool readOnly = false );
+	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, int32_t *intParam, const char *optionsStr, bool readOnly = false )		{ addParam( name, intParam, std::string( optionsStr ), readOnly ); }
 	//! \deprecated use addParam<T>() instead.
 	void	addParam( const std::string &name, Vec3f *vectorParam, const std::string &optionsStr, bool readOnly = false );
 	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, Vec3f *vectorParam, const char *optionsStr, bool readOnly = false )		{ addParam( name, vectorParam, std::string( optionsStr ), readOnly ); }
+	//! \deprecated use addParam<T>() instead.
 	void	addParam( const std::string &name, Quatf *quatParam, const std::string &optionsStr, bool readOnly = false );
 	//! \deprecated use addParam<T>() instead.
-	void	addParam( const std::string &name, Color *quatParam, const std::string &optionsStr, bool readOnly = false );
+	void	addParam( const std::string &name, Quatf *quatParam, const char *optionsStr, bool readOnly = false )		{ addParam( name, quatParam, std::string( optionsStr ), readOnly ); }
 	//! \deprecated use addParam<T>() instead.
-	void	addParam( const std::string &name, ColorA *quatParam, const std::string &optionsStr, bool readOnly = false );
+	void	addParam( const std::string &name, Color *colorParam, const std::string &optionsStr, bool readOnly = false );
+	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, Color *colorParam, const char *optionsStr, bool readOnly = false )		{ addParam( name, colorParam, std::string( optionsStr ), readOnly ); }
+	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, ColorA *colorParam, const std::string &optionsStr, bool readOnly = false );
+	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, ColorA *colorParam, const char *optionsStr, bool readOnly = false )		{ addParam( name, colorParam, std::string( optionsStr ), readOnly ); }
 	//! \deprecated use addParam<T>() instead.
 	void	addParam( const std::string &name, std::string *strParam, const std::string &optionsStr, bool readOnly = false );
+	//! \deprecated use addParam<T>() instead.
+	void	addParam( const std::string &name, std::string *strParam, const char *optionsStr, bool readOnly = false )	{ addParam( name, strParam, std::string( optionsStr ), readOnly ); }
 
   protected:
 	void	init( app::WindowRef window, const std::string &title, const Vec2i &size, const ColorA color );


### PR DESCRIPTION
This addresses the problem reported in #457 by adding overloads that take a const char\* and explicitly convert it to std::string.  This seems to make both clang and visual compiler happy and the correct method is picked.
