### PR TITLE
Proposal for adding Tessellation Shaders to Cinder

### DIFF
--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -65,6 +65,10 @@ class GlslProg : public std::enable_shared_from_this<GlslProg> {
 		Format&		geometry( const DataSourceRef &dataSource );
 		//! Supplies the GLSL source for the geometry shader
 		Format&		geometry( const char *geometryShader );
+		//! Supplies the GLSL source for the tesselation shader
+		Format&		tessellation( const DataSourceRef &controlDataSource, const DataSourceRef &evaluationDataSource );
+		//! Supplies the GLSL source for the tesselation shader
+		Format&		tessellation( const char *controlShader, const char* evaluationShader );
 		//! Sets the TransformFeedback varyings
 		Format&		feedbackVaryings( const std::vector<std::string>& varyings ) { mTransformVaryings = varyings; return *this; }
 		//! Sets the TransformFeedback format
@@ -88,6 +92,10 @@ class GlslProg : public std::enable_shared_from_this<GlslProg> {
 #if ! defined( CINDER_GL_ES )
 		//! Returns the GLSL source for the geometry shader
 		const std::string&	getGeometry() const { return mGeometryShader; }
+		//! Returns the GLSL source for the tesselation control shader
+		const std::string&	getTessellationControl() const { return mTessellationControlShader; }
+		//! Returns the GLSL source for the tesselation evaluation shader
+		const std::string&	getTessellationEvaluation() const { return mTessellationEvaluationShader; }
 		const std::vector<std::string>&  getVaryings() const { return mTransformVaryings; }
 		//! Returns the TransFormFeedback format
 		GLenum			getTransformFormat() const { return mTransformFormat; }
@@ -115,6 +123,8 @@ class GlslProg : public std::enable_shared_from_this<GlslProg> {
 		std::string					mFragmentShader;
 #if ! defined( CINDER_GL_ES )
 		std::string								mGeometryShader;
+		std::string								mTessellationControlShader;
+		std::string								mTessellationEvaluationShader;
 		GLenum									mTransformFormat;
 		std::vector<std::string>				mTransformVaryings;
 #endif

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -117,6 +117,43 @@ GlslProg::Format& GlslProg::Format::geometry( const char *geometryShader )
 
 	return *this;
 }
+	
+GlslProg::Format& GlslProg::Format::tessellation( const DataSourceRef &controlDataSource, const DataSourceRef &evaluationDataSource )
+{
+	if( controlDataSource && evaluationDataSource ) {
+		Buffer controlBuffer( controlDataSource );
+		mTessellationControlShader.resize( controlBuffer.getDataSize() + 1 );
+		memcpy( (void*)mTessellationControlShader.data(), controlBuffer.getData(), controlBuffer.getDataSize() );
+		mTessellationControlShader[controlBuffer.getDataSize()] = 0;
+		
+		Buffer evaluationBuffer( evaluationDataSource );
+		mTessellationEvaluationShader.resize( evaluationBuffer.getDataSize() + 1 );
+		memcpy( (void*)mTessellationEvaluationShader.data(), evaluationBuffer.getData(), evaluationBuffer.getDataSize() );
+		mTessellationEvaluationShader[evaluationBuffer.getDataSize()] = 0;
+	}
+	else {
+		mTessellationControlShader.clear();
+		mTessellationEvaluationShader.clear();
+	}
+	
+	return *this;
+}
+
+GlslProg::Format& GlslProg::Format::tessellation( const char *controlShader, const char* evaluationShader )
+{
+	if( controlShader && evaluationShader ) {
+		mTessellationControlShader		= string( controlShader );
+		mTessellationEvaluationShader	= string( evaluationShader );
+	}
+	else {
+		mTessellationControlShader.clear();
+		mTessellationEvaluationShader.clear();
+	}
+	
+	return *this;
+}
+	
+	
 #endif // ! defined( CINDER_GL_ES )
 
 GlslProg::Format& GlslProg::Format::attrib( geom::Attrib semantic, const std::string &attribName )
@@ -189,6 +226,10 @@ GlslProg::GlslProg( const Format &format )
 #if ! defined( CINDER_GL_ES )
 	if( ! format.getGeometry().empty() )
 		loadShader( format.getGeometry(), GL_GEOMETRY_SHADER );
+	if( ! format.getTessellationControl().empty() )
+		loadShader( format.getTessellationControl(), GL_TESS_CONTROL_SHADER );
+	if( ! format.getTessellationEvaluation().empty() )
+		loadShader( format.getTessellationEvaluation(), GL_TESS_EVALUATION_SHADER );
 #endif
 
 	// copy the Format's attribute-semantic map


### PR DESCRIPTION
Now that OSX officially supports Tessellation Shaders, would be good to have this option in Cinder. It is a really small change, I just added the getter/setters in the GlslProg::Format and the necessary loadShader(...) in the initialisation of the GlslProg.

Because tessellation shaders are (always?) composed of two sources, the Format::tessellation method has two parameters which make it look different from the vertex/fragment/geometry methods. I'm not sure having Format::tessellationControl and Format::tessellationEvaluation, would make the whole thing easier. On the other hand we could add a std::pair<string,string> getTessellation()...

Anyway, here's a working sample:
https://github.com/simongeilfus/glNextExperiments/tree/master/TessellationShader

![screen shot 2014-09-08 at 15 09 15](https://cloud.githubusercontent.com/assets/241098/4185663/632e7992-3759-11e4-9203-2ee4f551b7e0.png)
