### PR TITLE
audio updates

### DIFF
--- a/include/cinder/audio/GenNode.h
+++ b/include/cinder/audio/GenNode.h
@@ -28,9 +28,9 @@
 
 namespace cinder { namespace audio {
 
-//! Typedef for the base GenNode. If all you need to set on the GenNode is the frequency, you can reference the Node with this.
+//! Typedef for a shared_ptr to the base GenNode. If all you need to set on the GenNode is the frequency, you can reference the Node with this.
 typedef std::shared_ptr<class GenNode>				GenNodeRef;
-// Typedefs for all available GenNode types.
+// Typedefs for shared_ptr's to all available GenNode types.
 typedef std::shared_ptr<class GenNoiseNode>			GenNoiseNodeRef;
 typedef std::shared_ptr<class GenPhasorNode>		GenPhasorNodeRef;
 typedef std::shared_ptr<class GenSineNode>			GenSineNodeRef;

--- a/include/cinder/audio/GenNode.h
+++ b/include/cinder/audio/GenNode.h
@@ -48,6 +48,8 @@ class GenNode : public InputNode {
 	float getFreq() const			{ return mFreq.getValue(); }
 	//! Returns a pointer to the Param, which can be used to animate the frequency.
 	Param* getParamFreq()			{ return &mFreq; }
+	//! Sets the starting phase of the next processed block, in radians.
+	void	setPhase( float phase );
 
   protected:
 	GenNode( const Format &format = Format() );

--- a/include/cinder/audio/NodeMath.h
+++ b/include/cinder/audio/NodeMath.h
@@ -29,6 +29,13 @@ POSSIBILITY OF SUCH DAMAGE.
 
 namespace cinder { namespace audio {
 
+// Typedefs for shared_ptr's to all MathNode types
+typedef std::shared_ptr<class MathNode>			MathNodeRef;
+typedef std::shared_ptr<class AddNode>			AddNodeRef;
+typedef std::shared_ptr<class SubtractNode>		SubtractNodeRef;
+typedef std::shared_ptr<class MultiplyNode>		MultiplyNodeRef;
+typedef std::shared_ptr<class DivideNode>		DivideNodeRef;
+
 //! Base class for an arithmetic based Node.
 class MathNode : public Node {
   public:

--- a/include/cinder/audio/Param.h
+++ b/include/cinder/audio/Param.h
@@ -38,21 +38,21 @@ typedef std::shared_ptr<class Node>			NodeRef;
 //! A Reference to Event's returned by the ramping methods. \see applyRamp() \see appendRamp()
 typedef std::shared_ptr<class Event>			EventRef;
 //! note: unless we want to add _VARIADIC_MAX=6 in preprocessor definitions to all projects, number of args here has to be 5 or less for vc11 support
-typedef std::function<void ( float *, size_t, float, float, const std::pair<float, float>& )>	RampFn;
+typedef std::function<void ( float *, size_t, double, double, const std::pair<float, float>& )>	RampFn;
 
 //! Array-based linear ramping function.
-void rampLinear( float *array, size_t count, float t, float tIncr, const std::pair<float, float> &valueRange );
+void rampLinear( float *array, size_t count, double t, double tIncr, const std::pair<float, float> &valueRange );
 //! Array-based quadradic (t^2) ease-in ramping function.
-void rampInQuad( float *array, size_t count, float t, float tIncr, const std::pair<float, float> &valueRange );
+void rampInQuad( float *array, size_t count, double t, double tIncr, const std::pair<float, float> &valueRange );
 //! Array-based quadradic (t^2) ease-out ramping function.
-void rampOutQuad( float *array, size_t count, float t, float tIncr, const std::pair<float, float> &valueRange );
+void rampOutQuad( float *array, size_t count, double t, double tIncr, const std::pair<float, float> &valueRange );
 
 //! Class representing a sample-accurate parameter control instruction. \see Param::applyRamp(), Param::appendRamp()
 class Event {
   public:
-	float getTimeBegin()		const	{ return mTimeBegin; }
-	float getTimeEnd()			const	{ return mTimeEnd; }
-	float getDuration()			const	{ return mDuration; }
+	double getTimeBegin()		const	{ return mTimeBegin; }
+	double getTimeEnd()			const	{ return mTimeEnd; }
+	double getDuration()		const	{ return mDuration; }
 	//! \note if getCopyValueOnBegin() is true then the begin value may not be known until the Event begins to be processed.
 	float getValueBegin()		const	{ return mValueBegin; }
 	float getValueEnd()			const	{ return mValueEnd; }
@@ -69,9 +69,9 @@ class Event {
 	const std::string&	getLabel() const	{ return mLabel; }
 
   private:
-	Event( float timeBegin, float timeEnd, float valueBegin, float valueEnd, bool copyValueOnBegin, const RampFn &rampFn );
+	Event( double timeBegin, double timeEnd, float valueBegin, float valueEnd, bool copyValueOnBegin, const RampFn &rampFn );
 
-	float				mTimeBegin, mTimeEnd, mTimeCancel, mDuration;
+	double				mTimeBegin, mTimeEnd, mTimeCancel, mDuration;
 	float				mValueBegin, mValueEnd;
 	std::atomic<bool>	mIsComplete, mIsCanceled;
 	bool				mCopyValueOnBegin;
@@ -101,25 +101,25 @@ class Param {
 		Options() : mDelay( 0 ), mBeginTime( -1 ), mRampFn( rampLinear ) {}
 
 		//! Specifies a delay of \a delay in seconds.
-		Options& delay( float delay )				{ mDelay = delay; return *this; }
+		Options& delay( double delay )				{ mDelay = delay; return *this; }
 		//! Specifies the begin time in seconds. If this is value is greater or equal to zero, delay() is ignored.
-		Options& beginTime( float time )			{ mBeginTime = time; return *this; }
+		Options& beginTime( double time )			{ mBeginTime = time; return *this; }
 		//! Specifies the ramping function used during evaluation.
 		Options& rampFn( const RampFn &rampFn )		{ mRampFn = rampFn; return *this; }
 		//! Sets a label that will be assigned to the Event. Useful when debugging.
 		Options& label( const std::string &label )	{ mLabel = label; return *this; }
 
 		//! Returns the delay specified in seconds.
-		float				getDelay() const		{ return mDelay; }
+		double				getDelay() const		{ return mDelay; }
 		//! Returns the begin time specified in seconds.
-		float				getBeginTime() const	{ return mBeginTime; }
+		double				getBeginTime() const	{ return mBeginTime; }
 		//! Returns the ramping function that will be used during evaluation.
 		const RampFn&		getRampFn() const		{ return mRampFn; }
 		//! Returns a label that will be assigned to the Event. Useful when debugging.
 		const std::string&	getLabel() const		{ return mLabel; }
 
 	  private:
-		float	mDelay, mBeginTime;
+		double	mDelay, mBeginTime;
 		RampFn	mRampFn;
 		std::string	mLabel;
 	};
@@ -138,13 +138,13 @@ class Param {
 	const float*	getValueArray();
 
 	//! Apply a ramp Event from the current value to \a valueEnd over \a rampSeconds, replacing any existing Events when this one begins. Any existing processing Node is disconnected. \see Options.
-	EventRef applyRamp( float valueEnd, float rampSeconds, const Options &options = Options() );
+	EventRef applyRamp( float valueEnd, double rampSeconds, const Options &options = Options() );
 	//! Apply a ramp Event from t\a valueBegin to \a valueEnd over \a rampSeconds, replacing any existing Events when this one begins. Any existing processing Node is disconnected. \see Options.
-	EventRef applyRamp( float valueBegin, float valueEnd, float rampSeconds, const Options &options = Options() );
+	EventRef applyRamp( float valueBegin, float valueEnd, double rampSeconds, const Options &options = Options() );
 	//! Appends a ramp Event onto the end of the last scheduled Event (or the current time) to \a valueEnd over \a rampSeconds, according to \a options. Any existing processing Node is disconnected.
-	EventRef appendRamp( float valueEnd, float rampSeconds, const Options &options = Options() );
+	EventRef appendRamp( float valueEnd, double rampSeconds, const Options &options = Options() );
 	//! Appends an ramp Event onto the end of the last scheduled Event (or the current time), from \a valueBegin to \a valueEnd over \a rampSeconds, according to \a options. Any existing processing Node is disconnected.
-	EventRef appendRamp( float valueBegin, float valueEnd, float rampSeconds, const Options &options = Options() );
+	EventRef appendRamp( float valueBegin, float valueEnd, double rampSeconds, const Options &options = Options() );
 
 	//! Sets this Param's input to be the processing performed by \a node. Any existing Event's are discarded. \note Forces \a node to be mono.
 	void	setProcessor( const NodeRef &node );
@@ -163,19 +163,19 @@ class Param {
 	//! Evaluates the Param from \a timeBegin for \a arrayLength samples at \a sampleRate.
 	//! \return true if the Param is varying this block (there are Event's or a processing Node) and getValueArray() should be used, or false if the Param's value is constant for this block (use getValue()).
 	//! \note Safe to call on the audio thread.
-	bool	eval( float timeBegin, float *array, size_t arrayLength, size_t sampleRate );
+	bool	eval( double timeBegin, float *array, size_t arrayLength, size_t sampleRate );
 
 	//! Returns the total duration of any scheduled Event's, including delay, or 0 if none are scheduled.
 	float					findDuration() const;
 	//! Returns the end time and value of the latest scheduled Event, or [0, getValue()] if none are scheduled.
-	std::pair<float, float> findEndTimeAndValue() const;
+	std::pair<double, float> findEndTimeAndValue() const;
 
   protected:
 
 	// non-locking protected methods
 	void		initInternalBuffer();
 	void		resetImpl();
-	void		removeEventsAt( float time );
+	void		removeEventsAt( double time );
 	ContextRef	getContext() const;
 
 	std::list<EventRef>	mEvents;

--- a/include/cinder/audio/Param.h
+++ b/include/cinder/audio/Param.h
@@ -67,7 +67,7 @@ class Event {
   private:
 	Event( float timeBegin, float timeEnd, float valueBegin, float valueEnd, bool copyValueOnBegin, const RampFn &rampFn );
 
-	float				mTimeBegin, mTimeEnd, mDuration;
+	float				mTimeBegin, mTimeEnd, mTimeCancel, mDuration;
 	float				mValueBegin, mValueEnd;
 	std::atomic<bool>	mIsComplete, mIsCanceled;
 	bool				mCopyValueOnBegin;

--- a/include/cinder/audio/Param.h
+++ b/include/cinder/audio/Param.h
@@ -28,6 +28,7 @@
 #include <list>
 #include <atomic>
 #include <functional>
+#include <string>
 
 namespace cinder { namespace audio {
 
@@ -64,6 +65,9 @@ class Event {
 	void cancel()				{ mIsCanceled = true; }
 	bool isComplete() const		{ return mIsComplete; }
 
+	//! Returns the label that was assigned when the Event was created, or an empty string. Useful when debugging.
+	const std::string&	getLabel() const	{ return mLabel; }
+
   private:
 	Event( float timeBegin, float timeEnd, float valueBegin, float valueEnd, bool copyValueOnBegin, const RampFn &rampFn );
 
@@ -71,8 +75,8 @@ class Event {
 	float				mValueBegin, mValueEnd;
 	std::atomic<bool>	mIsComplete, mIsCanceled;
 	bool				mCopyValueOnBegin;
-
-	RampFn	mRampFn;
+	std::string			mLabel;
+	RampFn				mRampFn;
 
 	friend class Param;
 };
@@ -102,17 +106,22 @@ class Param {
 		Options& beginTime( float time )			{ mBeginTime = time; return *this; }
 		//! Specifies the ramping function used during evaluation.
 		Options& rampFn( const RampFn &rampFn )		{ mRampFn = rampFn; return *this; }
+		//! Sets a label that will be assigned to the Event. Useful when debugging.
+		Options& label( const std::string &label )	{ mLabel = label; return *this; }
 
 		//! Returns the delay specified in seconds.
-		float getDelay() const				{ return mDelay; }
+		float				getDelay() const		{ return mDelay; }
 		//! Returns the begin time specified in seconds.
-		float getBeginTime() const			{ return mBeginTime; }
+		float				getBeginTime() const	{ return mBeginTime; }
 		//! Returns the ramping function that will be used during evaluation.
-		const RampFn&	getRampFn() const	{ return mRampFn; }
+		const RampFn&		getRampFn() const		{ return mRampFn; }
+		//! Returns a label that will be assigned to the Event. Useful when debugging.
+		const std::string&	getLabel() const		{ return mLabel; }
 
 	  private:
 		float	mDelay, mBeginTime;
 		RampFn	mRampFn;
+		std::string	mLabel;
 	};
 
 	//! Constructs a Param with a pointer (weak reference) to the owning parent Node and an optional \a initialValue (default = 0).

--- a/src/cinder/audio/GenNode.cpp
+++ b/src/cinder/audio/GenNode.cpp
@@ -62,6 +62,13 @@ void GenNode::initialize()
 	mSamplePeriod = 1.0f / (float)getSampleRate();
 }
 
+void GenNode::setPhase( float phase )
+{
+	lock_guard<mutex> lock( getContext()->getMutex() );
+
+	mPhase = phase;
+}
+
 // ----------------------------------------------------------------------------------------------------
 // MARK: - GenNoiseNode
 // ----------------------------------------------------------------------------------------------------

--- a/src/cinder/audio/Node.cpp
+++ b/src/cinder/audio/Node.cpp
@@ -120,7 +120,11 @@ void Node::disconnectAllInputs()
 
 void Node::connectInput( const NodeRef &input )
 {
-	lock_guard<mutex> lock( getContext()->getMutex() );
+	auto ctx = getContext();
+	if( ! ctx )
+		return;
+
+	lock_guard<mutex> lock( ctx->getMutex() );
 
 	mInputs.insert( input );
 	configureConnections();
@@ -128,7 +132,11 @@ void Node::connectInput( const NodeRef &input )
 
 void Node::disconnectInput( const NodeRef &input )
 {
-	lock_guard<mutex> lock( getContext()->getMutex() );
+	auto ctx = getContext();
+	if( ! ctx )
+		return;
+
+	lock_guard<mutex> lock( ctx->getMutex() );
 
 	for( auto inIt = mInputs.begin(); inIt != mInputs.end(); ++inIt ) {
 		if( *inIt == input ) {
@@ -140,7 +148,11 @@ void Node::disconnectInput( const NodeRef &input )
 
 void Node::disconnectOutput( const NodeRef &output )
 {
-	lock_guard<mutex> lock( getContext()->getMutex() );
+	auto ctx = getContext();
+	if( ! ctx )
+		return;
+
+	lock_guard<mutex> lock( ctx->getMutex() );
 
 	for( auto outIt = mOutputs.begin(); outIt != mOutputs.end(); ++outIt ) {
 		if( outIt->lock() == output ) {
@@ -471,7 +483,11 @@ bool Node::checkCycle( const NodeRef &sourceNode, const NodeRef &destNode ) cons
 
 void Node::notifyConnectionsDidChange()
 {
-	getContext()->connectionsDidChange( shared_from_this() );
+	auto ctx = getContext();
+	if( ! ctx )
+		return;
+
+	ctx->connectionsDidChange( shared_from_this() );
 }
 
 bool Node::canConnectToInput( const NodeRef &input )

--- a/src/cinder/audio/Param.cpp
+++ b/src/cinder/audio/Param.cpp
@@ -346,10 +346,17 @@ void Param::resetImpl()
 void Param::removeEventsAt( float time )
 {
 	for( auto &event : mEvents ) {
-		if( event->getTimeBegin() >= time )
+		if( event->getTimeBegin() >= time ) {
 			event->cancel();
-		else if( event->getTimeEnd() >= time )
-			event->mTimeCancel = time;
+		}
+		else if( event->getTimeEnd() >= time ) {
+			// Handle cancel later to allow the ramp to continue until the cancel point. Only reset cancel time if it is newer than a previous setting.
+			if( event->mTimeCancel > 0 ) {
+				event->mTimeCancel = min( event->mTimeCancel, time );
+			}
+			else
+				event->mTimeCancel = time;
+		}
 	}
 }
 

--- a/src/cinder/audio/Param.cpp
+++ b/src/cinder/audio/Param.cpp
@@ -281,6 +281,13 @@ bool Param::eval( float timeBegin, float *array, size_t arrayLength, size_t samp
 
 			// If the event has a cancel time, adjust the count if needed, but all other ramp values remain the same
 			if( event->mTimeCancel > 0 ) {
+				if( event->mTimeCancel < timeBegin ) {
+					// event should already be over
+					event->cancel();
+					eventIt = mEvents.erase( eventIt );
+					continue;
+				}
+
 				size_t endIndexModified = timeEnd < event->mTimeCancel ? arrayLength : size_t( ( event->mTimeCancel - timeBegin ) * sampleRate );
 				if( endIndexModified != endIndex ) {
 					count = endIndexModified - startIndex;

--- a/src/cinder/audio/Param.cpp
+++ b/src/cinder/audio/Param.cpp
@@ -32,34 +32,34 @@ using namespace std;
 
 namespace cinder { namespace audio {
 
-void rampLinear( float *array, size_t count, float t, float tIncr, const std::pair<float, float> &valueRange )
+void rampLinear( float *array, size_t count, double t, double tIncr, const std::pair<float, float> &valueRange )
 {
 	for( size_t i = 0; i < count; i++ ) {
-		float factor = t;
+		float factor( t );
 		array[i] = lerp( valueRange.first, valueRange.second, factor );
 		t += tIncr;
 	}
 }
 
-void rampInQuad( float *array, size_t count, float t, float tIncr, const std::pair<float, float> &valueRange )
+void rampInQuad( float *array, size_t count, double t, double tIncr, const std::pair<float, float> &valueRange )
 {
 	for( size_t i = 0; i < count; i++ ) {
-		float factor = t * t;
+		float factor( t * t );
 		array[i] = lerp( valueRange.first, valueRange.second, factor );
 		t += tIncr;
 	}
 }
 
-void rampOutQuad( float *array, size_t count, float t, float tIncr, const std::pair<float, float> &valueRange )
+void rampOutQuad( float *array, size_t count, double t, double tIncr, const std::pair<float, float> &valueRange )
 {
 	for( size_t i = 0; i < count; i++ ) {
-		float factor = -t * ( t - 2 );
+		float factor( -t * ( t - 2 ) );
 		array[i] = lerp( valueRange.first, valueRange.second, factor );
 		t += tIncr;
 	}
 }
 
-Event::Event( float timeBegin, float timeEnd, float valueBegin, float valueEnd, bool copyValueOnBegin, const RampFn &rampFn )
+Event::Event( double timeBegin, double timeEnd, float valueBegin, float valueEnd, bool copyValueOnBegin, const RampFn &rampFn )
 	: mTimeBegin( timeBegin ), mTimeEnd( timeEnd ), mDuration( timeEnd - timeBegin ), mCopyValueOnBegin( copyValueOnBegin ),
 		mValueBegin( valueBegin ), mValueEnd( valueEnd ), mRampFn( rampFn ), mIsComplete( false ), mIsCanceled( false ), mTimeCancel( -1 )
 {
@@ -77,13 +77,13 @@ void Param::setValue( float value )
 	mValue = value;
 }
 
-EventRef Param::applyRamp( float valueEnd, float rampSeconds, const Options &options )
+EventRef Param::applyRamp( float valueEnd, double rampSeconds, const Options &options )
 {
 	initInternalBuffer();
 
 	auto ctx = getContext();
-	float timeBegin = ( options.getBeginTime() >= 0 ? options.getBeginTime() : (float)ctx->getNumProcessedSeconds() + options.getDelay() );
-	float timeEnd = timeBegin + rampSeconds;
+	double timeBegin = ( options.getBeginTime() >= 0 ? options.getBeginTime() : ctx->getNumProcessedSeconds() + options.getDelay() );
+	double timeEnd = timeBegin + rampSeconds;
 
 	EventRef event( new Event( timeBegin, timeEnd, mValue, valueEnd, true, options.getRampFn() ) );
 
@@ -100,13 +100,13 @@ EventRef Param::applyRamp( float valueEnd, float rampSeconds, const Options &opt
 	return event;
 }
 
-EventRef Param::applyRamp( float valueBegin, float valueEnd, float rampSeconds, const Options &options )
+EventRef Param::applyRamp( float valueBegin, float valueEnd, double rampSeconds, const Options &options )
 {
 	initInternalBuffer();
 
 	auto ctx = getContext();
-	float timeBegin = ( options.getBeginTime() >= 0 ? options.getBeginTime() : (float)ctx->getNumProcessedSeconds() + options.getDelay() );
-	float timeEnd = timeBegin + rampSeconds;
+	double timeBegin = ( options.getBeginTime() >= 0 ? options.getBeginTime() : ctx->getNumProcessedSeconds() + options.getDelay() );
+	double timeEnd = timeBegin + rampSeconds;
 
 	EventRef event( new Event( timeBegin, timeEnd, valueBegin, valueEnd, false, options.getRampFn() ) );
 
@@ -123,14 +123,14 @@ EventRef Param::applyRamp( float valueBegin, float valueEnd, float rampSeconds, 
 	return event;
 }
 
-EventRef Param::appendRamp( float valueEnd, float rampSeconds, const Options &options )
+EventRef Param::appendRamp( float valueEnd, double rampSeconds, const Options &options )
 {
 	initInternalBuffer();
 
 	auto ctx = getContext();
 	auto endTimeAndValue = findEndTimeAndValue();
-	float timeBegin = ( options.getBeginTime() >= 0 ? options.getBeginTime() : endTimeAndValue.first + options.getDelay() );
-	float timeEnd = timeBegin + rampSeconds;
+	double timeBegin = ( options.getBeginTime() >= 0 ? options.getBeginTime() : endTimeAndValue.first + options.getDelay() );
+	double timeEnd = timeBegin + rampSeconds;
 
 	EventRef event( new Event( timeBegin, timeEnd, endTimeAndValue.second, valueEnd, true, options.getRampFn() ) );
 
@@ -142,14 +142,14 @@ EventRef Param::appendRamp( float valueEnd, float rampSeconds, const Options &op
 	return event;
 }
 
-EventRef Param::appendRamp( float valueBegin, float valueEnd, float rampSeconds, const Options &options )
+EventRef Param::appendRamp( float valueBegin, float valueEnd, double rampSeconds, const Options &options )
 {
 	initInternalBuffer();
 
 	auto ctx = getContext();
 	auto endTimeAndValue = findEndTimeAndValue();
-	float timeBegin = ( options.getBeginTime() >= 0 ? options.getBeginTime() : endTimeAndValue.first + options.getDelay() );
-	float timeEnd = timeBegin + rampSeconds;
+	double timeBegin = ( options.getBeginTime() >= 0 ? options.getBeginTime() : endTimeAndValue.first + options.getDelay() );
+	double timeEnd = timeBegin + rampSeconds;
 
 	EventRef event( new Event( timeBegin, timeEnd, valueBegin, valueEnd, false, options.getRampFn() ) );
 
@@ -206,13 +206,13 @@ float Param::findDuration() const
 	}
 }
 
-pair<float, float> Param::findEndTimeAndValue() const
+pair<double, float> Param::findEndTimeAndValue() const
 {
 	auto ctx = getContext();
 	lock_guard<mutex> lock( ctx->getMutex() );
 
 	if( mEvents.empty() )
-		return make_pair( (float)ctx->getNumProcessedSeconds(), mValue.load() );
+		return make_pair( ctx->getNumProcessedSeconds(), mValue.load() );
 	else {
 		const EventRef &event = mEvents.back();
 		return make_pair( event->mTimeEnd, event->mValueEnd );
@@ -238,15 +238,16 @@ bool Param::eval()
 	}
 	else {
 		auto ctx = getContext();
-		mIsVaryingThisBlock = eval( (float)ctx->getNumProcessedSeconds(), mInternalBuffer.getData(), mInternalBuffer.getSize(), ctx->getSampleRate() );
+		mIsVaryingThisBlock = eval( ctx->getNumProcessedSeconds(), mInternalBuffer.getData(), mInternalBuffer.getSize(), ctx->getSampleRate() );
 		return mIsVaryingThisBlock;
 	}
 }
 
-bool Param::eval( float timeBegin, float *array, size_t arrayLength, size_t sampleRate )
+bool Param::eval( double timeBegin, float *array, size_t arrayLength, size_t sampleRate )
 {
+	const double samplePeriod = 1.0 / (double)sampleRate;
+	const double secondsPerBlock = (double)arrayLength * samplePeriod;
 	size_t samplesWritten = 0;
-	const float samplePeriod = 1.0f / (float)sampleRate;
 
 	for( auto eventIt = mEvents.begin(); eventIt != mEvents.end(); /* */ ) {
 		EventRef &event = *eventIt;
@@ -262,7 +263,7 @@ bool Param::eval( float timeBegin, float *array, size_t arrayLength, size_t samp
 			continue;
 		}
 
-		const float timeEnd = timeBegin + arrayLength * samplePeriod;
+		const double timeEnd = timeBegin + secondsPerBlock;
 
 		if( event->mTimeBegin < timeEnd && event->mTimeEnd > timeBegin ) {
 			size_t startIndex = timeBegin >= event->mTimeBegin ? 0 : size_t( ( event->mTimeBegin - timeBegin ) * sampleRate );
@@ -275,9 +276,9 @@ bool Param::eval( float timeBegin, float *array, size_t arrayLength, size_t samp
 				dsp::fill( mValue, array, startIndex );
 
 			size_t count = size_t( endIndex - startIndex );
-			float timeBeginNormalized = float( timeBegin - event->mTimeBegin + startIndex * samplePeriod ) / event->mDuration;
-			float timeEndNormalized = float( timeBegin - event->mTimeBegin + endIndex * samplePeriod ) / event->mDuration;
-			float timeIncr = ( timeEndNormalized - timeBeginNormalized ) / (float)count;
+			double timeBeginNormalized = ( timeBegin - event->mTimeBegin + startIndex * samplePeriod ) / event->mDuration;
+			double timeEndNormalized = ( timeBegin - event->mTimeBegin + endIndex * samplePeriod ) / event->mDuration;
+			double timeIncr = ( timeEndNormalized - timeBeginNormalized ) / (double)count;
 
 			// If the event has a cancel time, adjust the count if needed, but all other ramp values remain the same
 			if( event->mTimeCancel > 0 ) {
@@ -343,7 +344,7 @@ void Param::resetImpl()
 	mProcessor.reset();
 }
 
-void Param::removeEventsAt( float time )
+void Param::removeEventsAt( double time )
 {
 	for( auto &event : mEvents ) {
 		if( event->getTimeBegin() >= time ) {

--- a/src/cinder/audio/Param.cpp
+++ b/src/cinder/audio/Param.cpp
@@ -87,6 +87,9 @@ EventRef Param::applyRamp( float valueEnd, float rampSeconds, const Options &opt
 
 	EventRef event( new Event( timeBegin, timeEnd, mValue, valueEnd, true, options.getRampFn() ) );
 
+	if( ! options.getLabel().empty() )
+		event->mLabel = options.getLabel();
+
 	lock_guard<mutex> lock( ctx->getMutex() );
 
 	removeEventsAt( timeBegin );
@@ -106,6 +109,9 @@ EventRef Param::applyRamp( float valueBegin, float valueEnd, float rampSeconds, 
 	float timeEnd = timeBegin + rampSeconds;
 
 	EventRef event( new Event( timeBegin, timeEnd, valueBegin, valueEnd, false, options.getRampFn() ) );
+
+	if( ! options.getLabel().empty() )
+		event->mLabel = options.getLabel();
 
 	lock_guard<mutex> lock( ctx->getMutex() );
 
@@ -128,6 +134,9 @@ EventRef Param::appendRamp( float valueEnd, float rampSeconds, const Options &op
 
 	EventRef event( new Event( timeBegin, timeEnd, endTimeAndValue.second, valueEnd, true, options.getRampFn() ) );
 
+	if( ! options.getLabel().empty() )
+		event->mLabel = options.getLabel();
+
 	lock_guard<mutex> lock( ctx->getMutex() );
 	mEvents.push_back( event );
 	return event;
@@ -143,6 +152,9 @@ EventRef Param::appendRamp( float valueBegin, float valueEnd, float rampSeconds,
 	float timeEnd = timeBegin + rampSeconds;
 
 	EventRef event( new Event( timeBegin, timeEnd, valueBegin, valueEnd, false, options.getRampFn() ) );
+
+	if( ! options.getLabel().empty() )
+		event->mLabel = options.getLabel();
 
 	lock_guard<mutex> lock( ctx->getMutex() );
 	mEvents.push_back( event );

--- a/src/cinder/audio/Param.cpp
+++ b/src/cinder/audio/Param.cpp
@@ -342,7 +342,7 @@ void Param::initInternalBuffer()
 
 ContextRef Param::getContext() const
 {
-	return	mParentNode->getContext();
+	return mParentNode->getContext();
 }
 
 } } // namespace cinder::audio

--- a/src/cinder/audio/SamplePlayerNode.cpp
+++ b/src/cinder/audio/SamplePlayerNode.cpp
@@ -186,12 +186,15 @@ void BufferPlayerNode::process( Buffer *buffer )
 	size_t readPos = mReadPos;
 	size_t numFrames = frameRange.second - frameRange.first;
 	size_t readEnd = mLoop ? mLoopEnd.load() : mNumFrames;
-	size_t readCount = readEnd < readPos ? 0 : min( readEnd - readPos, numFrames );
 
-	buffer->copyOffset( *mBuffer, readCount, frameRange.first, readPos );
+	size_t readCount = 0;
+	if( readPos <= readEnd ) {
+		readCount = min( readEnd - readPos, numFrames );
+		buffer->copyOffset( *mBuffer, readCount, frameRange.first, readPos );
+	}
 
 	if( readCount < numFrames  ) {
-		// End of File. If looping copy from beginning, otherwise disable and mark the mIsEof.
+		// End of File. If looping copy from beginning, otherwise disable and mark mIsEof.
 		if( mLoop ) {
 			size_t readBegin = mLoopBegin;
 			size_t readLeft = min( numFrames - readCount, mNumFrames - readBegin );


### PR DESCRIPTION
Some minor-ish features and bug fixes that I've collected over the last few months, getting them back into master. Main changes are:

* improvements to the changes in #575, advanced audio timing with `audio::Param`.
* `audio::Param` handles time with double precision floating point now, to make the conversion to and from size_t sample to normalized time more accurate. Fixes #729
* added `GenNode::setPhase()`
* added shared_ptr `Ref` typedefs for `audio::MathNode` types
* you can attach labels to `audio::Event` for debugging purposes.