### PR TITLE
Fix for memory leak when quitting.

### DIFF
--- a/include/cinder/app/AppImplMswBasic.h
+++ b/include/cinder/app/AppImplMswBasic.h
@@ -43,7 +43,7 @@ class AppImplMswBasic : public AppImplMsw {
 
 	class AppBasic*		getApp() { return mApp; }
 	
-	void	quit() { mShouldQuit = true; }
+	void	quit();
 
 	float	setFrameRate( float aFrameRate );
 	void	disableFrameRate();

--- a/src/cinder/app/AppImplMswBasic.cpp
+++ b/src/cinder/app/AppImplMswBasic.cpp
@@ -211,6 +211,16 @@ void AppImplMswBasic::destroyBlankingWindows()
 	mBlankingWindows.clear();
 }
 
+void AppImplMswBasic::quit()
+{
+	// Close all windows, forcing the application to quit.
+	while( !mWindows.empty() )
+		mWindows.back()->close();
+
+	// Always quit, even if !isQuitOnLastWindowCloseEnabled()
+	mShouldQuit = true;
+}
+
 float AppImplMswBasic::setFrameRate( float aFrameRate )
 {
 	mFrameRate = aFrameRate;


### PR DESCRIPTION
When calling ```quit()```, the application's windows were not properly closed and destroyed, causing memory leak detectors to go nuts on application exit. To fix this, the ```quit()``` method now simply closes all open windows, forcing the application to quit as soon as the last window is closed.

I've implemented and tested this code only on Windows.