### PR TITLE
TextureFont bugfixes

### DIFF
--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -420,7 +420,7 @@ void TextureFont::drawGlyphs( const vector<pair<uint16_t,vec2> > &glyphMeasures,
 			int colorLoc = shader->getAttribSemanticLocation( geom::Attrib::COLOR );
 			if( colorLoc >= 0 ) {
 				enableVertexAttribArray( colorLoc );
-				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_FALSE, 0, (void*)dataOffset );
+				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, (void*)dataOffset );
 				defaultArrayVbo->bufferSubData( dataOffset, vertColors.size() * sizeof(ColorA8u), vertColors.data() );
 				dataOffset += vertColors.size() * sizeof(ColorA8u);				
 			}
@@ -554,7 +554,7 @@ void TextureFont::drawGlyphs( const std::vector<std::pair<uint16_t,vec2> > &glyp
 			int colorLoc = shader->getAttribSemanticLocation( geom::Attrib::COLOR );
 			if( colorLoc >= 0 ) {
 				enableVertexAttribArray( colorLoc );
-				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_FALSE, 0, (void*)dataOffset );
+				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, (void*)dataOffset );
 				defaultArrayVbo->bufferSubData( dataOffset, vertColors.size() * sizeof(ColorA8u), vertColors.data() );
 				dataOffset += vertColors.size() * sizeof(ColorA8u);				
 			}

--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -393,7 +393,7 @@ void TextureFont::drawGlyphs( const vector<pair<uint16_t,vec2> > &glyphMeasures,
 		curTex->bind();
 		auto ctx = gl::context();
 		size_t dataSize = (verts.size() + texCoords.size()) * sizeof(float) + vertColors.size() * sizeof(ColorA8u);
-		ctx->pushVao();
+		gl::ScopedVao vaoScp( ctx->getDefaultVao() );
 		ctx->getDefaultVao()->replacementBindBegin();
 		VboRef defaultElementVbo = ctx->getDefaultElementVbo( indices.size() * sizeof(curIdx) );
 		VboRef defaultArrayVbo = ctx->getDefaultArrayVbo( dataSize );
@@ -527,7 +527,7 @@ void TextureFont::drawGlyphs( const std::vector<std::pair<uint16_t,vec2> > &glyp
 		curTex->bind();
 		auto ctx = gl::context();
 		size_t dataSize = (verts.size() + texCoords.size()) * sizeof(float) + vertColors.size() * sizeof(ColorA8u);
-		ctx->pushVao();
+		gl::ScopedVao vaoScp( ctx->getDefaultVao() );
 		ctx->getDefaultVao()->replacementBindBegin();
 		VboRef defaultElementVbo = ctx->getDefaultElementVbo( indices.size() * sizeof(curIdx) );
 		VboRef defaultArrayVbo = ctx->getDefaultArrayVbo( dataSize );


### PR DESCRIPTION
Fix infinite vao stack growth.
Correct per-glyph coloring when provided by user.