### PR TITLE
LoggerFile: Create the file only if/when needed.

### DIFF
--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -289,17 +289,19 @@ LoggerFile::LoggerFile( const fs::path &filePath )
 		mFilePath = DEFAULT_FILE_LOG_PATH;
 
 	setTimestampEnabled();
-	
-	mStream.open( mFilePath.string() );
 }
 
 LoggerFile::~LoggerFile()
 {
-	mStream.close();
+	if( mStream.is_open() )
+		mStream.close();
 }
 
 void LoggerFile::write( const Metadata &meta, const string &text )
 {
+	if( !mStream.is_open() )
+		mStream.open( mFilePath.string() );
+	
 	writeDefault( mStream, meta, text );
 }
 


### PR DESCRIPTION
Two lines modification to address the “issue” explained here:
https://forum.libcinder.org/topic/using-the-new-log-feature-in-glnext#23
286000002245021

Thanks to std::ofstream::is_open, it is easy to check whether the file has already been created or not (http://www.cplusplus.com/reference/fstream/ofstream/is_open/).