### PR TITLE
Allow for custom start/finish draw functions on CINDER_MAC.

### DIFF
--- a/src/cinder/app/RendererGl.cpp
+++ b/src/cinder/app/RendererGl.cpp
@@ -77,12 +77,18 @@ void RendererGl::setup( App *aApp, CGRect frame, NSView *cinderView, RendererRef
 
 void RendererGl::startDraw()
 {
-	[mImpl makeCurrentContext];
+	if( mStartDrawFn )
+		mStartDrawFn( this );
+	else
+		[mImpl makeCurrentContext];
 }
 
 void RendererGl::finishDraw()
 {
-	[mImpl flushBuffer];
+	if( mFinishDrawFn )
+		mFinishDrawFn( this );
+	else
+		[mImpl flushBuffer];
 }
 
 void RendererGl::setFrameSize( int width, int height )


### PR DESCRIPTION
Needed for Oculus Rift implementation on Mac.
