### PR TITLE
Pass in T to Entry’s operator<< by const &.

### DIFF
--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -238,7 +238,7 @@ struct Entry {
 	}
 
 	template <typename T>
-	Entry& operator<<( T rhs )
+	Entry& operator<<( const T &rhs )
 	{
 		mHasContent = true;
 		mStream << rhs;


### PR DESCRIPTION
I'm not sure why I originally had this as passing in by value, but that wrong. I discovered this when trying to log a T that wasn't copyable (`ci::Display`)...
