### PR TITLE
Added Timeline::applyAt() to allow for ‘delayed apply' tweens

### DIFF
--- a/include/cinder/Timeline.h
+++ b/include/cinder/Timeline.h
@@ -143,7 +143,9 @@ class Timeline : public TimelineItem {
 
 	//! Replaces any existing TimelineItems that match \a item's target and adds \a item to the timeline. Safe to use from callback fn's.
 	void apply( TimelineItemRef item );
-	
+	//! Replaces any existing TimelineItems that match \a item's target and end at or after `item->getStartTime()`, and adds \a item to the timeline. Safe to use from callback fn's.
+	void applyAt( TimelineItemRef item );
+
 	//! add an item to the timeline at the current time. Safe to use from callback fn's.
 	void add( TimelineItemRef item );
 	//! adds an item to the timeline. Its start time is not modified. Safe to use from callback fn's.
@@ -167,6 +169,8 @@ class Timeline : public TimelineItem {
 	void				remove( TimelineItemRef item );
 	//! Removes all TimelineItems whose target matches \a target
 	void				removeTarget( void *target );
+	//! Removes the TimelineItem \a item from the Timeline that have a end time at or after \a time. Safe to use from callback fn's.
+	void				removeTargetAt( void *target, float time );
 	//! Clones all TimelineItems whose target matches \a target, but replacing their target with \a replacementTarget
 	void				cloneAndReplaceTarget( void *target, void *replacementTarget );
 	//! Replaces the target of all TimelineItems whose target matches \a target, with \a replacementTarget

--- a/src/cinder/Timeline.cpp
+++ b/src/cinder/Timeline.cpp
@@ -113,6 +113,13 @@ void Timeline::apply( TimelineItemRef item )
 	insert( item );
 }
 
+void Timeline::applyAt( TimelineItemRef item )
+{
+	if( item->getTarget() )
+		removeTargetAt( item->getTarget(), item->getStartTime() );
+	insert( item );
+}
+
 void Timeline::add( TimelineItemRef item )
 {
 	item->mParent = this;
@@ -247,6 +254,21 @@ void Timeline::removeTarget( void *target )
 	pair<s_iter,s_iter> range = mItems.equal_range( target );
 	for( s_iter iter = range.first; iter != range.second; ++iter )
 		iter->second->mMarkedForRemoval = true;
+
+	setDurationDirty();
+}
+
+void Timeline::removeTargetAt( void *target, float time )
+{
+	if( target == 0 )
+		return;
+
+	pair<s_iter,s_iter> range = mItems.equal_range( target );
+	for( s_iter iter = range.first; iter != range.second; ++iter ) {
+
+		if( iter->second->getEndTime() >= time )
+			iter->second->mMarkedForRemoval = true;
+	}
 
 	setDurationDirty();
 }


### PR DESCRIPTION
I have been working on a real time sequencer that needs to be able to schedule an apply in the future, however this wasn't possible with the existing API because the apply's 'removeTarget' happens immediately.

We discussed offline that it would make sense for apply() to only cancel existing Tweens after the TimelineItem's start time (which is usually all Tweens unless you have a 'time ahead' system like I'm working on), however making this modification may have unwanted side effects due to Timeline's complex abilities to nest, reverse, etc. So, I have proposed to add these new methods so the current functionality isn't disturbed.

Because the start time needs to be known during the initial call that will remove current Tweens, we currently cannot use a templated function that returns an Options struct, since the removal would have already happened. For now, you must use this like the following:

```
float timeInFuture = timeline().getCurrentTime() + 0.5f;
ci::TweenRef<float> applyMagTween( new ci::Tween<float>( &anim, endValue, timeInFuture, duration )  );
timeline().applyAt( applyMagTween );
```

It was mentioned that later we will be addressing ways to improve Timelime, and at that point we may decide to change (more like augment) the default functionality to include a notion of delayed Tween removals.
