### PR TITLE
Allow access to environment variables on OS X and iOS

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -26,6 +26,9 @@
 
 #include <string>
 #include <vector>
+#if defined( CINDER_MAC )
+	#include <map>
+#endif
 #include "cinder/Cinder.h"
 #include "cinder/Url.h"
 #include "cinder/DataSource.h"
@@ -60,6 +63,11 @@ void sleep( float milliseconds );
 inline char getPathSeparator() { return '\\'; }
 #else
 inline char getPathSeparator() { return '/'; }
+#endif
+
+#if defined( CINDER_MAC )
+//! Returns the process's environment variables.
+std::map<std::string, std::string> getEnvironmentVariables();
 #endif
 
 template<typename T>

--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -26,7 +26,7 @@
 
 #include <string>
 #include <vector>
-#if defined( CINDER_MAC )
+#if defined( CINDER_COCOA )
 	#include <map>
 #endif
 #include "cinder/Cinder.h"
@@ -65,7 +65,7 @@ inline char getPathSeparator() { return '\\'; }
 inline char getPathSeparator() { return '/'; }
 #endif
 
-#if defined( CINDER_MAC )
+#if defined( CINDER_COCOA )
 //! Returns the process's environment variables.
 std::map<std::string, std::string> getEnvironmentVariables();
 #endif

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -27,6 +27,11 @@
 #include "cinder/Unicode.h"
 #include "cinder/app/Platform.h"
 
+#if defined( CINDER_MAC )
+	#include "cinder/cocoa/CinderCocoa.h"
+	#import <Cocoa/Cocoa.h>
+#endif
+
 #include <vector>
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string.hpp>
@@ -56,6 +61,25 @@ void launchWebBrowser( const Url &url )
 {
 	app::Platform::get()->launchWebBrowser( url );
 }
+
+#if defined( CINDER_MAC )
+std::map<std::string, std::string> getEnvironmentVariables()
+{
+	__block std::map<std::string, std::string> result;
+	NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+	[environment enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+		if (![key isKindOfClass:[NSString class]] || ![obj isKindOfClass:[NSString class]]) {
+			return;
+		}
+
+		std::string k = ci::cocoa::convertNsString(key);
+		std::string v = ci::cocoa::convertNsString(obj);
+		result[k] = v;
+	}];
+
+	return result;
+}
+#endif
 
 std::vector<std::string> split( const std::string &str, char separator, bool compress )
 {

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -27,9 +27,13 @@
 #include "cinder/Unicode.h"
 #include "cinder/app/Platform.h"
 
-#if defined( CINDER_MAC )
+#if defined( CINDER_COCOA )
 	#include "cinder/cocoa/CinderCocoa.h"
-	#import <Cocoa/Cocoa.h>
+	#if defined( CINDER_MAC )
+		#import <Cocoa/Cocoa.h>
+	#elif defined( CINDER_COCOA_TOUCH )
+		#import <UIKit/UIKit.h>
+	#endif
 #endif
 
 #include <vector>
@@ -62,7 +66,7 @@ void launchWebBrowser( const Url &url )
 	app::Platform::get()->launchWebBrowser( url );
 }
 
-#if defined( CINDER_MAC )
+#if defined( CINDER_COCOA )
 std::map<std::string, std::string> getEnvironmentVariables()
 {
 	__block std::map<std::string, std::string> result;

--- a/xcode/cinder.xcodeproj/project.pbxproj
+++ b/xcode/cinder.xcodeproj/project.pbxproj
@@ -1348,7 +1348,7 @@
 		00E0B60C0F60DE8B002C8FBD /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
 		00E5A41B163F5A2B00AACB3A /* CaptureImplCocoaDummy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CaptureImplCocoaDummy.h; sourceTree = "<group>"; };
 		00E5A41D163F5AC500AACB3A /* CaptureImplCocoaDummy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CaptureImplCocoaDummy.mm; sourceTree = "<group>"; };
-		00F3BD1C0EBF88AA00382AC1 /* Utilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Utilities.cpp; sourceTree = "<group>"; };
+		00F3BD1C0EBF88AA00382AC1 /* Utilities.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = Utilities.cpp; sourceTree = "<group>"; };
 		00F3BD1F0EBF89B700382AC1 /* Utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utilities.h; sourceTree = "<group>"; };
 		00F601C719F6C9DD00C83781 /* Ubo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Ubo.cpp; path = gl/Ubo.cpp; sourceTree = "<group>"; };
 		00F601CB19F6CA2D00C83781 /* Ubo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Ubo.h; path = gl/Ubo.h; sourceTree = "<group>"; };


### PR DESCRIPTION
A very basic add of `getEnvironmentVariables()` to Utilities. Would it make sense to hoist this to `Platform` and `CocoaPlatform`?

As an aside, `CINDER_COCOA` is a little misleading since iOS does not have _Cocoa_ but instead _Cocoa Touch_ no? I'd almost rather `CINDER_OSX` and `CINDER_IOS` :wink: