### PR TITLE
Add gl::ScopedColor default constructor

### DIFF
--- a/include/cinder/gl/gl.h
+++ b/include/cinder/gl/gl.h
@@ -476,6 +476,7 @@ struct ScopedState : public boost::noncopyable {
 };
 
 struct ScopedColor : public boost::noncopyable {
+	ScopedColor();
 	ScopedColor( const ColorAf &color );
 	~ScopedColor();
 

--- a/src/cinder/gl/gl.cpp
+++ b/src/cinder/gl/gl.cpp
@@ -1955,6 +1955,12 @@ ScopedState::~ScopedState() {
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // ScopedColor
+ScopedColor::ScopedColor()
+	: mCtx( gl::context() )
+{
+	mColor = mCtx->getCurrentColor();
+}
+
 ScopedColor::ScopedColor( const ColorAf &color )
 	: mCtx( gl::context() )
 {


### PR DESCRIPTION
I think this is nice to have, and pretty intuitive, when you are setting multiple colors and drawing multiple things in the same drawing routine:

```
MyApp::draw()
{
  gl::ScopedModelMatrix scopedMat;
  gl::ScopedColor colorScope;

  gl::color( vec3( 1, 0, 0 ) );
  // draw something red..

  gl::color( vec3( 0, 0, 1 );
  // draw something blue..
}
```
