### PR TITLE
add Aspect Fill to Rect

### DIFF
--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -103,7 +103,9 @@ class RectT {
 
 	/** \return Scaled copy with the same aspect ratio centered relative to and scaled to fit inside \a other. If \a expand then the rectangle is expanded if it is smaller than \a other */
 	RectT		getCenteredFit( const RectT &other, bool expand ) const;
-
+	/** \return Scaled copy with the same aspect ratio centered relative to and scaled so it completely fills \a other. If \a contract then the rectangle is contracted if it is larger than \a other */
+	RectT		getCenteredFill( const RectT &other, bool contract ) const;
+	
 	/** Expands the Rect to include \a point in its interior **/
 	void		include( const Vec2<T> &point );
 	/** Expands the Rect to include all points in \a points in its interior **/

--- a/src/cinder/Rect.cpp
+++ b/src/cinder/Rect.cpp
@@ -314,6 +314,28 @@ RectT<T> RectT<T>::getCenteredFit( const RectT<T> &other, bool expand ) const
 	
 	return result;
 }
+	
+template<typename T>
+RectT<T> RectT<T>::getCenteredFill( const RectT<T> &other, bool contract ) const
+{
+	RectT<T> result = *this;
+	result.offset( other.getCenter() - result.getCenter() );
+	
+	bool otherIsInside = ( ( result.getWidth() > other.getWidth() ) && ( result.getHeight() > other.getHeight() ) );
+	if( contract || ( ! otherIsInside ) ) { // need to do some scaling
+		T aspectAspect = result.getAspectRatio() / other.getAspectRatio();
+		if( aspectAspect <= 1.0f ) { // result is proportionally wider so we need to fit its x-axis
+			T scaleBy = other.getWidth() / result.getWidth();
+			result.scaleCentered( scaleBy );
+		}
+		else { // result is proportionally wider so we need to fit its y-axis
+			T scaleBy = other.getHeight() / result.getHeight();
+			result.scaleCentered( scaleBy );
+		}
+	}
+	
+	return result;
+}
 
 RectMapping::RectMapping( const Rectf &aSrcRect, const Rectf &aDstRect, bool preserveSrcAspect )
 	: mSrcRect( aSrcRect ), mDstRect( aDstRect )


### PR DESCRIPTION
Submitting the PR again as the previous one was targeted to the dev branch.

`getCenteredFill( const RectT<T> &other, bool contract )` is the counterpart of `getCenteredFit()`, a basic feature I've needed in a lot of projects.

Centered fill is the [CSS equivalent](http://www.w3schools.com/cssref/playit.asp?filename=playcss_background-size&preval=cover) of `background-size:cover`, with centered fit being `background-size:contain`.

You can test how it works with this simple app https://gist.github.com/araid/c6a59642e511cf3e0112
