### PR TITLE
Start a contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+We love pull requests. Here's a quick guide.
+
+* [Fork the Cinder repo][fork].
+* Clone the repo and checkout the `dev` branch:
+```
+git clone git@github.com:YOUR-USER-NAME/Cinder.git -b dev
+```
+* Create a branch for your changes off `dev`:
+```
+git checkout -b YOUR-BRANCH-NAME
+```
+* Make your changes and commit them.
+* Push to your fork and [submit a pull request][pr].
+
+[fork]: https://github.com/cinder/Cinder/fork
+[pr]: https://github.com/cinder/Cinder/compare/


### PR DESCRIPTION
Took me a while to realize that PRs should be opend against dev. We can provide
some hints in the contributing file to help others avoid this mistake. GitHub
will display a link to it when the PR is created.

https://github.com/blog/1184-contributing-guidelines
