### PR TITLE
Problem when using CINDER_GL_ES_3 define

### DIFF
--- a/src/cinder/gl/VboMesh.cpp
+++ b/src/cinder/gl/VboMesh.cpp
@@ -377,22 +377,14 @@ void VboMesh::drawImpl()
 		glDrawArrays( mGlPrimitive, 0, mNumVertices );
 }
 
-#if (! defined( CINDER_GL_ES_2 )) || defined( CINDER_COCOA_TOUCH )
 void VboMesh::drawInstancedImpl( GLsizei instanceCount )
 {
-#if defined( CINDER_COCOA_TOUCH )
+	auto ctx = gl::context();
 	if( mNumIndices )
-		glDrawElementsInstancedEXT( mGlPrimitive, mNumIndices, mIndexType, (GLvoid*)( 0 ), instanceCount );
+		ctx->drawElementsInstanced( mGlPrimitive, mNumIndices, mIndexType, (GLvoid*)( 0 ), instanceCount );
 	else
-		glDrawArraysInstancedEXT( mGlPrimitive, 0, mNumVertices, instanceCount );
-#else
-	if( mNumIndices )
-		glDrawElementsInstanced( mGlPrimitive, mNumIndices, mIndexType, (GLvoid*)( 0 ), instanceCount );
-	else
-		glDrawArraysInstanced( mGlPrimitive, 0, mNumVertices, instanceCount );
-#endif
+		ctx->drawArraysInstanced( mGlPrimitive, 0, mNumVertices, instanceCount );
 }
-#endif
 
 std::pair<geom::BufferLayout,VboRef>* VboMesh::findAttrib( geom::Attrib attr )
 {


### PR DESCRIPTION
- Because of define, uses EXT version of both drawArraysInstanced and drawElementsInstanced but those don't exist in ES3.
- Simplified it using the contexts draw...Instanced methods
