### PR TITLE
Added getters for Frustum Planes

### DIFF
--- a/include/cinder/Frustum.h
+++ b/include/cinder/Frustum.h
@@ -77,8 +77,6 @@ class Frustum {
 	//! Returns true if the box is partially contained within frustum. See also 'contains'.
 	bool intersects( const AxisAlignedBox3f &box ) const;
 
-	//! Returns a reference to the Plane associated with /a section of the Frustum.
-	Plane<T>& getPlane( FrustumSection section ) { return mFrustumPlanes[section]; }
 	//! Returns a const reference to the Plane associated with /a section of the Frustum.
 	const Plane<T>& getPlane( FrustumSection section ) const { return mFrustumPlanes[section]; }
 	

--- a/include/cinder/Frustum.h
+++ b/include/cinder/Frustum.h
@@ -42,7 +42,7 @@ namespace cinder {
 template<typename T>
 class Frustum {
   public:
-	enum { NEAR, FAR, LEFT, RIGHT, TOP, BOTTOM };
+	enum FrustumSection { NEAR, FAR, LEFT, RIGHT, TOP, BOTTOM };
 
 	typedef glm::detail::tvec3<T, glm::defaultp> Vec3T;
 
@@ -77,6 +77,11 @@ class Frustum {
 	//! Returns true if the box is partially contained within frustum. See also 'contains'.
 	bool intersects( const AxisAlignedBox3f &box ) const;
 
+	//! Returns a reference to the Plane associated with /a section of the Frustum.
+	Plane<T>& getPlane( FrustumSection section ) { return mFrustumPlanes[section]; }
+	//! Returns a const reference to the Plane associated with /a section of the Frustum.
+	const Plane<T>& getPlane( FrustumSection section ) const { return mFrustumPlanes[section]; }
+	
   protected:
 	Plane<T>	mFrustumPlanes[6];
 };


### PR DESCRIPTION
A small change for the purpose of extracting Frustum Planes.
- This enables easy access of the Planes contained in Frustum specifically for use with aspects of gl including but not necessarily limited to [gl_ClipDistance](https://www.opengl.org/sdk/docs/man/html/gl_ClipDistance.xhtml) functionality. 