### PR TITLE
include Color.h, needed for ColorFromAttrib class

### DIFF
--- a/include/cinder/GeomIo.h
+++ b/include/cinder/GeomIo.h
@@ -28,6 +28,7 @@
 #include "cinder/Vector.h"
 #include "cinder/Matrix.h"
 #include "cinder/Shape2d.h"
+#include "cinder/Color.h"
 
 #include <set>
 #include <vector>


### PR DESCRIPTION
I'm getting build errors on macosx without this in some situations (cinder is a subproject), although strangely it builds when just building cinder directly.  In any event, it seems like a dependency to me and no other headers in GeomIO.h include it.
