### PR TITLE
PolyLine area and centroid

### DIFF
--- a/include/cinder/PolyLine.h
+++ b/include/cinder/PolyLine.h
@@ -60,6 +60,8 @@ class PolyLine {
 	//! Returns whether the point \a pt is contained within the boundaries of the PolyLine
 	bool	contains( const Vec2f &pt ) const;
 
+	double	area() const;
+
 	//! Calculates the boolean union of \a a and \a b. Assumes the first PolyLine in the vector is the outermost and the (optional) others are holes.
 	static std::vector<PolyLine> 	calcUnion( const std::vector<PolyLine> &a, std::vector<PolyLine> &b );
 	//! Calculates the boolean intersection of \a a and \a b. Assumes the first PolyLine in the vector is the outermost and the (optional) others are holes.

--- a/include/cinder/PolyLine.h
+++ b/include/cinder/PolyLine.h
@@ -61,6 +61,7 @@ class PolyLine {
 	bool	contains( const Vec2f &pt ) const;
 
 	double	area() const;
+	T		centroid() const;
 
 	//! Calculates the boolean union of \a a and \a b. Assumes the first PolyLine in the vector is the outermost and the (optional) others are holes.
 	static std::vector<PolyLine> 	calcUnion( const std::vector<PolyLine> &a, std::vector<PolyLine> &b );

--- a/src/cinder/PolyLine.cpp
+++ b/src/cinder/PolyLine.cpp
@@ -173,6 +173,14 @@ double PolyLine<T>::area() const
 }
 
 template<typename T>
+T PolyLine<T>::centroid() const
+{
+	point p = boost::geometry::return_centroid<point>( convertPolyLineToBoostGeometry ( *this ) );
+	return T( p.x(), p.y() );
+}
+
+
+template<typename T>
 std::vector<PolyLine<T> > PolyLine<T>::calcUnion( const std::vector<PolyLine<T> > &a, std::vector<PolyLine<T> > &b )
 {
 	if( a.empty() )

--- a/src/cinder/PolyLine.cpp
+++ b/src/cinder/PolyLine.cpp
@@ -157,8 +157,6 @@ polygon convertPolyLinesToBoostGeometry( const std::vector<PolyLine<T> > &a )
 template<typename T>
 std::vector<PolyLine<T> > PolyLine<T>::calcUnion( const std::vector<PolyLine<T> > &a, std::vector<PolyLine<T> > &b )
 {
-	typedef boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double> > polygon;
-
 	if( a.empty() )
 		return b;
 	else if( b.empty() )
@@ -176,8 +174,6 @@ std::vector<PolyLine<T> > PolyLine<T>::calcUnion( const std::vector<PolyLine<T> 
 template<typename T>
 std::vector<PolyLine<T> > PolyLine<T>::calcIntersection( const std::vector<PolyLine<T> > &a, std::vector<PolyLine<T> > &b )
 {
-	typedef boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double> > polygon;
-
 	if( a.empty() )
 		return b;
 	else if( b.empty() )
@@ -195,8 +191,6 @@ std::vector<PolyLine<T> > PolyLine<T>::calcIntersection( const std::vector<PolyL
 template<typename T>
 std::vector<PolyLine<T> > PolyLine<T>::calcXor( const std::vector<PolyLine<T> > &a, std::vector<PolyLine<T> > &b )
 {
-	typedef boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double> > polygon;
-
 	if( a.empty() )
 		return b;
 	else if( b.empty() )

--- a/src/cinder/PolyLine.cpp
+++ b/src/cinder/PolyLine.cpp
@@ -107,7 +107,6 @@ bool PolyLine<T>::contains( const Vec2f &pt ) const
 	return (crossings & 1) == 1;
 }
 
-
 namespace {
 typedef boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double> > polygon;
 
@@ -152,7 +151,25 @@ polygon convertPolyLinesToBoostGeometry( const std::vector<PolyLine<T> > &a )
 	
 	return result;
 }
+
+template<typename T>
+polygon convertPolyLineToBoostGeometry( const PolyLine<T> &p )
+{
+	polygon result;
+
+	for( typename std::vector<T>::const_iterator ptIt = p.getPoints().begin(); ptIt != p.getPoints().end(); ++ptIt )
+		result.outer().push_back( boost::geometry::make<boost::geometry::model::d2::point_xy<double> >( ptIt->x, ptIt->y ) );
+
+	return result;
+}
+
 } // anonymous namespace
+
+template<typename T>
+double PolyLine<T>::area() const
+{
+	return boost::geometry::area( convertPolyLineToBoostGeometry ( *this ) );
+}
 
 template<typename T>
 std::vector<PolyLine<T> > PolyLine<T>::calcUnion( const std::vector<PolyLine<T> > &a, std::vector<PolyLine<T> > &b )

--- a/src/cinder/PolyLine.cpp
+++ b/src/cinder/PolyLine.cpp
@@ -108,7 +108,8 @@ bool PolyLine<T>::contains( const Vec2f &pt ) const
 }
 
 namespace {
-typedef boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double> > polygon;
+typedef boost::geometry::model::d2::point_xy<double> point;
+typedef boost::geometry::model::polygon<point> polygon;
 
 template<typename T>
 std::vector<PolyLine<T> > convertBoostGeometryPolygons( std::vector<polygon> &polygons )
@@ -139,11 +140,11 @@ polygon convertPolyLinesToBoostGeometry( const std::vector<PolyLine<T> > &a )
 	polygon result;
 	
 	for( typename std::vector<T>::const_iterator ptIt = a[0].getPoints().begin(); ptIt != a[0].getPoints().end(); ++ptIt )
-		result.outer().push_back( boost::geometry::make<boost::geometry::model::d2::point_xy<double> >( ptIt->x, ptIt->y ) );
+		result.outer().push_back( boost::geometry::make<point>( ptIt->x, ptIt->y ) );
 	for( typename std::vector<PolyLine<T> >::const_iterator plIt = a.begin() + 1; plIt != a.end(); ++plIt ) {
 		polygon::ring_type ring;
 		for( typename std::vector<T>::const_iterator ptIt = plIt->getPoints().begin(); ptIt != plIt->getPoints().end(); ++ptIt )
-			ring.push_back( boost::geometry::make<boost::geometry::model::d2::point_xy<double> >( ptIt->x, ptIt->y ) );
+			ring.push_back( boost::geometry::make<point>( ptIt->x, ptIt->y ) );
 		result.inners().push_back( ring );
 	}
 	
@@ -158,7 +159,7 @@ polygon convertPolyLineToBoostGeometry( const PolyLine<T> &p )
 	polygon result;
 
 	for( typename std::vector<T>::const_iterator ptIt = p.getPoints().begin(); ptIt != p.getPoints().end(); ++ptIt )
-		result.outer().push_back( boost::geometry::make<boost::geometry::model::d2::point_xy<double> >( ptIt->x, ptIt->y ) );
+		result.outer().push_back( boost::geometry::make<point>( ptIt->x, ptIt->y ) );
 
 	return result;
 }


### PR DESCRIPTION
This exposes boost::geometry's [area](http://www.boost.org/doc/libs/1_57_0/libs/geometry/doc/html/geometry/reference/algorithms/area/area_1.html) and [centroid](http://www.boost.org/doc/libs/1_57_0/libs/geometry/doc/html/geometry/reference/algorithms/centroid/return_centroid_1.html) algorithms

This fixes #679.