### PR TITLE
Enable use of custom shaders with TextureFont.

### DIFF
--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -326,9 +326,14 @@ void TextureFont::drawGlyphs( const vector<pair<uint16_t,vec2> > &glyphMeasures,
 	if( ! colors.empty() )
 		assert( glyphMeasures.size() == colors.size() );
 
+	auto ctx = context();
+	auto shader = ctx->getGlslProg();
+	// Create a new shader iff there isn't a texturing shader already bound.
+	if( (! shader) || (! shader->hasAttribSemantic( geom::Attrib::TEX_COORD_0 )) ) {
+		auto shaderDef = ShaderDef().texture( mTextures[0] ).color();
+		shader = gl::getStockShader( shaderDef );
+	}
 	ScopedTextureBind texBindScp( mTextures[0] );
-	auto shaderDef = ShaderDef().texture( mTextures[0] ).color();
-	GlslProgRef shader = gl::getStockShader( shaderDef );
 	ScopedGlslProg glslScp( shader );
 
 	vec2 baseline = baselineIn;
@@ -441,9 +446,14 @@ void TextureFont::drawGlyphs( const std::vector<std::pair<uint16_t,vec2> > &glyp
 	if( ! colors.empty() )
 		assert( glyphMeasures.size() == colors.size() );
 
+	auto ctx = context();
+	auto shader = ctx->getGlslProg();
+	// Create a new shader iff there isn't a texturing shader already bound.
+	if( (! shader) || (! shader->hasAttribSemantic( geom::Attrib::TEX_COORD_0 )) ) {
+		auto shaderDef = ShaderDef().texture( mTextures[0] ).color();
+		shader = gl::getStockShader( shaderDef );
+	}
 	ScopedTextureBind texBindScp( mTextures[0] );
-	auto shaderDef = ShaderDef().texture( mTextures[0] ).color();
-	GlslProgRef shader = gl::getStockShader( shaderDef );
 	ScopedGlslProg glslScp( shader );
 
 	const float scale = options.getScale();


### PR DESCRIPTION
Only bind a new shader if there isn't a texturing shader already bound.

Example gradient shader with TextureFont:
![gradient screenshot](https://cloud.githubusercontent.com/assets/81553/5092975/b86a21ae-6f21-11e4-8d3f-60808dc99e28.png)
In same project, using TextureFont without binding a shader first still works as expected:
![stock screenshot](https://cloud.githubusercontent.com/assets/81553/5092976/b86d68dc-6f21-11e4-8dd9-92e80d48cb3b.png)
