### PR TITLE
add min, mid and max Rect helpers

### DIFF
--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -94,6 +94,13 @@ class RectT {
 	T		getX2() const { return x2; }
 	T		getY2() const { return y2; }
 
+	T		getMinX() const { return x1; }
+	T		getMinY() const { return y1; }
+	T		getMidX() const { return x1 + (x2 - x1) / 2; }
+	T		getMidY() const { return y1 + (y2 - y1) / 2; }
+	T		getMaxX() const { return x2; }
+	T		getMaxY() const { return y2; }
+
 	Vec2<T>		getUpperLeft() const { return Vec2<T>( x1, y1 ); };
 	Vec2<T>		getUpperRight() const { return Vec2<T>( x2, y1 ); };
 	Vec2<T>		getLowerRight() const { return Vec2<T>( x2, y2 ); };	


### PR DESCRIPTION
(originally #458, now updated for the new `master` branch).

Like `getWidth()` and others, these functions require the rect to be in canonical form and offer a helper veneer.
