### PR TITLE
Implement FboCubeMap::Format::textureCubeMapFormat

### DIFF
--- a/include/cinder/gl/Fbo.h
+++ b/include/cinder/gl/Fbo.h
@@ -299,7 +299,7 @@ class FboCubeMap : public Fbo {
 		Format();
 		
 		//! Sets the TextureCubeMap format for the default CubeMap.
-		Format&							textureCubeMapFormat( const TextureCubeMap::Format &format );
+		Format&							textureCubeMapFormat( const TextureCubeMap::Format &format )	{ mTextureCubeMapFormat = format; return *this; }
 		//! Returns the TextureCubeMap format for the default CubeMap.
 		const TextureCubeMap::Format&	getTextureCubeMapFormat() const { return mTextureCubeMapFormat; }
 		


### PR DESCRIPTION
Found this was declared and not implemented. I'm not sure if more work needs to go into this method but it seems to work..
