### PR TITLE
audio: SourcefileMediaFoundation clone fix

### DIFF
--- a/include/cinder/audio/Debug.h
+++ b/include/cinder/audio/Debug.h
@@ -27,24 +27,20 @@
 
 #include "cinder/Cinder.h"
 
+// these are placeholder log functions, replaced in 0.9.0 with those from cinder/Log.h
 #if( CINDER_VERSION < 807 )
 
 #include "cinder/CurrentFunction.h"
-
-#if ! defined( NDEBUG )
-
 #include "cinder/app/App.h"
 
-	#define CI_LOG_V( stream )			do{ ci::app::console() << CINDER_CURRENT_FUNCTION << " | " << stream << std::endl; } while( 0 )
-	#define CI_LOG_W( warningStream )	do{ CI_LOG_V( __LINE__ << " | WARNING | " << warningStream ); } while( 0 )
-	#define CI_LOG_E( errorStream )		do{ CI_LOG_V( __LINE__ << " | ERROR | " << errorStream ); } while( 0 )
-
+#if ! defined( NDEBUG )
+#define CI_LOG_V( stream )		do{ ci::app::console() << " |verbose| " << CINDER_CURRENT_FUNCTION << " | " << stream << std::endl; } while( 0 )
 #else
-
-	#define CI_LOG_V( stream )			do{} while( 0 )
-	#define CI_LOG_W( warningStream )	do{} while( 0 )
-	#define CI_LOG_E( errorStream )		do{} while( 0 )
-
+#define CI_LOG_V( stream )		do{} while( 0 )
 #endif // ! defined( NDEBUG )
+
+#define CI_LOG_I( stream )		do{ ci::app::console() << " |info   | " << CINDER_CURRENT_FUNCTION << " | " << stream << std::endl; } while( 0 )
+#define CI_LOG_W( stream )		do{ ci::app::console() << " |warning| " << CINDER_CURRENT_FUNCTION << " | " << stream << std::endl; } while( 0 )
+#define CI_LOG_E( stream )		do{ ci::app::console() << " |error  | " << CINDER_CURRENT_FUNCTION << " | " << stream << std::endl; } while( 0 )
 
 #endif // CINDER_VERSION < 807

--- a/src/cinder/audio/msw/FileMediaFoundation.cpp
+++ b/src/cinder/audio/msw/FileMediaFoundation.cpp
@@ -99,8 +99,7 @@ SourceFileMediaFoundation::SourceFileMediaFoundation( const DataSourceRef &dataS
 
 SourceFileRef SourceFileMediaFoundation::cloneWithSampleRate( size_t sampleRate ) const
 {
-	shared_ptr<SourceFileMediaFoundation> result( new SourceFileMediaFoundation );
-	result->mDataSource = mDataSource;
+	auto result = make_shared<SourceFileMediaFoundation>( mDataSource, sampleRate );
 	result->initReader();
 	result->setupSampleRateConversion();
 

--- a/test/_audio/VoiceTest/src/VoiceTestApp.cpp
+++ b/test/_audio/VoiceTest/src/VoiceTestApp.cpp
@@ -20,9 +20,10 @@ using namespace std;
 
 class VoiceTestApp : public AppNative {
 public:
-	void setup();
-	void resize();
-	void draw();
+	void setup() override;
+	void fileDrop( FileDropEvent event ) override;
+	void resize() override;
+	void draw() override;
 
 	void setupBasic();
 	void setupBasicStereo();
@@ -49,10 +50,19 @@ void VoiceTestApp::setup()
 	mVolumeSlider.set( DEFAULT_VOLUME );
 
 	setupBasic();
+	setupUI();
 
 	PRINT_GRAPH( audio::master() );
+	CI_LOG_I( "complete. context samplerate: " << audio::master()->getSampleRate() );
+}
 
-	setupUI();
+void VoiceTestApp::fileDrop( FileDropEvent event )
+{
+	const fs::path &filePath = event.getFile( 0 );
+	CI_LOG_I( "File dropped: " << filePath );
+
+	mVoice = audio::Voice::create( audio::load( loadFile( filePath ) ) );
+	mVoice->setVolume( mVolumeSlider.mValueScaled );
 }
 
 void VoiceTestApp::setupBasic()


### PR DESCRIPTION
Fixes issue [reported here](https://forum.libcinder.org/topic/cinder-audio-playing-files-of-different-formats-at-different-pitches#23286000002259009).

Also made the log placeholder macros more like those in 0.9.0.