### PR TITLE
Fix Timeline::isComplete immediately after changes

### DIFF
--- a/src/cinder/TimelineItem.cpp
+++ b/src/cinder/TimelineItem.cpp
@@ -51,11 +51,11 @@ void TimelineItem::stepTo( float newTime, bool reverse )
 {
 	if( mMarkedForRemoval )
 		return;
-	
-	const float absTime = newTime - mStartTime;
-	const float endTime = mStartTime + mDuration;
 
 	updateDuration();
+
+	const float absTime = newTime - mStartTime;
+	const float endTime = mStartTime + mDuration;
 
 	if( ( ! mHasReverseStarted ) && reverse && ( newTime < mStartTime ) ) {
 		// first update the current time to be the start time


### PR DESCRIPTION
The `endTime` variable is calculated based on the `mDuration` of this `TimelineItem`.  If the duration of this `TimelineItem` instance should be updated, then we should recalculate the duration before using it in the calculation of `endTime`.
# Use Case:

Let's say we're nesting a `Timeline` instance in the main `Timeline`, and we want to know if it's complete via `isComplete()`.  In order to track completion state, we need to configure the `Timeline` instance as non-infinite:

``` cpp
myTimeline->setInfinite( false );
```

Now let's say we've let the `Timeline` run to completion, but we want to reset it, and run it in reverse:

``` cpp
// Calculate the duration, then duplicate everything in reverse
float forwardDuration = myTimeline->getDuration();
myTimeline->appendPingPong();

// Start right before all the new reversed items
float currentTime = myTimeline->getParent()->getCurrentTime();
myTimeline->setStartTime( currentTime - forwardDuration );

// Reset the mComplete state
myTimeline->reset();
```

Okay, things are looking good.  However, when we get down here on the next `stepTo()` cycle:

``` cpp
    if( newTime < endTime ) {  // Oh no, endTime is not correct!
        if( ( ! mReverseComplete ) && reverse ) {
            mReverseComplete = true;
            mComplete = false;
            complete( true );
        }
    }
    else if( ( ! mLoop ) && ( ! mInfinite ) ) { // newTime >= endTime
        if( ( ! mComplete ) && ( ! reverse ) ) {
            mComplete = true;
            mReverseComplete = false;
            complete( false );
        }
    }
```

... we will incorrectly set `mComplete` to `true`, and call the `complete` method!  This is because the call to `appendPingPong` has changed this `Timeline`'s duration, but we don't use the updated `mDuration` in the calculation of `endTime`.  The result is that `isComplete()` will return `true` while we are still running the new PingPong tweens!

I cannot think of an example where we would want `endTime` to reflect the value of the old duration if we have added `Tween`s to a `Timeline`.
