### PR TITLE
Pass in string shaders to GlslProg as std::string

### DIFF
--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -55,24 +55,24 @@ class GlslProg : public std::enable_shared_from_this<GlslProg> {
 		//! Supplies the GLSL source for the vertex shader
 		Format&		vertex( const DataSourceRef &dataSource );
 		//! Supplies the GLSL source for the vertex shader
-		Format&		vertex( const char *vertexShader );
+		Format&		vertex( const std::string &vertexShader );
 		//! Supplies the GLSL source for the fragment shader
 		Format&		fragment( const DataSourceRef &dataSource );
 		//! Supplies the GLSL source for the fragment shader
-		Format&		fragment( const char *vertexShader );
+		Format&		fragment( const std::string &vertexShader );
 #if ! defined( CINDER_GL_ES )
 		//! Supplies the GLSL source for the geometry shader
 		Format&		geometry( const DataSourceRef &dataSource );
 		//! Supplies the GLSL source for the geometry shader
-		Format&		geometry( const char *geometryShader );
+		Format&		geometry( const std::string &geometryShader );
 		//! Supplies the GLSL source for the tessellation control shader
 		Format&		tessellationCtrl( const DataSourceRef &dataSource );
 		//! Supplies the GLSL source for the tessellation control shader
-		Format&		tessellationCtrl( const char *tessellationCtrlShader );
+		Format&		tessellationCtrl( const std::string &tessellationCtrlShader );
 		//! Supplies the GLSL source for the tessellation control shader
 		Format&		tessellationEval( const DataSourceRef &dataSource );
 		//! Supplies the GLSL source for the tessellation control shader
-		Format&		tessellationEval( const char *tessellationEvalShader );
+		Format&		tessellationEval( const std::string &tessellationEvalShader );
 #endif
 #if ! defined( CINDER_GL_ES_2 )		
 		//! Sets the TransformFeedback varyings
@@ -164,14 +164,14 @@ class GlslProg : public std::enable_shared_from_this<GlslProg> {
 								   DataSourceRef geometryShader = DataSourceRef(),
 								   DataSourceRef tessEvalShader = DataSourceRef(),
 								   DataSourceRef tessCtrlShader = DataSourceRef() );
-	static GlslProgRef create( const char *vertexShader,
-								   const char *fragmentShader = 0,
-								   const char *geometryShader = 0,
-								   const char *tessEvalShader = 0,
-								   const char *tessCtrlShader = 0 );
+	static GlslProgRef create( const std::string &vertexShader,
+								   const std::string &fragmentShader = std::string(),
+								   const std::string &geometryShader = std::string(),
+								   const std::string &tessEvalShader = std::string(),
+								   const std::string &tessCtrlShader = std::string() );
 #else
 	static GlslProgRef create( DataSourceRef vertexShader, DataSourceRef fragmentShader = DataSourceRef() );
-	static GlslProgRef create( const char *vertexShader, const char *fragmentShader = 0 );
+	static GlslProgRef create( const std::string &vertexShader, const std::string &fragmentShader = std::string() );
 #endif
 	~GlslProg();
 	

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -59,10 +59,10 @@ GlslProg::Format& GlslProg::Format::vertex( const DataSourceRef &dataSource )
 	return *this;
 }
 
-GlslProg::Format& GlslProg::Format::vertex( const char *vertexShader )
+GlslProg::Format& GlslProg::Format::vertex( const string &vertexShader )
 {
-	if( vertexShader )
-		mVertexShader = string( vertexShader );
+	if( ! vertexShader.empty() )
+		mVertexShader = vertexShader;
 	else
 		mVertexShader.clear();
 
@@ -83,10 +83,10 @@ GlslProg::Format& GlslProg::Format::fragment( const DataSourceRef &dataSource )
 	return *this;
 }
 
