### PR TITLE
Added the ability to specify a custom deleter for your Texture...

### DIFF
--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -220,7 +220,7 @@ class TextureBase {
 		Format&				label( const std::string &label ) { setLabel( label ); return *this; }
 
 		//! Returns whether the texture uses a custom deleter.
-		bool				hasDeleter() const { return mDeleter != nullptr; }
+		bool				hasDeleter() const { return (bool) mDeleter; }
 		//! Allows you to specify a custom \a deleter for the shared pointer.
 		void				setDeleter( const std::function<void( TextureBase* )> &deleter ) { mDeleter = deleter; }
 		//! Allows you to specify a custom \a deleter for the shared pointer.

--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -59,8 +59,6 @@ class TextureBase {
   public:
 	virtual ~TextureBase();
 
-	//! Determines whether the Texture will call glDeleteTextures() to free the associated texture objects on destruction
-	void			setDoNotDispose( bool aDoNotDispose = true ) { mDoNotDispose = aDoNotDispose; }
 	//! the Texture's internal format, which is the format that OpenGL stores the texture data in memory. Common values include \c GL_RGB, \c GL_RGBA and \c GL_LUMINANCE
 	GLint			getInternalFormat() const;
 	//! the ID number for the texture, appropriate to pass to calls like \c glBindTexture()
@@ -220,6 +218,13 @@ class TextureBase {
 		void				setLabel( const std::string &label ) { mLabel = label; }
 		//! Sets the debugging label associated with the Texture. Calls glObjectLabel() when available.
 		Format&				label( const std::string &label ) { setLabel( label ); return *this; }
+
+		//! Returns whether the texture uses a custom deleter.
+		bool				hasDeleter() const { return mDeleter != nullptr; }
+		//! Allows you to specify a custom \a deleter for the shared pointer.
+		void				setDeleter( const std::function<void( TextureBase* )> &deleter ) { mDeleter = deleter; }
+		//! Allows you to specify a custom \a deleter for the shared pointer.
+		Format&				deleter( const std::function<void( TextureBase* )> &deleter ) { setDeleter( deleter ); return *this; }
 		
 	protected:
 		Format();
@@ -241,6 +246,9 @@ class TextureBase {
 		bool				mBorderSpecified;
 		std::array<GLfloat,4>	mBorderColor;
 		std::string			mLabel; // debug label
+
+		
+		std::function<void( TextureBase* )>	mDeleter;
 
 #if ! defined( CINDER_GL_ES )		
 		PboRef				mIntermediatePbo;

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -472,7 +472,6 @@ TextureBase::Format::Format()
 	mSwizzleMask[0] = GL_RED; mSwizzleMask[1] = GL_GREEN; mSwizzleMask[2] = GL_BLUE; mSwizzleMask[3] = GL_ALPHA;
 	mCompareMode = -1;
 	mCompareFunc = -1;
-	mDeleter = nullptr;
 }
 
 void TextureBase::Format::setSwizzleMask( GLint r, GLint g, GLint b, GLint a )
@@ -497,58 +496,58 @@ void TextureBase::Format::setBorderColor( const ColorA &color )
 // Texture
 Texture2dRef Texture2d::create( int width, int height, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( width, height, format ) )
+	return ( !format.mDeleter ) ? TextureRef( new Texture( width, height, format ) )
 		: TextureRef( new Texture( width, height, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const unsigned char *data, int dataFormat, int width, int height, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( data, dataFormat, width, height, format ) ) 
+	return ( !format.mDeleter ) ? TextureRef( new Texture( data, dataFormat, width, height, format ) )
 		: TextureRef( new Texture( data, dataFormat, width, height, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Surface8u &surface, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( surface, format ) )
+	return ( !format.mDeleter ) ? TextureRef( new Texture( surface, format ) )
 		: TextureRef( new Texture( surface, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Surface16u &surface, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( surface, format ) )
+	return ( !format.mDeleter ) ? TextureRef( new Texture( surface, format ) )
 		: TextureRef( new Texture( surface, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Surface32f &surface, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( surface, format ) )
+	return ( !format.mDeleter ) ? TextureRef( new Texture( surface, format ) )
 		: TextureRef( new Texture( surface, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Channel8u &channel, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( channel, format ) )
+	return ( !format.mDeleter ) ? TextureRef( new Texture( channel, format ) )
 		: TextureRef( new Texture( channel, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Channel16u &channel, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( channel, format ) )
+	return ( !format.mDeleter ) ? TextureRef( new Texture( channel, format ) )
 		: TextureRef( new Texture( channel, format ), format.mDeleter );
 }
-	
+
 Texture2dRef Texture2d::create( const Channel32f &channel, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( channel, format ) )
+	return ( !format.mDeleter ) ? TextureRef( new Texture( channel, format ) )
 		: TextureRef( new Texture( channel, format ), format.mDeleter );
 }
-	
+
 Texture2dRef Texture2d::create( ImageSourceRef imageSource, Format format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( imageSource, format ) )
+	return ( !format.mDeleter ) ? TextureRef( new Texture( imageSource, format ) )
 		: TextureRef( new Texture( imageSource, format ), format.mDeleter );
 }
-	
+
 Texture2dRef Texture2d::create( GLenum target, GLuint textureID, int width, int height, bool doNotDispose )
 {
 	return TextureRef( new Texture( target, textureID, width, height, doNotDispose ) );
@@ -556,7 +555,7 @@ Texture2dRef Texture2d::create( GLenum target, GLuint textureID, int width, int 
 
 Texture2dRef Texture2d::create( const TextureData &data, const Format &format )
 {
-	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( data, format ) ) 
+	return ( !format.mDeleter ) ? TextureRef( new Texture( data, format ) )
 		: TextureRef( new Texture( data, format ), format.mDeleter );
 }
 

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -471,7 +471,8 @@ TextureBase::Format::Format()
 	mSwizzleSpecified = false;
 	mSwizzleMask[0] = GL_RED; mSwizzleMask[1] = GL_GREEN; mSwizzleMask[2] = GL_BLUE; mSwizzleMask[3] = GL_ALPHA;
 	mCompareMode = -1;
-	mCompareFunc = -1;	
+	mCompareFunc = -1;
+	mDeleter = nullptr;
 }
 
 void TextureBase::Format::setSwizzleMask( GLint r, GLint g, GLint b, GLint a )
@@ -496,47 +497,56 @@ void TextureBase::Format::setBorderColor( const ColorA &color )
 // Texture
 Texture2dRef Texture2d::create( int width, int height, Format format )
 {
-	return TextureRef( new Texture( width, height, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( width, height, format ) )
+		: TextureRef( new Texture( width, height, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const unsigned char *data, int dataFormat, int width, int height, Format format )
 {
-	return TextureRef( new Texture( data, dataFormat, width, height, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( data, dataFormat, width, height, format ) ) 
+		: TextureRef( new Texture( data, dataFormat, width, height, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Surface8u &surface, Format format )
 {
-	return TextureRef( new Texture( surface, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( surface, format ) )
+		: TextureRef( new Texture( surface, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Surface16u &surface, Format format )
 {
-	return TextureRef( new Texture( surface, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( surface, format ) )
+		: TextureRef( new Texture( surface, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Surface32f &surface, Format format )
 {
-	return TextureRef( new Texture( surface, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( surface, format ) )
+		: TextureRef( new Texture( surface, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Channel8u &channel, Format format )
 {
-	return TextureRef( new Texture( channel, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( channel, format ) )
+		: TextureRef( new Texture( channel, format ), format.mDeleter );
 }
 
 Texture2dRef Texture2d::create( const Channel16u &channel, Format format )
 {
-	return TextureRef( new Texture( channel, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( channel, format ) )
+		: TextureRef( new Texture( channel, format ), format.mDeleter );
 }
 	
 Texture2dRef Texture2d::create( const Channel32f &channel, Format format )
 {
-	return TextureRef( new Texture( channel, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( channel, format ) )
+		: TextureRef( new Texture( channel, format ), format.mDeleter );
 }
 	
 Texture2dRef Texture2d::create( ImageSourceRef imageSource, Format format )
 {
-	return TextureRef( new Texture( imageSource, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( imageSource, format ) )
+		: TextureRef( new Texture( imageSource, format ), format.mDeleter );
 }
 	
 Texture2dRef Texture2d::create( GLenum target, GLuint textureID, int width, int height, bool doNotDispose )
@@ -546,7 +556,8 @@ Texture2dRef Texture2d::create( GLenum target, GLuint textureID, int width, int 
 
 Texture2dRef Texture2d::create( const TextureData &data, const Format &format )
 {
-	return TextureRef( new Texture( data, format ) );
+	return ( format.mDeleter == nullptr ) ? TextureRef( new Texture( data, format ) ) 
+		: TextureRef( new Texture( data, format ), format.mDeleter );
 }
 
 Texture2d::Texture2d( int width, int height, Format format )


### PR DESCRIPTION
...using the Format's ```setDeleter()``` method. If a custom deleter is specified, the texture's shared pointer will use it. This is a cleaner solution than the one I proposed earlier in #541 .

This raises the question whether or not we should also add this to Cinder's other Format classes (Fbo, Vbo, etc).