### PR TITLE
Moving gl::Context from VaoRef stack to Vao* stack

### DIFF
--- a/include/cinder/gl/Batch.h
+++ b/include/cinder/gl/Batch.h
@@ -66,7 +66,7 @@ class Batch {
 	//! Replaces the shader associated with the Batch. Issues a warning if not all attributes were able to match.
 	void			replaceGlslProg( const GlslProgRef& glsl );
 	//! Returns the VAO mapping the Batch's geometry to its shader
-	const VaoRef&	getVao() const { return mVao; }
+	const VaoRef	getVao() const { return mVao; }
 	//! Returns the VboMesh associated with the Batch
 	VboMeshRef		getVboMesh() const { return mVboMesh; }
 	//! Replaces the VboMesh associated with the Batch. Issues a warning if not all attributes were able to match.
@@ -141,7 +141,8 @@ class VertBatch {
 	std::vector<vec4>		mTexCoords;
 	
 	bool					mOwnsBuffers;
-	VaoRef					mVao;
+	Vao*					mVao;
+	VaoRef					mVaoStorage;
 	VboRef					mVbo;
 };
 

--- a/include/cinder/gl/Context.h
+++ b/include/cinder/gl/Context.h
@@ -97,15 +97,19 @@ class Context {
 	const std::vector<mat4>&	getProjectionMatrixStack() const { return mProjectionMatrixStack; }
 	
 	//! Binds a VAO. Consider using a ScopedVao instead.
-	void		bindVao( const VaoRef &vao );
+	void		bindVao( Vao *vao );
+	//! Binds a VAO. Consider using a ScopedVao instead.
+	void		bindVao( VaoRef &vao ) { bindVao( vao.get() ); }
 	//! Pushes and binds the VAO \a vao
-	void		pushVao( const VaoRef &vao );
+	void		pushVao( Vao *vao );
+	//! Pushes and binds the VAO \a vao
+	void		pushVao( const VaoRef &vao ) { pushVao( vao.get() ); }
 	//! Duplicates and pushes the current VAO binding 
 	void		pushVao();
 	//! Pops the current VAO binding
 	void		popVao();
 	//! Returns the currently bound VAO
-	VaoRef		getVao();
+	Vao*		getVao();
 	//! Restores the VAO binding when code that is not caching aware has invalidated it. Not typically necessary.
 	void		restoreInvalidatedVao();
 	//! Used by object tracking.
@@ -395,11 +399,11 @@ class Context {
 	//! Returns default VBO for element array data, ensuring it is at least \a requiredSize bytes. Designed for use with convenience functions.
 	VboRef			getDefaultElementVbo( size_t requiredSize = 0 );
 	//! Returns default VAO, designed for use with convenience functions.
-	VaoRef			getDefaultVao();
+	Vao*			getDefaultVao();
 	//! Returns a VBO for drawing textured rectangles; used by gl::draw(TextureRef)
 	VboRef			getDrawTextureVbo();
 	//! Returns a VBO for drawing textured rectangles; used by gl::draw(TextureRef)
-	VaoRef			getDrawTextureVao();
+	Vao*			getDrawTextureVao();
 
 	//! Returns a reference to the immediate mode emulation structure. Generally use gl::begin() and friends instead.
 	VertBatch&		immediate() { return *mImmediateMode; }
@@ -429,7 +433,7 @@ class Context {
 	std::map<GLenum,std::vector<int>>	mBufferBindingStack;
 	std::map<GLenum,std::vector<int>>	mRenderbufferBindingStack;
 	std::vector<const GlslProg*>		mGlslProgStack;
-	std::vector<VaoRef>					mVaoStack;
+	std::vector<Vao*>					mVaoStack;
 	
 #if ! defined( CINDER_GL_ES_2 )
 	TransformFeedbackObjRef				mCachedTransformFeedbackObj;

--- a/include/cinder/gl/gl.h
+++ b/include/cinder/gl/gl.h
@@ -448,7 +448,8 @@ void checkError();
 
 
 struct ScopedVao : private Noncopyable {
-	ScopedVao( const VaoRef &vao );
+	ScopedVao( Vao *vao );
+	ScopedVao( VaoRef &vao );
 	~ScopedVao();
 
   private:

--- a/src/cinder/gl/Batch.cpp
+++ b/src/cinder/gl/Batch.cpp
@@ -254,7 +254,7 @@ void VertBatch::clear()
 	mColors.clear();
 	mTexCoords.clear();
 	mVbo.reset();
-	mVao.reset();
+	mVao = nullptr;
 }
 
 void VertBatch::draw()
@@ -325,7 +325,8 @@ void VertBatch::setupBuffers()
 	if( ! mOwnsBuffers )
 		mVao->replacementBindBegin();
 	else {
-		mVao = gl::Vao::create();
+		mVaoStorage = gl::Vao::create();
+		mVao = mVaoStorage.get();
 		mVao->bind();
 	}
 

--- a/src/cinder/gl/Vao.cpp
+++ b/src/cinder/gl/Vao.cpp
@@ -97,7 +97,7 @@ void Vao::setContext( Context *context )
 void Vao::bind()
 {
 	// this will "come back" by calling bindImpl if it's necessary
-	mCtx->bindVao( shared_from_this() );
+	mCtx->bindVao( this );
 }
 
 void Vao::unbind() const

--- a/src/cinder/gl/gl.cpp
+++ b/src/cinder/gl/gl.cpp
@@ -2013,7 +2013,13 @@ void checkError()
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // ScopedVao
-ScopedVao::ScopedVao( const VaoRef &vao )
+ScopedVao::ScopedVao( Vao *vao )
+	: mCtx( gl::context() )
+{
+	mCtx->pushVao( vao );
+}
+
+ScopedVao::ScopedVao( VaoRef &vao )
 	: mCtx( gl::context() )
 {
 	mCtx->pushVao( vao );


### PR DESCRIPTION
Redesigning gl::Context VAO stack to use raw pointers instead of shared_ptr's. Small but measurable optimization.