### PR TITLE
Window::Format().setResizable(false) only removes the thick border...

### DIFF
--- a/src/cinder/app/AppImplMsw.cpp
+++ b/src/cinder/app/AppImplMsw.cpp
@@ -399,7 +399,7 @@ void WindowImplMsw::createWindow( const Vec2i &windowSize, const std::string &ti
 	else {
 		mWindowExStyle = WS_EX_APPWINDOW | WS_EX_WINDOWEDGE;			// Window Extended Style
 		mWindowStyle = ( mResizable ) ? WS_OVERLAPPEDWINDOW
-			:	( WS_OVERLAPPEDWINDOW & ~WS_THICKFRAME );							// Windows Style
+			:	( WS_OVERLAPPEDWINDOW & ~WS_THICKFRAME & ~WS_MINIMIZEBOX & ~WS_MAXIMIZEBOX );	// Windows Style
 	}
 
 	::AdjustWindowRectEx( &windowRect, mWindowStyle, FALSE, mWindowExStyle );		// Adjust Window To True Requested Size


### PR DESCRIPTION
...preventing you to drag the frame to resize the window. But the Minimize and Maximize buttons are still visible in the title bar and they allow you to resize the window. That's not what you want. This change will remove the icons, too.
