### PR TITLE
Added getSubnetMask() to both System and NetworkAdapter instances

### DIFF
--- a/include/cinder/System.h
+++ b/include/cinder/System.h
@@ -77,17 +77,20 @@ class System {
 	  public:
 		const std::string&	getName() const { return mName; }
 		const std::string&	getIpAddress() const { return mIpAddress; }
+		const std::string&	getSubnetMask() const { return mSubnetMask; }
 
-		NetworkAdapter( const std::string &name, const std::string &ip )
-			: mName( name ), mIpAddress( ip ) {}
+		NetworkAdapter(const std::string &name, const std::string &ip, const std::string &subnetMask)
+			: mName( name ), mIpAddress( ip ), mSubnetMask( subnetMask ) {}
 
 	  private:
-		std::string		mName, mIpAddress;
+		std::string		mName, mIpAddress, mSubnetMask;
 	};
 	//! Returns a list of the network adapters associated with the machine. Not cached.
 	static std::vector<NetworkAdapter>		getNetworkAdapters();
 	//! Returns a best guess at the machine's "IP address". Not cached. Computers often have multiple IP addresses, but this will attempt to select the "best". \sa getNetworkAdapaters().
 	static std::string						getIpAddress();
+	//! Returns the subnet mask of the "best" network adapter, as found by getIpAddress(). This can be used to calculate the proper broadcast IP address for a network. Not cached. \sa getNetworkAdapaters().\sa getIpAddress().
+	static std::string						getSubnetMask();
 	
   private:
 	 enum {	HAS_SSE2, HAS_SSE3, HAS_SSE4_1, HAS_SSE4_2, HAS_X86_64, HAS_ARM, PHYSICAL_CPUS, LOGICAL_CPUS, OS_MAJOR, OS_MINOR, OS_BUGFIX, MULTI_TOUCH, MAX_MULTI_TOUCH_POINTS, 

--- a/src/cinder/System.cpp
+++ b/src/cinder/System.cpp
@@ -616,7 +616,7 @@ vector<System::NetworkAdapter> System::getNetworkAdapters()
                            host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST );
 				if( result != 0 )
 					continue;
-				adapters.push_back( System::NetworkAdapter( currentInterface->ifa_name, host ) );
+				adapters.push_back( System::NetworkAdapter( currentInterface->ifa_name, host, currentInterface->ifa_netmask ) );
 			}
 			currentInterface = currentInterface->ifa_next;
 		}
@@ -645,7 +645,7 @@ vector<System::NetworkAdapter> System::getNetworkAdapters()
     if( (dwRetVal = ::GetAdaptersInfo( pAdapterInfo, &ulOutBufLen )) == NO_ERROR ) {
         pAdapter = pAdapterInfo;
         while( pAdapter ) {
-			adapters.push_back( System::NetworkAdapter( pAdapter->Description, pAdapter->IpAddressList.IpAddress.String ) );
+			adapters.push_back( System::NetworkAdapter( pAdapter->Description, pAdapter->IpAddressList.IpAddress.String, pAdapter->IpAddressList.IpMask.String ) );
             pAdapter = pAdapter->Next;
         }
     }
@@ -655,7 +655,7 @@ vector<System::NetworkAdapter> System::getNetworkAdapters()
 #elif defined( CINDER_WINRT )
 	auto hosts = NetworkInformation::GetHostNames();
 	std::for_each(begin(hosts), end(hosts), [&](HostName^ n) {
-		adapters.push_back( System::NetworkAdapter( PlatformStringToString(n->CanonicalName), PlatformStringToString(n->DisplayName) ) );
+		adapters.push_back( System::NetworkAdapter( PlatformStringToString(n->CanonicalName), PlatformStringToString(n->DisplayName), PlatformStringToString(n->IPInformation.PrefixLength.ToString()) ) );
 	});
 #else
 		throw std::exception( "Not implemented" );
@@ -663,6 +663,17 @@ vector<System::NetworkAdapter> System::getNetworkAdapters()
 
 	return adapters;
 
+}
+
+std::string System::getSubnetMask() {
+	auto preferredIpAddress = System::getIpAddress();
+	vector<System::NetworkAdapter> adapters = getNetworkAdapters();
+	for (vector<System::NetworkAdapter>::const_iterator adaptIt = adapters.begin(); adaptIt != adapters.end(); ++adaptIt) {
+		if (adaptIt->getIpAddress() == preferredIpAddress) {
+			return adaptIt->getSubnetMask();
+		}
+	}
+	return "0.0.0.0";
 }
 
 #if defined( CINDER_WINRT )


### PR DESCRIPTION
As per [this discussion](https://forum.libcinder.org/#Topic/23286000002295005), this adds information about an adapter's subnet mask to NetworkAdapter instances and a static `System::getSubnetMask()` call that works similarly to `System::getIpAddress()`, but for the subnet mask of the most appropriate network adapter.

    console() << "Your IP is " + System::getIpAddress() + ", and your subnet mask is " + System::getSubnetMask() << endl;

The reason a subnet mask is needed is so a broadcast IP [can be properly calculated](http://learn-networking.com/network-design/how-a-broadcast-address-works). Calculating the broadcast IP is necessary so we can [establish OSC communications](https://forum.libcinder.org/topic/osc-broadcast) without having to hard-code the OSC listener IP, or pass it as a parameter; it allows applications in the same network to communicate without additional configuration or tools.

Calculating the broadcast IP is not part of this pull request.

The code should be good for WinRT (XP), Win Vista+, OSX, and iOS, since I just exposed properties that already existed without change to the logic. However, I have only tested in Windows 7 so far.