### PR TITLE
Added the old 'setDoNotDispose()' method back to gl::TextureBase.

### DIFF
--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -59,6 +59,8 @@ class TextureBase {
   public:
 	virtual ~TextureBase();
 
+	//! Determines whether the Texture will call glDeleteTextures() to free the associated texture objects on destruction
+	void			setDoNotDispose( bool aDoNotDispose = true ) { mDoNotDispose = aDoNotDispose; }
 	//! the Texture's internal format, which is the format that OpenGL stores the texture data in memory. Common values include \c GL_RGB, \c GL_RGBA and \c GL_LUMINANCE
 	GLint			getInternalFormat() const;
 	//! the ID number for the texture, appropriate to pass to calls like \c glBindTexture()


### PR DESCRIPTION
It allows you to keep the generated texture on destruction of the gl::Texture itself. This is needed if you require a custom deleter for your gl::TextureRef. The only way to create one using existing Cinder code, is to call a specific gl::Texture::create() method with an existing texture target and ID. The easiest way to create such a texture is to use one of the other create() methods, then 'transfer ownership' to a newly created TextureRef. The first texture should then not dispose of its internal buffers, hence the need for this function.

It was the cleanest solution to my particular problem that I could find :)
