### PR TITLE
Blur sample update

### DIFF
--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/motion-blur.fs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/motion-blur.fs
@@ -1,4 +1,4 @@
-#version 150 core
+#version 330 core
 
 uniform sampler2D uColorMap; // texture we're blurring
 uniform sampler2D uVelocityMap;

--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/neighbormax.fs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/neighbormax.fs
@@ -1,7 +1,7 @@
-#version 150 core
+#version 330 core
 
 uniform sampler2D uTileMap;	// downsampled velocity
-out vec4 fVelocity;
+layout (location = 1) out vec2 fVelocity;
 
 void main() {
 	vec2 texelSize = 1.0 / vec2(textureSize(uTileMap, 0));
@@ -59,7 +59,4 @@ void main() {
 	}
 	// store screen-space velocity
 	fVelocity.xy = velocity;
-	// observed strange behavior on OSX+AMD when only writing to rg/xy
-	// writing 1s to unused channels fixes the issue
-	fVelocity.ba = vec2( 1.0 );
 }

--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/neighbormax.fs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/neighbormax.fs
@@ -1,7 +1,7 @@
 #version 330 core
 
 uniform sampler2D uTileMap;	// downsampled velocity
-layout (location = 1) out vec2 fVelocity;
+out vec2 fVelocity;
 
 void main() {
 	vec2 texelSize = 1.0 / vec2(textureSize(uTileMap, 0));
@@ -58,5 +58,5 @@ void main() {
 		}
 	}
 	// store screen-space velocity
-	fVelocity.xy = velocity;
+	fVelocity = velocity;
 }

--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/passthrough.vs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/passthrough.vs
@@ -1,4 +1,4 @@
-#version 150 core
+#version 330 core
 
 in vec4 ciPosition;
 in vec2 ciTexCoord0;

--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/tilemax.fs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/tilemax.fs
@@ -3,7 +3,7 @@
 uniform sampler2D uVelocityMap; // full-resolution velocity
 uniform int uTileSize;
 
-layout (location = 0) out vec2 fVelocity;
+out vec2 fVelocity;
 
 void main()
 {	// texel size is dependent on our output dimensions
@@ -27,5 +27,5 @@ void main()
 		}
 	}
 
-	fVelocity.xy = maxTileVelocity;
+	fVelocity = maxTileVelocity;
 }

--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/tilemax.fs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/tilemax.fs
@@ -1,9 +1,9 @@
-#version 150 core
+#version 330 core
 
 uniform sampler2D uVelocityMap; // full-resolution velocity
 uniform int uTileSize;
 
-out vec4 fVelocity;
+layout (location = 0) out vec2 fVelocity;
 
 void main()
 {	// texel size is dependent on our output dimensions
@@ -28,7 +28,4 @@ void main()
 	}
 
 	fVelocity.xy = maxTileVelocity;
-	// observed strange behavior on OSX+AMD when only writing to rg/xy
-	// writing 1s to unused channels fixes the issue
-	fVelocity.ba = vec2( 1.0 );
 }

--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/velocity-render.fs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/velocity-render.fs
@@ -1,4 +1,4 @@
-#version 150 core
+#version 330 core
 
 uniform sampler2D uTex0;
 

--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/velocity.fs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/velocity.fs
@@ -1,15 +1,21 @@
-#version 150 core
+#version 330 core
 
 smooth in vec4 vPosition;
 smooth in vec4 vPrevPosition;
+smooth in vec4 vColor;
 
-out vec4 fVelocity;
+layout (location = 0) out vec4 fColor;
+layout (location = 1) out vec4 fVelocity;
 
 void main(void) {
 	// place each position in range (0.0,1.0)
   vec2 a = (vPosition.xy / vPosition.w) * 0.5 + 0.5;
   vec2 b = (vPrevPosition.xy / vPrevPosition.w) * 0.5 + 0.5;
+
 	// store velocity in range (-1.0,1.0)
-  fVelocity.xy = (a - b);
-  fVelocity.zw = vec2( 1.0 );
+  // observed strange behavior on OSX+AMD when outputting an xy vec2.
+  // using vec4 and writing 1.0 to unused channels fixes the issue.
+  fVelocity = vec4(a - b, 1.0, 1.0);
+
+  fColor = vColor;
 }

--- a/samples/_opengl/MotionBlurVelocityBuffer/assets/velocity.vs
+++ b/samples/_opengl/MotionBlurVelocityBuffer/assets/velocity.vs
@@ -1,6 +1,7 @@
-#version 150 core
+#version 330 core
 
 in vec4 ciPosition;
+in vec4 ciColor;
 
 uniform mat4 uModelMatrix;
 uniform mat4 uPrevModelMatrix;
@@ -8,10 +9,12 @@ uniform mat4 uViewProjection;
 
 smooth out vec4 vPosition;
 smooth out vec4 vPrevPosition;
+smooth out vec4 vColor;
 
 void main(void) {
   vPosition = uViewProjection * uModelMatrix * ciPosition;
   vPrevPosition = uViewProjection * uPrevModelMatrix * ciPosition;
 
   gl_Position = vPosition;
+  vColor = ciColor;
 }

