### PR TITLE
Fixed texture's getAreaTexCoords on less than full size area inputs.

### DIFF
--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -1173,7 +1173,8 @@ Rectf Texture2d::getAreaTexCoords( const Area &area ) const
 	}
 	
 	if( ! mTopDown ) {
-		std::swap( result.y1, result.y2 );
+		result.y1 = 1.0f - result.y1;
+		result.y2 = 1.0f - result.y2;
 	}
 	
 	return result;


### PR DESCRIPTION
Fixes issue #656.

std::swap would only work on (0.0, 1.0) y-texcoord inputs. Take (0.5, 1.0) for example. Swap would yield (1.0, 0.5) while the correct values are in fact (0.5, 0.0).