### PR TITLE
mallocScoped() utility

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -93,6 +93,13 @@ inline double fromString( const std::string &s ) { return atof( s.c_str() ); }
 //! Returns a stack trace (aka backtrace) where \c stackTrace()[0] == caller, \c stackTrace()[1] == caller's parent, etc
 std::vector<std::string> stackTrace();
 
+//! Mallocs `count * sizeof( T )` bytes and returns it in a std::unique_ptr so that `free` will be called when it goes out of scope.
+template <typename T>
+std::unique_ptr<T, decltype( &free )> mallocScoped( size_t count )
+{
+	return unique_ptr<T, decltype( &free )>( (T*)malloc( count * sizeof( T ) ), free );
+}
+
 // ENDIANNESS
 inline int8_t	swapEndian( int8_t val ) { return val; }
 inline uint8_t	swapEndian( uint8_t val ) { return val; }


### PR DESCRIPTION
I stumbled upon [this article](http://www.codeproject.com/Articles/820931/Using-std-unique-ptr-RAII-with-malloc-and-free) not too long ago, which shows a nice way to make a scoped malloc. It is a bit long winded but an improvement over using a shared_ptr() in times where you just want to make a local chunk of data and ensure that it gets freed at the end of scope.

So, today I made this utlity function to simplify matters. Here is an example where I'm using it in Cinder-Dart ([this commit](https://github.com/richardeakin/Cinder-Dart/commit/49cd87d5b0ddc62d848f4f8a619cb8fb0a11e787):

This:
```c++
const char **vmCFlags = (const char **)malloc( mVMFlags.size() * sizeof( const char * ) );
for( size_t i = 0; i < mVMFlags.size(); i++ )
  vmCFlags[i] = mVMFlags[i].c_str();

Dart_SetVMFlags( mVMFlags.size(), vmCFlags );
free( vmCFlags );
```

turns into:
```c++
auto vmCFlags = mallocScoped<const char *>( mVMFlags.size() );

for( size_t i = 0; i < mVMFlags.size(); i++ )
   vmCFlags.get()[i] = mVMFlags[i].c_str();

Dart_SetVMFlags( mVMFlags.size(), vmCFlags.get() );
```

Making the unique_ptr without the addition of `mallocScoped` util would look like:
```c++
auto vmCFlags = unique_ptr<const char *, decltype( &free )>( (const char **)malloc( vmFlagsBytes ), free );
```

Which is a bit hard to remember, IMO.

There are several places in cinder's codebase where I think we can make use of this util to improve the code a bit.
