### PR TITLE
Fixed InterfaceGl::addParam<string/Color> (setter/getter version)

### DIFF
--- a/src/cinder/params/Params.cpp
+++ b/src/cinder/params/Params.cpp
@@ -213,6 +213,15 @@ void TW_CALL getterCallback( void *value, void *clientData )
 	*(T *)value = twc->mGetter();
 }
 
+// specialization of getterCallback for string (string must be copied using TwCopyStdStringToLibrary)
+template <>
+void TW_CALL getterCallback<string>(void *value, void *clientData)
+{
+	Accessors<string> *twc = reinterpret_cast<Accessors<string>*>(clientData);
+	std::string *destPtr = static_cast<std::string *>(value);
+	TwCopyStdStringToLibrary(*destPtr, twc->mGetter());
+}
+
 } // anonymous namespace
 
 int initAntGl( weak_ptr<app::Window> winWeak )


### PR DESCRIPTION
Nothing critical, but addParam<string> and addParam<Color> with getter/setter were not linking since addParamCallbackImpl wasn't specialized for those two types (TwCopyStdStringToLibrary was also needed for string).
