### PR TITLE
copy mCinderSurface ref from other in SurfaceImage copy constructor.

### DIFF
--- a/blocks/Cairo/src/Cairo.cpp
+++ b/blocks/Cairo/src/Cairo.cpp
@@ -229,7 +229,7 @@ SurfaceImage::SurfaceImage( ImageSourceRef imageSource )
 }
 
 SurfaceImage::SurfaceImage( const SurfaceImage &other )
-	: SurfaceBase( other )
+	: SurfaceBase( other ), mCinderSurface( other.mCinderSurface )
 {
 }
 


### PR DESCRIPTION
This is an alternative to the cairo::SurfaceImage fix provided in #453, which does not make a deep copy of the ci::Surface but instead copies over a reference to it (because it is still 'implicitly shared').  My understanding is that this is consistent with the existing ci::cairo API and ci::Surface in general to do ref counting on image data.

I've tested that the ref counts go to zero with both methods (this one and @paulhoux's), so its really just a matter of whether the data should be copied over or not.
