### PR TITLE
User can specify GlslProg for use when rendering TextureFont.

### DIFF
--- a/include/cinder/gl/TextureFont.h
+++ b/include/cinder/gl/TextureFont.h
@@ -98,10 +98,15 @@ class TextureFont {
 		//! Sets the scale at which the type is rendered. 2 is double size. Default \c 1
 		DrawOptions&	scale( float sc ) { mScale = sc; return *this; }
 
+		//! Returns the user-specified glsl program if set. Otherwise returns nullptr.
+		const GlslProgRef& getGlslProg() const { return mGlslProg; }
+		//! Sets a custom shader to use when the type is rendered.
+		DrawOptions&	glslProg( const GlslProgRef &glslProg ) { mGlslProg = glslProg; return *this; }
 
 	  protected:
 		bool		mClipHorizontal, mClipVertical, mPixelSnap, mLigate;
 		float		mScale;
+		GlslProgRef	mGlslProg;
 	};
 
 	//! Creates a new TextureFontRef with font \a font, ensuring that glyphs necessary to render \a supportedChars are renderable, and format \a format

--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -420,7 +420,7 @@ void TextureFont::drawGlyphs( const vector<pair<uint16_t,vec2> > &glyphMeasures,
 			int colorLoc = shader->getAttribSemanticLocation( geom::Attrib::COLOR );
 			if( colorLoc >= 0 ) {
 				enableVertexAttribArray( colorLoc );
-				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_FALSE, 0, (void*)dataOffset );
+				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, (void*)dataOffset );
 				defaultArrayVbo->bufferSubData( dataOffset, vertColors.size() * sizeof(ColorA8u), vertColors.data() );
 				dataOffset += vertColors.size() * sizeof(ColorA8u);				
 			}
@@ -554,7 +554,7 @@ void TextureFont::drawGlyphs( const std::vector<std::pair<uint16_t,vec2> > &glyp
 			int colorLoc = shader->getAttribSemanticLocation( geom::Attrib::COLOR );
 			if( colorLoc >= 0 ) {
 				enableVertexAttribArray( colorLoc );
-				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_FALSE, 0, (void*)dataOffset );
+				vertexAttribPointer( colorLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, (void*)dataOffset );
 				defaultArrayVbo->bufferSubData( dataOffset, vertColors.size() * sizeof(ColorA8u), vertColors.data() );
 				dataOffset += vertColors.size() * sizeof(ColorA8u);				
 			}

--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -393,7 +393,7 @@ void TextureFont::drawGlyphs( const vector<pair<uint16_t,vec2> > &glyphMeasures,
 		curTex->bind();
 		auto ctx = gl::context();
 		size_t dataSize = (verts.size() + texCoords.size()) * sizeof(float) + vertColors.size() * sizeof(ColorA8u);
-		ctx->pushVao();
+		gl::ScopedVao vaoScp( ctx->getDefaultVao() );
 		ctx->getDefaultVao()->replacementBindBegin();
 		VboRef defaultElementVbo = ctx->getDefaultElementVbo( indices.size() * sizeof(curIdx) );
 		VboRef defaultArrayVbo = ctx->getDefaultArrayVbo( dataSize );
@@ -527,7 +527,7 @@ void TextureFont::drawGlyphs( const std::vector<std::pair<uint16_t,vec2> > &glyp
 		curTex->bind();
 		auto ctx = gl::context();
 		size_t dataSize = (verts.size() + texCoords.size()) * sizeof(float) + vertColors.size() * sizeof(ColorA8u);
-		ctx->pushVao();
+		gl::ScopedVao vaoScp( ctx->getDefaultVao() );
 		ctx->getDefaultVao()->replacementBindBegin();
 		VboRef defaultElementVbo = ctx->getDefaultElementVbo( indices.size() * sizeof(curIdx) );
 		VboRef defaultArrayVbo = ctx->getDefaultArrayVbo( dataSize );

--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -326,9 +326,12 @@ void TextureFont::drawGlyphs( const vector<pair<uint16_t,vec2> > &glyphMeasures,
 	if( ! colors.empty() )
 		assert( glyphMeasures.size() == colors.size() );
 
+	auto shader = options.getGlslProg();
+	if( ! shader ) {
+		auto shaderDef = ShaderDef().texture( mTextures[0] ).color();
+		shader = gl::getStockShader( shaderDef );
+	}
 	ScopedTextureBind texBindScp( mTextures[0] );
-	auto shaderDef = ShaderDef().texture( mTextures[0] ).color();
-	GlslProgRef shader = gl::getStockShader( shaderDef );
 	ScopedGlslProg glslScp( shader );
 
 	vec2 baseline = baselineIn;
@@ -441,9 +444,12 @@ void TextureFont::drawGlyphs( const std::vector<std::pair<uint16_t,vec2> > &glyp
 	if( ! colors.empty() )
 		assert( glyphMeasures.size() == colors.size() );
 
+	auto shader = options.getGlslProg();
+	if( ! shader ) {
+		auto shaderDef = ShaderDef().texture( mTextures[0] ).color();
+		shader = gl::getStockShader( shaderDef );
+	}
 	ScopedTextureBind texBindScp( mTextures[0] );
-	auto shaderDef = ShaderDef().texture( mTextures[0] ).color();
-	GlslProgRef shader = gl::getStockShader( shaderDef );
 	ScopedGlslProg glslScp( shader );
 
 	const float scale = options.getScale();


### PR DESCRIPTION
Pass as `TextureFont::DrawOptions().glslProg( shader )`

Sample result:
![screen shot 2014-12-23 at 5 40 26 pm](https://cloud.githubusercontent.com/assets/81553/5543991/77f92eb0-8acb-11e4-8380-26ec393e8b83.png)

Also includes the bugfixes from #644 