### PR TITLE
AssetLoadExc uses setDescription()

### DIFF
--- a/include/cinder/app/App.h
+++ b/include/cinder/app/App.h
@@ -713,10 +713,6 @@ class ResourceLoadExc : public Exception {
 class AssetLoadExc : public Exception {
   public:
 	AssetLoadExc( const fs::path &relativePath );
-
-	virtual const char * what() const throw() { return mMessage; }
-
-	char mMessage[4096];
 };
 
 } } // namespace cinder::app

--- a/src/cinder/app/App.cpp
+++ b/src/cinder/app/App.cpp
@@ -620,8 +620,8 @@ ResourceLoadExc::ResourceLoadExc( const string &macPath, int mswID, const string
 #endif // defined( CINDER_MSW )
 
 AssetLoadExc::AssetLoadExc( const fs::path &relativePath )
-	: Exception( relativePath.string() )
 {
+	setDescription( string( "Failed to load asset with relative path: " ) + relativePath.string() );
 }
 
 } } // namespace cinder::app


### PR DESCRIPTION
Instead of returning its own mMessage ivar (which was empty).

Fixes #648.