-GlslProg::Format& GlslProg::Format::fragment( const char *fragmentShader )
+GlslProg::Format& GlslProg::Format::fragment( const string &fragmentShader )
 {
-	if( fragmentShader )
-		mFragmentShader = string( fragmentShader );
+	if( ! fragmentShader.empty() )
+		mFragmentShader = fragmentShader;
 	else
 		mFragmentShader.clear();
 
@@ -108,10 +108,10 @@ GlslProg::Format& GlslProg::Format::geometry( const DataSourceRef &dataSource )
 	return *this;
 }
 
-GlslProg::Format& GlslProg::Format::geometry( const char *geometryShader )
+GlslProg::Format& GlslProg::Format::geometry( const string &geometryShader )
 {
-	if( geometryShader ) {
-		mGeometryShader = string( geometryShader );	}
+	if( ! geometryShader.empty() )
+		mGeometryShader = geometryShader;
 	else
 		mGeometryShader.clear();
 
@@ -132,10 +132,10 @@ GlslProg::Format& GlslProg::Format::tessellationCtrl( const DataSourceRef &dataS
 	return *this;
 }
 
-GlslProg::Format& GlslProg::Format::tessellationCtrl( const char *tessellationCtrlShader )
+GlslProg::Format& GlslProg::Format::tessellationCtrl( const string &tessellationCtrlShader )
 {
-	if( tessellationCtrlShader ) {
-		mTessellationCtrlShader = string( tessellationCtrlShader );	}
+	if( ! tessellationCtrlShader.empty() )
+		mTessellationCtrlShader = tessellationCtrlShader;
 	else
 		mTessellationCtrlShader.clear();
 	
@@ -156,10 +156,10 @@ GlslProg::Format& GlslProg::Format::tessellationEval( const DataSourceRef &dataS
 	return *this;
 }
 
-GlslProg::Format& GlslProg::Format::tessellationEval( const char *tessellationEvalShader )
+GlslProg::Format& GlslProg::Format::tessellationEval( const string &tessellationEvalShader )
 {
-	if( tessellationEvalShader ) {
-		mTessellationEvalShader = string( tessellationEvalShader );	}
+	if( ! tessellationEvalShader.empty() )
+		mTessellationEvalShader = tessellationEvalShader;
 	else
 		mTessellationEvalShader.clear();
 	
@@ -213,7 +213,7 @@ GlslProgRef GlslProg::create( DataSourceRef vertexShader, DataSourceRef fragment
 	return GlslProgRef( new GlslProg( GlslProg::Format().vertex( vertexShader ).fragment( fragmentShader ).geometry( geometryShader ).tessellationEval( tessEvalShader ).tessellationCtrl( tessCtrlShader ) ) );
 }
 
-GlslProgRef GlslProg::create( const char *vertexShader, const char *fragmentShader, const char *geometryShader, const char *tessEvalShader, const char *tessCtrlShader )
+GlslProgRef GlslProg::create( const string &vertexShader, const string &fragmentShader, const string &geometryShader, const string &tessEvalShader, const string &tessCtrlShader )
 {
 	return GlslProgRef( new GlslProg( GlslProg::Format().vertex( vertexShader ).fragment( fragmentShader ).geometry( geometryShader ).tessellationEval( tessEvalShader ).tessellationCtrl( tessCtrlShader ) ) );
 }
@@ -224,7 +224,7 @@ GlslProgRef GlslProg::create( DataSourceRef vertexShader, DataSourceRef fragment
 	return GlslProgRef( new GlslProg( GlslProg::Format().vertex( vertexShader ).fragment( fragmentShader ) ) );
 }
 
-GlslProgRef GlslProg::create( const char *vertexShader, const char *fragmentShader )
+GlslProgRef GlslProg::create( const string &vertexShader, const string &fragmentShader )
 {
 	return GlslProgRef( new GlslProg( GlslProg::Format().vertex( vertexShader ).fragment( fragmentShader ) ) );
 }


### PR DESCRIPTION
Saves a couple keystrokes for users who store shaders as `std::string`, since they don't need the extra `c_str()` this way.