--- a/samples/_opengl/MotionBlurVelocityBuffer/src/BlurrableThings.h
+++ b/samples/_opengl/MotionBlurVelocityBuffer/src/BlurrableThings.h
@@ -35,7 +35,7 @@
 //
 class BlurrableTransform
 {
-public:
+  public:
 	BlurrableTransform() = default;
 
 	//! Set current and previous transformation matrices to the same values.
@@ -49,7 +49,7 @@ public:
 
 	//! Returns the previous transformation matrix. Matches the penultimate values sent to update.
 	const ci::mat4& getPreviousTransform() const { return mPreviousTransform; }
-private:
+  private:
 	ci::mat4	mTransform;
 	ci::mat4	mPreviousTransform;
 };
@@ -59,7 +59,7 @@ private:
 //
 class BlurrableMesh
 {
-public:
+  public:
 	BlurrableMesh( ci::gl::VboMeshRef mesh, const ci::vec3 &pos );
 
 	//! Move the mesh and update its transforms.
@@ -79,7 +79,7 @@ public:
 	void setOscillation( const ci::vec3 &osc ) { mOscillation = osc; }
 	void setColor( const ci::ColorA &color ) { mColor = color; }
 	void setTheta( float t ) { mTheta = t; }
-private:
+  private:
 	// Transform data.
 	BlurrableTransform	mTransform;
 

--- a/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
+++ b/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
@@ -68,7 +68,6 @@ class MotionBlurVelocityBufferApp : public App {
 	gl::FboRef		mGBuffer;					// Full-resolution RGBA color and velocity.
 	gl::FboRef		mVelocityDilationBuffer;	// Dilated, downsampled velocity and dominant region velocities.
 	// Name our framebuffer attachment points.
-
 	const GLenum G_COLOR			        = GL_COLOR_ATTACHMENT0;
 	const GLenum G_VELOCITY		        = GL_COLOR_ATTACHMENT1;
 	const GLenum DILATE_TILE_MAX		  = GL_COLOR_ATTACHMENT0;
@@ -250,6 +249,7 @@ void MotionBlurVelocityBufferApp::dilateVelocity()
 	{ // downsample velocity into tilemax
 		gl::ScopedTextureBind tex( mGBuffer->getTexture( G_VELOCITY ), 0 );
 		gl::ScopedGlslProg prog( mTileProg );
+		gl::drawBuffer( DILATE_TILE_MAX );
 
 		mTileProg->uniform( "uVelocityMap", 0 );
 		mTileProg->uniform( "uTileSize", mTileSize );
@@ -259,6 +259,7 @@ void MotionBlurVelocityBufferApp::dilateVelocity()
 	{ // build max neighbors from tilemax
 		gl::ScopedTextureBind tex( mVelocityDilationBuffer->getTexture( DILATE_TILE_MAX ), 0 );
 		gl::ScopedGlslProg prog( mNeighborProg );
+		gl::drawBuffer( DILATE_NEIGHBOR_MAX );
 
 		mNeighborProg->uniform( "uTileMap", 0 );
 

--- a/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
+++ b/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
@@ -68,9 +68,9 @@ class MotionBlurVelocityBufferApp : public App {
 	gl::FboRef		mGBuffer;					// Full-resolution RGBA color and velocity.
 	gl::FboRef		mVelocityDilationBuffer;	// Dilated, downsampled velocity and dominant region velocities.
 	// Name our framebuffer attachment points.
-	const GLenum G_COLOR			        = GL_COLOR_ATTACHMENT0;
-	const GLenum G_VELOCITY		        = GL_COLOR_ATTACHMENT1;
-	const GLenum DILATE_TILE_MAX		  = GL_COLOR_ATTACHMENT0;
+	const GLenum G_COLOR				= GL_COLOR_ATTACHMENT0;
+	const GLenum G_VELOCITY				= GL_COLOR_ATTACHMENT1;
+	const GLenum DILATE_TILE_MAX		= GL_COLOR_ATTACHMENT0;
 	const GLenum DILATE_NEIGHBOR_MAX	= GL_COLOR_ATTACHMENT1;
 
 	gl::QueryTimeSwappedRef mGpuTimer;

--- a/samples/_opengl/MotionBlurVelocityBuffer/xcode/MotionBlurVelocityBuffer.xcodeproj/project.pbxproj
+++ b/samples/_opengl/MotionBlurVelocityBuffer/xcode/MotionBlurVelocityBuffer.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		153B089219A7B8BC002E78AD /* BlurrableThings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BlurrableThings.cpp; path = ../src/BlurrableThings.cpp; sourceTree = "<group>"; };
 		153B089319A7B8BC002E78AD /* BlurrableThings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlurrableThings.h; path = ../src/BlurrableThings.h; sourceTree = "<group>"; };
+		159851C61AAB349C00C1E400 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../assets; sourceTree = "<group>"; };
 		1BDEF0D6398B4945BBEB6DE9 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
 		261D7236DC8044D3AA888D66 /* MotionBlurVelocityBuffer_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = MotionBlurVelocityBuffer_Prefix.pch; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
@@ -120,6 +121,7 @@
 		29B97314FDCFA39411CA2CEA /* MotionBlurVelocityBuffer */ = {
 			isa = PBXGroup;
 			children = (
+				159851C61AAB349C00C1E400 /* assets */,
 				01B97315FEAEA392516A2CEA /* Blocks */,
 				29B97315FDCFA39411CA2CEA /* Headers */,
 				080E96DDFE201D6D7F000001 /* Source */,


### PR DESCRIPTION
Use two FBOs with multiple attachments (one FBO for each size needed).
GPU and CPU frame timing added to params.
Separate methods for each phase of the blur process should be easier to follow.
Update shaders to 330 core so we can specify layout for FBO attachments.
