### PR TITLE
Check if main window exists before calling getWindowIndex( 0 ).  

### DIFF
--- a/src/cinder/app/App.cpp
+++ b/src/cinder/app/App.cpp
@@ -143,9 +143,11 @@ void App::privateUpdate__()
 	mIo->poll();
 #endif
 
-	WindowRef mainWin = getWindowIndex( 0 );
-	if( mainWin )
-		mainWin->getRenderer()->makeCurrentContext();
+	if( getNumWindows() > 0 ) {
+		WindowRef mainWin = getWindowIndex( 0 );
+		if( mainWin )
+			mainWin->getRenderer()->makeCurrentContext();
+	}
 
 	mSignalUpdate();
 


### PR DESCRIPTION
Fixes #569.
