### PR TITLE
Improve fullbuild.sh script

### DIFF
--- a/xcode/fullbuild.sh
+++ b/xcode/fullbuild.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-xcrun xcodebuild -project cinder.xcodeproj -target cinder -configuration Release $@
-xcrun xcodebuild -project cinder.xcodeproj -target cinder_iphone -configuration Release $@
-xcrun xcodebuild -project cinder.xcodeproj -target cinder_iphone_sim -configuration Release -sdk iphonesimulator $@
-xcrun xcodebuild -project cinder.xcodeproj -target cinder -configuration Debug $@
-xcrun xcodebuild -project cinder.xcodeproj -target cinder_iphone -configuration Debug $@
-xcrun xcodebuild -project cinder.xcodeproj -target cinder_iphone_sim -configuration Debug -sdk iphonesimulator $@
+CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+CINDER_XCODEPROJ="${CURRENT_DIR}/cinder.xcodeproj"
+
+xcrun xcodebuild -project ${CINDER_XCODEPROJ} -alltargets -configuration Release $@
+xcrun xcodebuild -project ${CINDER_XCODEPROJ} -alltargets -configuration Debug $@


### PR DESCRIPTION
Getting the full path of the cinder.xcodeproj so that it can be run from other directories, ex.

```bash
./xcode/fullbuild.sh
```
Also reducing the number of xcodebuild commands by using `-alltargets`.