### PR TITLE
Added VboMesh::MappedAttrib::operator->()

### DIFF
--- a/include/cinder/gl/VboMesh.h
+++ b/include/cinder/gl/VboMesh.h
@@ -210,7 +210,10 @@ class VboMesh {
 	  public:
 		T&			operator*() { return *(reinterpret_cast<T*>( mPtr )); }
 		const T&	operator*() const { return *(reinterpret_cast<const T*>( mPtr )); }
-		
+
+		T*			operator->()		{ return reinterpret_cast<T*>( mPtr ); }
+		const T*	operator->() const	{ return reinterpret_cast<const T*>( mPtr ); }
+
 		T&			operator[]( size_t i ) { return *(reinterpret_cast<T*>( ((uint8_t*)mPtr) + mStride * i )); }
 		const T&	operator[]( size_t i ) const { return *(reinterpret_cast<T*>( ((uint8_t*)mPtr) + mStride * i )); }
 		

--- a/include/cinder/gl/VboMesh.h
+++ b/include/cinder/gl/VboMesh.h
@@ -208,14 +208,14 @@ class VboMesh {
 	template<typename T>
 	class MappedAttrib : public MappedAttribBase {
 	  public:
-		T&			operator*() { return *(reinterpret_cast<T*>( mPtr )); }
-		const T&	operator*() const { return *(reinterpret_cast<const T*>( mPtr )); }
+		T&			operator*()			{ return *(reinterpret_cast<T*>( mPtr )); }
+		const T&	operator*() const	{ return *(reinterpret_cast<const T*>( mPtr )); }
 
 		T*			operator->()		{ return reinterpret_cast<T*>( mPtr ); }
 		const T*	operator->() const	{ return reinterpret_cast<const T*>( mPtr ); }
 
-		T&			operator[]( size_t i ) { return *(reinterpret_cast<T*>( ((uint8_t*)mPtr) + mStride * i )); }
-		const T&	operator[]( size_t i ) const { return *(reinterpret_cast<T*>( ((uint8_t*)mPtr) + mStride * i )); }
+		T&			operator[]( size_t i )			{ return *(reinterpret_cast<T*>( ((uint8_t*)mPtr) + mStride * i )); }
+		const T&	operator[]( size_t i ) const	{ return *(reinterpret_cast<T*>( ((uint8_t*)mPtr) + mStride * i )); }
 		
 		// pre-increment
 		MappedAttrib	operator++() { mPtr = ((uint8_t*)mPtr) + mStride; return *this; }


### PR DESCRIPTION
Allows you to use a MappedAttrib like:

```
mappedPosIter->y = updatedHeight;
```

instead of:

```
(*mappedPosIter).y = updatedHeight;
```
