### PR TITLE
mac borderless fixes

### DIFF
--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -125,7 +125,7 @@ class AppBase {
 		//! the title of the app reflected in ways particular to the app type and platform (such as its Window or menu)
 		const	std::string&	getTitle() const { return mTitle; }
 		//! the title of the app reflected in ways particular to the app type and platform (such as its Window or menu)
-		void					setTitle( const std::string &title ) { mTitle = title; }
+		void					setTitle( const std::string &title ) { mTitle = title; mDefaultWindowFormat.setTitle( title ); }
 
 		//! Sets whether Windows created on a high-density (Retina) display will have their resolution doubled. Default is \c true on iOS and \c false on other platforms
 		void	setHighDensityDisplayEnabled( bool enable = true )	{ mHighDensityDisplayEnabled = enable; }

--- a/include/cinder/app/cocoa/AppImplMac.h
+++ b/include/cinder/app/cocoa/AppImplMac.h
@@ -87,6 +87,7 @@
   @public
 	AppImplMac*					mAppImpl;
 	NSWindow*					mWin;
+	NSString*					mTitle; // title is cached becasue sometimes we need to restore it after changing window border styles
 	CinderViewMac*				mCinderView;
 	cinder::app::WindowRef		mWindowRef;
 	cinder::DisplayRef			mDisplay;

--- a/include/cinder/app/cocoa/AppImplMac.h
+++ b/include/cinder/app/cocoa/AppImplMac.h
@@ -87,7 +87,7 @@
   @public
 	AppImplMac*					mAppImpl;
 	NSWindow*					mWin;
-	NSString*					mTitle; // title is cached becasue sometimes we need to restore it after changing window border styles
+	NSString*					mTitle; // title is cached because sometimes we need to restore it after changing window border styles
 	CinderViewMac*				mCinderView;
 	cinder::app::WindowRef		mWindowRef;
 	cinder::DisplayRef			mDisplay;

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -472,6 +472,9 @@ using namespace cinder::app;
 
 - (void)setTitle:(NSString *)title
 {
+	if( mTitle )
+		[mTitle release];
+
 	mTitle = [title copy]; // title is cached becasue sometimes we need to restore it after changing window border styles
 	[mWin setTitle:title];
 }

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -475,7 +475,7 @@ using namespace cinder::app;
 	if( mTitle )
 		[mTitle release];
 
-	mTitle = [title copy]; // title is cached becasue sometimes we need to restore it after changing window border styles
+	mTitle = [title copy]; // title is cached because sometimes we need to restore it after changing window border styles
 	[mWin setTitle:title];
 }
 

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -389,6 +389,9 @@ using namespace cinder::app;
 - (void)dealloc
 {
 	[mCinderView release];
+	if( mTitle )
+		[mTitle release];
+
 	[super dealloc];
 }
 
@@ -464,11 +467,12 @@ using namespace cinder::app;
 
 - (NSString *)getTitle
 {
-	return [mWin title];
+	return mTitle;
 }
 
 - (void)setTitle:(NSString *)title
 {
+	mTitle = [title copy]; // title is cached becasue sometimes we need to restore it after changing window border styles
 	[mWin setTitle:title];
 }
 
@@ -503,6 +507,10 @@ using namespace cinder::app;
 		ivec2 currentSize = mSize;
 		[self setSize:currentSize + ivec2( 0, 1 )];
 		[self setSize:currentSize];
+
+		// restore title, which also seems to disappear after coming back from borderless
+		if( mTitle )
+			[mWin setTitle:mTitle];
 	}
 }
 
@@ -753,7 +761,7 @@ using namespace cinder::app;
 	[winImpl->mWin setLevel:( winImpl->mAlwaysOnTop ? NSScreenSaverWindowLevel : NSNormalWindowLevel )];
 
 	if( ! winFormat.getTitle().empty() )
-		[winImpl->mWin setTitle:[NSString stringWithUTF8String:winFormat.getTitle().c_str()]];
+		[winImpl setTitle:[NSString stringWithUTF8String:winFormat.getTitle().c_str()]];
 
 	if( winFormat.isFullScreenButtonEnabled() )
 		[winImpl->mWin setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -481,18 +481,19 @@ using namespace cinder::app;
 {
 	mBorderless = borderless;
 
-	unsigned int styleMask;
+	NSUInteger styleMask;
 	if( mBorderless )
 		styleMask = ( mResizable ) ? ( NSBorderlessWindowMask | NSResizableWindowMask ) : NSBorderlessWindowMask;
 	else if( mResizable )
-		styleMask = NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask| NSResizableWindowMask;
+		styleMask = NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask;
 	else
 		styleMask = NSTitledWindowMask;
+
 	[mWin setStyleMask:styleMask];
 	[mWin makeFirstResponder:mCinderView];
 	[mWin makeKeyWindow];
 	[mWin makeMainWindow];
-	[mWin setHasShadow:(! mBorderless)];
+	[mWin setHasShadow:( ! mBorderless )];
 }
 
 - (bool)isAlwaysOnTop

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -497,6 +497,13 @@ using namespace cinder::app;
 	[mWin makeKeyWindow];
 	[mWin makeMainWindow];
 	[mWin setHasShadow:( ! mBorderless )];
+
+	// kludge: the titlebar buttons don't want to re-appear after coming back from borderless mode unless we resize the window.
+	if( ! mBorderless && mResizable ) {
+		ivec2 currentSize = mSize;
+		[self setSize:currentSize + ivec2( 0, 1 )];
+		[self setSize:currentSize];
+	}
 }
 
 - (bool)isAlwaysOnTop

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -479,6 +479,9 @@ using namespace cinder::app;
 
 - (void)setBorderless:(BOOL)borderless
 {
+	if( mBorderless == borderless )
+		return;
+
 	mBorderless = borderless;
 
 	NSUInteger styleMask;

--- a/test/windowTest/src/windowTestApp.cpp
+++ b/test/windowTest/src/windowTestApp.cpp
@@ -60,6 +60,7 @@ void WindowTestApp::prepareSettings( Settings *settings )
 	settings->setQuitOnLastWindowCloseEnabled( false );
 //	settings->setFullScreen( false );
 	settings->setWindowSize( 800, 500 );
+	settings->setTitle( "title set from App::Settings" );
 //	settings->prepareWindow( Window::Format().resizable( false ).renderer( RendererGl::create() ).fullScreen( true ) );
 //	settings->prepareWindow( Window::Format().fullScreen().fullScreenButton() );
 }


### PR DESCRIPTION
Merging against app_refactor since app impls have moved in that, amongst other changes. This includes:

* @lithium-snepo's fix for coming back from borderless and the resize buttons being gone. Internally it appears we need to resize the window to make this work (I tried a number of other things as well) - probably a bug on apple's part, but seeing as how the window is already visually changing, doesn't have any real side effects.
* caching the window title so that we can restore it after coming back from borderless
* `App::Settings::setTitle()` also sets the default `Window::Format`'s title. This seems like expected behavior, and also I think this is how things already work on windows (on mac, you had to explicitly call `Window::setTitle()`)

Fixes issues in #694, supersedes #709