### PR TITLE
Fixes missing titlebar buttons when exiting borderless mode

### DIFF
--- a/src/cinder/app/AppImplCocoaBasic.mm
+++ b/src/cinder/app/AppImplCocoaBasic.mm
@@ -476,6 +476,7 @@
 
 - (void)setBorderless:(BOOL)borderless
 {
+	bool isReturningFromBorderless = mBorderless && !borderless;
 	mBorderless = borderless;
 
 	unsigned int styleMask;
@@ -490,6 +491,14 @@
 	[mWin makeKeyWindow];
 	[mWin makeMainWindow];
 	[mWin setHasShadow:(! mBorderless)];
+	
+	if ( isReturningFromBorderless )
+	{
+		// Trigger the title bar buttons to re-appear
+		ci::ivec2 currentSize = [self getSize];
+		[self setSize:currentSize + ci::ivec2(0, 1)];
+		[self setSize:currentSize];
+	}
 }
 
 - (bool)isAlwaysOnTop


### PR DESCRIPTION
Addresses issue reported at https://github.com/cinder/Cinder/issues/694 (excluding window title problem)