### PR TITLE
Add JsonTree::ParseOptions::allowComments(), enabled by default

### DIFF
--- a/include/cinder/Json.h
+++ b/include/cinder/Json.h
@@ -60,12 +60,13 @@ class JsonTree {
 		ParseOptions& ignoreErrors( bool ignore = true );
 		//! Returns whether JSON parse errors are ignored.
 		bool	getIgnoreErrors() const;
-		
+		//! Sets if comments are allowed. Default \c true.
+		ParseOptions& allowComments( bool allow = true );
+		//! Returns whether comments are allowed or not.
+		bool	getAllowComments() const;
+
 	  private:
-		//! \cond
-		bool	mIgnoreErrors;
-		//! \endcond
-		
+		bool	mIgnoreErrors, mAllowComments;
 	};
 	
 	//! Options for JSON writing. Passed to the \c write method.

--- a/include/cinder/Json.h
+++ b/include/cinder/Json.h
@@ -56,7 +56,7 @@ class JsonTree {
 	  public:
 		//! Default options. Enables parsing errors.
 		ParseOptions();
-		//! Sets if JSON parse errors are ignored. Default \c true.
+		//! Sets if JSON parse errors are ignored. Default \c false.
 		ParseOptions& ignoreErrors( bool ignore = true );
 		//! Returns whether JSON parse errors are ignored.
 		bool	getIgnoreErrors() const;

--- a/src/cinder/Json.cpp
+++ b/src/cinder/Json.cpp
@@ -66,7 +66,7 @@ bool JsonTree::ParseOptions::getAllowComments() const
 }
 
 JsonTree::WriteOptions::WriteOptions()
-: mCreateDocument( false ), mIndented( true )
+	: mCreateDocument( false ), mIndented( true )
 {
 }
 
@@ -278,8 +278,8 @@ void JsonTree::init( const string &key, const Json::Value &value, bool setType, 
 Json::Value JsonTree::deserializeNative( const string &jsonString, ParseOptions parseOptions )
 {
 	Json::Features features;
-	features.strictRoot_ = !parseOptions.getIgnoreErrors();
 	features.allowComments_ = parseOptions.getAllowComments();
+	features.strictRoot_ = ! parseOptions.getIgnoreErrors();
 	Json::Reader reader( features );
 	Json::Value value;
     try {
@@ -288,7 +288,7 @@ Json::Value JsonTree::deserializeNative( const string &jsonString, ParseOptions 
 	catch ( ... ) {
 		throw ExcJsonParserError( "Unknown error." );
     }
-	if( !parseOptions.getIgnoreErrors() ) {
+	if( ! parseOptions.getIgnoreErrors() ) {
 		string errorMessage = reader.getFormattedErrorMessages();
 		if( errorMessage.length() > 0 ) {
 			throw ExcJsonParserError( errorMessage );

--- a/src/cinder/Json.cpp
+++ b/src/cinder/Json.cpp
@@ -39,7 +39,7 @@ using namespace std;
 namespace cinder {
 	
 JsonTree::ParseOptions::ParseOptions() 
-: mIgnoreErrors( false ) 
+	: mIgnoreErrors( false ), mAllowComments( true )
 {
 }
 	
@@ -52,6 +52,17 @@ JsonTree::ParseOptions& JsonTree::ParseOptions::ignoreErrors( bool ignore )
 bool JsonTree::ParseOptions::getIgnoreErrors() const 
 { 
 	return mIgnoreErrors; 
+}
+
+JsonTree::ParseOptions& JsonTree::ParseOptions::allowComments( bool allow )
+{
+	mAllowComments = allow;
+	return *this;
+}
+
+bool JsonTree::ParseOptions::getAllowComments() const
+{
+	return mAllowComments;
 }
 
 JsonTree::WriteOptions::WriteOptions()
@@ -267,8 +278,8 @@ void JsonTree::init( const string &key, const Json::Value &value, bool setType, 
 Json::Value JsonTree::deserializeNative( const string &jsonString, ParseOptions parseOptions )
 {
 	Json::Features features;
-	features.allowComments_ = false;
 	features.strictRoot_ = !parseOptions.getIgnoreErrors();
+	features.allowComments_ = parseOptions.getAllowComments();
 	Json::Reader reader( features );
 	Json::Value value;
     try {


### PR DESCRIPTION
Fixes #667.

Also fixed a doc and a couple minor whitespace improvements.

Comments test in test/JsonTest is now passing.