### PR TITLE
Fix rejected WAVEFORMATEX update for OutputDeviceNodeWasapi

### DIFF
--- a/src/cinder/audio/msw/ContextWasapi.cpp
+++ b/src/cinder/audio/msw/ContextWasapi.cpp
@@ -452,6 +452,8 @@ void OutputDeviceNodeWasapi::initialize()
 		// kludge: Update OutputDeviceNode's channels to match the number requested from IAudioClient.
 		// - this will call Node::uninitializeImpl(), but that won't do anything because we haven't completed our initialization yet.
 		setNumChannels( mRenderImpl->mNumChannels );
+		// manually call this to make sure internal buffers are the correct size
+		setupProcessWithSumming();
 	}
 
 	mInterleavedBuffer = BufferInterleaved( getFramesPerBlock(), getNumChannels() );


### PR DESCRIPTION
We recently found out that in some cases, particularly on a macbook running windows / bootcamp and default audio settings where it tries to use a quad stereo setup, that the internal summing buffers can become out of sync with the actual AudioRenderClientImpl's configuration.

Solution is to to manually call `Node::setupProcessWithSumming()` after updating the channel count during initialize().  AFAIK, this can't really do any harm, since at most it will try to resize the `audio::BufferDynamic` twice, and the second time around won't do anything.
