### PR TITLE
Fixed a few typos in gl.cpp and gl.h

### DIFF
--- a/include/cinder/gl/gl.h
+++ b/include/cinder/gl/gl.h
@@ -555,7 +555,7 @@ struct ScopedTextureBind : public boost::noncopyable
 struct ScopedScissor : public boost::noncopyable
 {
 	//! Implicitly enables scissor test
-	ScopedScissor( const ivec2 &lowerLeftPostion, const ivec2 &dimension );
+	ScopedScissor( const ivec2 &lowerLeftPosition, const ivec2 &dimension );
 	//! Implicitly enables scissor test	
 	ScopedScissor( int lowerLeftX, int lowerLeftY, int width, int height );
 	~ScopedScissor();
@@ -566,7 +566,7 @@ struct ScopedScissor : public boost::noncopyable
 
 struct ScopedViewport : public boost::noncopyable
 {
-	ScopedViewport( const ivec2 &lowerLeftPostion, const ivec2 &dimension );
+	ScopedViewport( const ivec2 &lowerLeftPosition, const ivec2 &dimension );
 	ScopedViewport( int lowerLeftX, int lowerLeftY, int width, int height );
 	~ScopedViewport();
 

--- a/src/cinder/gl/gl.cpp
+++ b/src/cinder/gl/gl.cpp
@@ -2057,11 +2057,11 @@ ScopedTextureBind::~ScopedTextureBind()
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // ScopedScissor
-ScopedScissor::ScopedScissor( const ivec2 &lowerLeftPostion, const ivec2 &dimension )
+ScopedScissor::ScopedScissor( const ivec2 &lowerLeftPosition, const ivec2 &dimension )
 	: mCtx( gl::context() )
 {
 	mCtx->pushBoolState( GL_SCISSOR_TEST, GL_TRUE );
-	mCtx->pushScissor( std::pair<ivec2, ivec2>( lowerLeftPostion, dimension ) ); 
+	mCtx->pushScissor( std::pair<ivec2, ivec2>( lowerLeftPosition, dimension ) );
 }
 
 ScopedScissor::ScopedScissor( int lowerLeftX, int lowerLeftY, int width, int height )
@@ -2122,10 +2122,10 @@ ScopedRenderbuffer::~ScopedRenderbuffer()
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // ScopedViewport
-ScopedViewport::ScopedViewport( const ivec2 &lowerLeftPostion, const ivec2 &dimension )
+ScopedViewport::ScopedViewport( const ivec2 &lowerLeftPosition, const ivec2 &dimension )
 	: mCtx( gl::context() )
 {
-	mCtx->pushViewport( std::pair<ivec2, ivec2>( lowerLeftPostion, dimension ) ); 
+	mCtx->pushViewport( std::pair<ivec2, ivec2>( lowerLeftPosition, dimension ) );
 }
 
 ScopedViewport::ScopedViewport( int lowerLeftX, int lowerLeftY, int width, int height )


### PR DESCRIPTION
Just happened upon a typo when I was looking at ScopedViewport (lowerLeftPostion > lowerLeftPosition).
