### PR TITLE
Added support for LANGUAGE tags to Cinder's loadResource() method.

### DIFF
--- a/src/cinder/app/msw/PlatformMsw.cpp
+++ b/src/cinder/app/msw/PlatformMsw.cpp
@@ -58,7 +58,7 @@ DataSourceRef PlatformMsw::loadResource( const fs::path &resourcePath, int mswID
 
 	wchar_t unicodeType[1024];
 	wsprintfW( unicodeType, L"%S", mswType.c_str() );
-	resInfoHandle = ::FindResource( NULL, MAKEINTRESOURCE( mswID ), unicodeType );
+	resInfoHandle = ::FindResourceEx( NULL, unicodeType, MAKEINTRESOURCE( mswID ), ::GetUserDefaultLangID() );
 	if( resInfoHandle == NULL ) {
 		throw ResourceLoadExcMsw( mswID, mswType );
 	}


### PR DESCRIPTION
Adding localized resources on Windows is relatively easy: just add LANGUAGE LANG_GERMAN, SUBLANG_NEUTRAL to the Resources.rc file, and all resources following it will be listed as "German". Cinder did not support this out-of-the-box, so I've made a little change. This should have no effect on existing samples and applications.

Note: to support LANGUAGE tags, users must add '#include &lt;Windows.h&gt;' to their Resources.h file. Unfortunately, adding this line to 'cinder/CinderResources.h' does not seem to work, perhaps because the resource compiler doesn't properly handle includes-within-includes.