### PR TITLE
Distinguish between asset directories and paths

### DIFF
--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -539,6 +539,8 @@ inline DataSourceRef		loadAsset( const fs::path &relativePath )		{ return Platfo
 inline fs::path				getAssetPath( const fs::path &relativePath )	{ return Platform::get()->getAssetPath( relativePath ); }
 //! Adds an absolute path \a dirPath to the active App's list of directories which are searched for assets.
 inline void					addAssetDirectory( const fs::path &dirPath )	{ return Platform::get()->addAssetDirectory( dirPath ); }
+//! Returns a vector of directories that are searched when looking up an asset path.
+inline const std::vector<fs::path>&	getAssetDirectories()					{ return Platform::get()->getAssetDirectories(); }
 
 //! Returns the path to the active App on disk
 inline fs::path		getAppPath() { return AppBase::get()->getAppPath(); }

--- a/include/cinder/app/Platform.h
+++ b/include/cinder/app/Platform.h
@@ -69,9 +69,8 @@ class Platform {
 #endif // defined( CINDER_MSW )
 
 	//! Returns the absolute file path to the resources folder. Returns an empty fs::path on windows. \sa CinderResources
-	virtual fs::path	getResourcePath() const = 0;
+	virtual fs::path	getResourceDirectory() const = 0;
 	//! Returns the absolute file path to a resource located at \a rsrcRelativePath inside the bundle's resources folder. Throws ResourceLoadExc on failure. \sa CinderResources
-	//! TODO: this seems unnecessary to be abstract virtual - instead can implement as getResourcePath() / relPath.
 	virtual fs::path	getResourcePath( const fs::path &rsrcRelativePath ) const = 0;
 
 	void				setExecutablePath( const fs::path &execPath )	{ mExecutablePath = execPath; }

--- a/include/cinder/app/Platform.h
+++ b/include/cinder/app/Platform.h
@@ -56,6 +56,8 @@ class Platform {
 	fs::path				getAssetPath( const fs::path &relativePath );
 	//! Adds an absolute path 'dirPath' to the list of directories which are searched for assets.
 	void					addAssetDirectory( const fs::path &directory );
+	//! Returns a vector of directories that are searched when looking up an asset path.
+	const std::vector<fs::path>& getAssetDirectories();
 
 	// Resources
 #if defined( CINDER_MSW )
@@ -118,6 +120,7 @@ class Platform {
   private:
 	void		findAndAddAssetBasePath();
 	fs::path	findAssetPath( const fs::path &relativePath );
+	void		ensureAssetDirsPrepared();
 
 	std::vector<fs::path>		mAssetDirectories;
 	bool						mAssetDirsInitialized;

--- a/include/cinder/app/Platform.h
+++ b/include/cinder/app/Platform.h
@@ -114,7 +114,8 @@ class Platform {
   protected:
 	Platform() : mAssetDirsInitialized( false )	{}
 
-	virtual void prepareAssetLoading() = 0;
+	//! Called when asset directories are first prepared, subclasses can override to add platform specific directories.
+	virtual void prepareAssetLoading()		{}
 
   private:
 	void		findAndAddAssetBasePath();

--- a/include/cinder/app/Platform.h
+++ b/include/cinder/app/Platform.h
@@ -55,7 +55,7 @@ class Platform {
 	//! Returns a fs::path to an application asset. Returns an empty path on failure.
 	fs::path				getAssetPath( const fs::path &relativePath );
 	//! Adds an absolute path 'dirPath' to the list of directories which are searched for assets.
-	void					addAssetDirectory( const fs::path &dirPath );
+	void					addAssetDirectory( const fs::path &directory );
 
 	// Resources
 #if defined( CINDER_MSW )
@@ -111,7 +111,7 @@ class Platform {
 	virtual const std::vector<DisplayRef>&	getDisplays() = 0;
 
   protected:
-	Platform() : mAssetPathsInitialized( false )	{}
+	Platform() : mAssetDirsInitialized( false )	{}
 
 	virtual void prepareAssetLoading() = 0;
 
@@ -119,8 +119,8 @@ class Platform {
 	void		findAndAddAssetBasePath();
 	fs::path	findAssetPath( const fs::path &relativePath );
 
-	std::vector<fs::path>		mAssetPaths;
-	bool						mAssetPathsInitialized;
+	std::vector<fs::path>		mAssetDirectories;
+	bool						mAssetDirsInitialized;
 	fs::path					mExecutablePath;
 };
 

--- a/include/cinder/app/Platform.h
+++ b/include/cinder/app/Platform.h
@@ -57,7 +57,7 @@ class Platform {
 	//! Adds an absolute path 'dirPath' to the list of directories which are searched for assets.
 	void					addAssetDirectory( const fs::path &directory );
 	//! Returns a vector of directories that are searched when looking up an asset path.
-	const std::vector<fs::path>& getAssetDirectories();
+	const std::vector<fs::path>&	getAssetDirectories();
 
 	// Resources
 #if defined( CINDER_MSW )

--- a/include/cinder/app/cocoa/PlatformCocoa.h
+++ b/include/cinder/app/cocoa/PlatformCocoa.h
@@ -66,7 +66,7 @@ class PlatformCocoa : public Platform {
 
 	DataSourceRef	loadResource( const fs::path &resourcePath ) override;
 
-	fs::path getResourcePath() const override;
+	fs::path getResourceDirectory() const override;
 	fs::path getResourcePath( const fs::path &rsrcRelativePath ) const override;
 
 	//! Implemented on desktop, no-op on iOS (returns empty path ).

--- a/include/cinder/app/msw/PlatformMsw.h
+++ b/include/cinder/app/msw/PlatformMsw.h
@@ -43,7 +43,7 @@ class PlatformMsw : public Platform {
 	fs::path getFolderPath( const fs::path &initialPath ) override;
 	fs::path getSaveFilePath( const fs::path &initialPath, const std::vector<std::string> &extensions ) override;
 
-	// currently nothing to do here, Platform::findAndAddAssetBasePath() will search for an assets folder 5 levels deep from executable
+	// currently nothing to do here, Platform::findAndAddAssetBasePath() will search for an assets folder 10 levels deep from executable
 	void prepareAssetLoading() override {}
 
 	fs::path	expandPath( const fs::path &path ) override;

--- a/include/cinder/app/msw/PlatformMsw.h
+++ b/include/cinder/app/msw/PlatformMsw.h
@@ -43,9 +43,6 @@ class PlatformMsw : public Platform {
 	fs::path getFolderPath( const fs::path &initialPath ) override;
 	fs::path getSaveFilePath( const fs::path &initialPath, const std::vector<std::string> &extensions ) override;
 
-	// currently nothing to do here, Platform::findAndAddAssetBasePath() will search for an assets folder 10 levels deep from executable
-	void prepareAssetLoading() override {}
-
 	fs::path	expandPath( const fs::path &path ) override;
 	fs::path	getHomeDirectory() override;
 	fs::path	getDocumentsDirectory()	override;

--- a/include/cinder/app/msw/PlatformMsw.h
+++ b/include/cinder/app/msw/PlatformMsw.h
@@ -36,7 +36,7 @@ class PlatformMsw : public Platform {
 
 	DataSourceRef	loadResource( const fs::path &resourcePath, int mswID, const std::string &mswType ) override;
 
-	fs::path getResourcePath() const override										{ return fs::path(); }
+	fs::path getResourceDirectory() const override									{ return fs::path(); }
 	fs::path getResourcePath( const fs::path &rsrcRelativePath ) const override		{ return fs::path(); }
 
 	fs::path getOpenFilePath( const fs::path &initialPath, const std::vector<std::string> &extensions ) override;

--- a/include/cinder/app/winrt/PlatformWinRt.h
+++ b/include/cinder/app/winrt/PlatformWinRt.h
@@ -40,7 +40,7 @@ class PlatformWinRt : public Platform {
 	fs::path getFolderPath( const fs::path &initialPath ) override;
 	fs::path getSaveFilePath( const fs::path &initialPath, const std::vector<std::string> &extensions ) override;
 
-	// currently nothing to do here, Platform::findAndAddAssetBasePath() will search for an assets folder 5 levels deep from executable
+	// currently nothing to do here, Platform::findAndAddAssetBasePath() will search for an assets folder 10 levels deep from executable
 	void prepareAssetLoading() override {}
 
 	// Overridden to use OutputDebugString

--- a/include/cinder/app/winrt/PlatformWinRt.h
+++ b/include/cinder/app/winrt/PlatformWinRt.h
@@ -40,9 +40,6 @@ class PlatformWinRt : public Platform {
 	fs::path getFolderPath( const fs::path &initialPath ) override;
 	fs::path getSaveFilePath( const fs::path &initialPath, const std::vector<std::string> &extensions ) override;
 
-	// currently nothing to do here, Platform::findAndAddAssetBasePath() will search for an assets folder 10 levels deep from executable
-	void prepareAssetLoading() override {}
-
 	// Overridden to use OutputDebugString
 	std::ostream&	console() override;
 

--- a/include/cinder/app/winrt/PlatformWinRt.h
+++ b/include/cinder/app/winrt/PlatformWinRt.h
@@ -33,7 +33,7 @@ class PlatformWinRt : public Platform {
 
 	DataSourceRef	loadResource( const fs::path &resourcePath, int mswID, const std::string &mswType ) override;
 
-	fs::path getResourcePath() const override										{ return fs::path(); }
+	fs::path getResourceDirectory() const override									{ return fs::path(); }
 	fs::path getResourcePath( const fs::path &rsrcRelativePath ) const override		{ return fs::path(); }
 
 	fs::path getOpenFilePath( const fs::path &initialPath, const std::vector<std::string> &extensions ) override;

--- a/src/cinder/app/Platform.cpp
+++ b/src/cinder/app/Platform.cpp
@@ -111,9 +111,9 @@ fs::path Platform::findAssetPath( const fs::path &relativePath )
 void Platform::ensureAssetDirsPrepared()
 {
 	if( ! mAssetDirsInitialized ) {
+		mAssetDirsInitialized = true;
 		prepareAssetLoading();
 		findAndAddAssetBasePath();
-		mAssetDirsInitialized = true;
 	}
 }
 

--- a/src/cinder/app/Platform.cpp
+++ b/src/cinder/app/Platform.cpp
@@ -81,18 +81,23 @@ fs::path Platform::getAssetPath( const fs::path &relativePath )
 
 void Platform::addAssetDirectory( const fs::path &directory )
 {
+	CI_ASSERT( fs::is_directory( directory ) );
+	ensureAssetDirsPrepared();
+
 	auto it = find( mAssetDirectories.begin(), mAssetDirectories.end(), directory );
 	if( it == mAssetDirectories.end() )
 		mAssetDirectories.push_back( directory );
 }
 
+const vector<fs::path>& Platform::getAssetDirectories()
+{
+	ensureAssetDirsPrepared();
+	return mAssetDirectories;
+}
+
 fs::path Platform::findAssetPath( const fs::path &relativePath )
 {
-	if( ! mAssetDirsInitialized ) {
-		prepareAssetLoading();
-		findAndAddAssetBasePath();
-		mAssetDirsInitialized = true;
-	}
+	ensureAssetDirsPrepared();
 
 	for( const auto &directory : mAssetDirectories ) {
 		auto fullPath = directory / relativePath;
@@ -101,6 +106,15 @@ fs::path Platform::findAssetPath( const fs::path &relativePath )
 	}
 
 	return fs::path(); // empty implies failure
+}
+
+void Platform::ensureAssetDirsPrepared()
+{
+	if( ! mAssetDirsInitialized ) {
+		prepareAssetLoading();
+		findAndAddAssetBasePath();
+		mAssetDirsInitialized = true;
+	}
 }
 
 void Platform::findAndAddAssetBasePath()

--- a/src/cinder/app/Platform.cpp
+++ b/src/cinder/app/Platform.cpp
@@ -79,23 +79,23 @@ fs::path Platform::getAssetPath( const fs::path &relativePath )
 	return findAssetPath( relativePath );
 }
 
-void Platform::addAssetDirectory( const fs::path &dirPath )
+void Platform::addAssetDirectory( const fs::path &directory )
 {
-	auto it = find( mAssetPaths.begin(), mAssetPaths.end(), dirPath );
-	if( it == mAssetPaths.end() )
-		mAssetPaths.push_back( dirPath );
+	auto it = find( mAssetDirectories.begin(), mAssetDirectories.end(), directory );
+	if( it == mAssetDirectories.end() )
+		mAssetDirectories.push_back( directory );
 }
 
 fs::path Platform::findAssetPath( const fs::path &relativePath )
 {
-	if( ! mAssetPathsInitialized ) {
+	if( ! mAssetDirsInitialized ) {
 		prepareAssetLoading();
 		findAndAddAssetBasePath();
-		mAssetPathsInitialized = true;
+		mAssetDirsInitialized = true;
 	}
 
-	for( const auto &assetPath : mAssetPaths ) {
-		auto fullPath = assetPath / relativePath;
+	for( const auto &directory : mAssetDirectories ) {
+		auto fullPath = directory / relativePath;
 		if( fs::exists( fullPath ) )
 			return fullPath;
 	}

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -100,7 +100,7 @@ fs::path PlatformCocoa::getResourcePath( const fs::path &rsrcRelativePath ) cons
 	return fs::path( [resultPath cStringUsingEncoding:NSUTF8StringEncoding] );
 }
 
-fs::path PlatformCocoa::getResourcePath() const
+fs::path PlatformCocoa::getResourceDirectory() const
 {
 	NSString *resultPath = [getBundle() resourcePath];
 
@@ -119,7 +119,7 @@ DataSourceRef PlatformCocoa::loadResource( const fs::path &resourcePath )
 void PlatformCocoa::prepareAssetLoading()
 {
 	// search for the assets folder inside the bundle's resources, and then the bundle's root
-	fs::path bundleAssetsPath = getResourcePath() / "assets";
+	fs::path bundleAssetsPath = getResourceDirectory() / "assets";
 	if( fs::exists( bundleAssetsPath ) && fs::is_directory( bundleAssetsPath ) ) {
 		addAssetDirectory( bundleAssetsPath );
 	}

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -422,8 +422,8 @@ void DisplayMac::displayReconfiguredCallback( CGDirectDisplayID displayId, CGDis
 					mDisplays.erase( std::remove( mDisplays.begin(), mDisplays.end(), display ), mDisplays.end() );
 					mDisplays.insert( mDisplays.begin(), display );
 				}
-			}		
-		
+			}
+
 			// CG appears to not do the coordinate y-flip that NSScreen does
 			CGRect frame = ::CGDisplayBounds( displayId );
 			Area displayArea( frame.origin.x, frame.origin.y, frame.origin.x + frame.size.width, frame.origin.y + frame.size.height );
@@ -432,7 +432,7 @@ void DisplayMac::displayReconfiguredCallback( CGDirectDisplayID displayId, CGDis
 				reinterpret_cast<DisplayMac*>( display.get() )->mArea = displayArea;
 				newArea = true;
 			}
-			
+
 			if( newMainDisplay || newArea ) {
 				if( app::AppBase::get() )
 					app::AppBase::get()->emitDisplayChanged( display );


### PR DESCRIPTION
Fixes #727, mostly just implements the changes discussed there. Notes to consider:

* in order to ensure that the base asset path is always loaded when you call `getAssetDirectories()`, we need to make sure it is prepared from that call. This means it can't be const, as the virtual `prepareAssetLoading()` method can't be const (we'd also have to make a couple variables mutable).
* considering to add a `getAssetBaseDirectory()` as a cleaner alternative to `getAssetPath( "" )`, which would essentially be the same as `getAssetDirectories()[0]`

