### PR TITLE
creates containing folder for logging

### DIFF
--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -299,8 +299,19 @@ LoggerFile::~LoggerFile()
 
 void LoggerFile::write( const Metadata &meta, const string &text )
 {
-	if( ! mStream.is_open() )
+	if( ! mStream.is_open() ) {
+		
+		fs::path dir = mFilePath.parent_path();
+		if( ! fs::is_directory( dir ) ) {
+			boost::system::error_code ec;
+			fs::create_directories( dir, ec );
+			if( ec ) {
+				cerr << "Unable to create folder \"" << dir.string() << "\", error: " << ec.message();
+			}
+		}
+		
 		mStream.open( mFilePath.string() );
+	}
 	
 	writeDefault( mStream, meta, text );
 }

--- a/test/DebugTest/src/DebugTestApp.cpp
+++ b/test/DebugTest/src/DebugTestApp.cpp
@@ -13,10 +13,12 @@ class DebugTestApp : public AppBasic {
 	void setup();
 
 	void testEnableFile();
+	void testEnableBadFilePath();
 	void testEnableDisable();
 	void testAddFile();
 	void testAddRemove();
 	void testAsserts();
+
 
 	void keyDown( KeyEvent event );
 
@@ -28,7 +30,8 @@ void DebugTestApp::setup()
 //	log::manager()->enableSystemLogging();
 
 
-	testEnableFile();
+	testEnableBadFilePath();
+	//testEnableFile();
 //	testEnableDisable();
 //	testAddRemove();
 }
@@ -47,8 +50,7 @@ void DebugTestApp::testAsserts()
 void DebugTestApp::testEnableFile()
 {
 	log::manager()->enableFileLogging();
-//	log::manager()->enableFileLogging( "/tmp/blarg/cinder.log" );  // FIXME: writing to a non-existent folder path is broken.
-
+//	log::manager()->enableFileLogging( "/tmp/blarg/cinder.log" );
 //	log::manager()->enableFileLogging( "/tmp", "loggingTests.%Y.%m.%d.log", false );
 //	log::manager()->enableFileLogging( "/tmp/cinder", "loggingTests.%Y.%m.%d.log", false );
 
@@ -79,6 +81,14 @@ void DebugTestApp::testAddRemove()
 	log::manager()->removeLogger( logger );
 	CI_LOG_I( "removed LoggerNSLog" );
 }
+
+void DebugTestApp::testEnableBadFilePath()
+{
+	log::manager()->enableFileLogging( "ABCDE:/Volumes/__THISDOESNOTEXIST_gf5jk313__/tmp/cinder.log" );
+	
+	CI_LOG_I( "This should hit the console but not deal with the bad files." );
+}
+
 
 void DebugTestApp::keyDown( KeyEvent event )
 {


### PR DESCRIPTION
Related to issue #717

* There may be a more appropriate way to get an error message to the user other than ```cerr```, but I didn't want to rely on any app contexts, etc.
* I hit the ```cerr``` when I call ```testEnableFile();``` and it gives an empty path, but not when I call ```testEnableBadFilePath();``` with a bogus path.  I'm a little confused about it, but not really worried.