### PR TITLE
Missing implementation of Color / "std::ostream& operator<<"

### DIFF
--- a/src/cinder/Color.cpp
+++ b/src/cinder/Color.cpp
@@ -200,10 +200,22 @@ void ColorAT<T>::set( ColorModel cm, const vec4 &v )
 			throw ImageIoExceptionIllegalColorModel();
 	}
 }
-
+	
+std::ostream& operator<<( std::ostream &lhs, const ColorT<float> &rhs )
+{
+	lhs << "[" << rhs.r << "," << rhs.g << "," << rhs.b << "]";
+	return lhs;
+}
+	
 std::ostream& operator<<( std::ostream &lhs, const ColorAT<float> &rhs ) 
 {
 	lhs << "[" << rhs.r << "," << rhs.g << "," << rhs.b << "," << rhs.a << "]";
+	return lhs;
+}
+
+std::ostream& operator<<( std::ostream &lhs, const ColorT<uint8_t> &rhs )
+{
+	lhs << "[" << static_cast<int>( rhs.r ) << "," << static_cast<int>( rhs.g ) << "," << static_cast<int>( rhs.b ) << "]";
 	return lhs;
 }
 


### PR DESCRIPTION
Apparently this one has been left out when updating the Color class. There's the function signature for the 4 color types, but only the implementation for ColorA<uint8_t> and ColorA<float>.

This PR fixes this.