### PR TITLE
Fix TextureFont alpha when providing color per glyph

### DIFF
--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -425,7 +425,7 @@ void TextureFont::drawGlyphs( const vector<pair<uint16_t,vec2> > &glyphMeasures,
 			int colorLoc = shader->getAttribSemanticLocation( geom::Attrib::COLOR );
 			if( colorLoc >= 0 ) {
 				enableVertexAttribArray( colorLoc );
-				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_FALSE, 0, (void*)dataOffset );
+				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, (void*)dataOffset );
 				defaultArrayVbo->bufferSubData( dataOffset, vertColors.size() * sizeof(ColorA8u), vertColors.data() );
 				dataOffset += vertColors.size() * sizeof(ColorA8u);				
 			}
@@ -564,7 +564,7 @@ void TextureFont::drawGlyphs( const std::vector<std::pair<uint16_t,vec2> > &glyp
 			int colorLoc = shader->getAttribSemanticLocation( geom::Attrib::COLOR );
 			if( colorLoc >= 0 ) {
 				enableVertexAttribArray( colorLoc );
-				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_FALSE, 0, (void*)dataOffset );
+				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, (void*)dataOffset );
 				defaultArrayVbo->bufferSubData( dataOffset, vertColors.size() * sizeof(ColorA8u), vertColors.data() );
 				dataOffset += vertColors.size() * sizeof(ColorA8u);				
 			}


### PR DESCRIPTION
Fixes blocky type.
Normalizes the vertex color values so the stock shaders (and others) behave correctly.

This includes the work from #594 
