### PR TITLE
Relax shader preprocessor version regex

### DIFF
--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -35,7 +35,7 @@ namespace cinder { namespace gl {
 
 namespace {
 	const regex sIncludeRegex = regex( "^[ \t]*#[ ]*include[ ]+[\"<](.*)[\">].*" );
-	const regex sVersionRegex = regex( "^#[ ]*version[ ]+([123456789][0123456789][0123456789]).*" );
+	const regex sVersionRegex = regex( "^[ \t]*#[ ]*version[ ]+([123456789][0123456789][0123456789]).*" );
 } // anonymous namespace
 
 ShaderPreprocessor::ShaderPreprocessor()


### PR DESCRIPTION
Previous to the ShaderPreprocessor branch getting merged into glNext, one could have a version string that had leading spaces or tabs, which was quite handy if one defined their shader source in a C++11 multi-line raw string literal. Once merged, shader preprocessing is enabled by default and with the version check regex disallowed any space, it fails to find it and prepends *another* version string of the default value into the shader source, which causes the shader compile to fail.

The chage made here allows spaces and tabs to precede `#version` which avoids the double version string and compile issue. Only tested on OS X, though I would think other shader compilers would allow the whitespace as well, perhaps worth a quick test.

As a quick example, here is the passthrough vertex shader I used in the [Cinder-DDS](https://github.com/pizthewiz/Cinder-DDS) sample [ImageCompressor](https://github.com/pizthewiz/Cinder-DDS/blob/master/samples/ImageCompressor/src/ImageCompressorApp.cpp#L23-36): 
```C++
static const std::string sVertexShaderPassThrough = R"(
    #version 150
    uniform mat4 ciModelViewProjection;
    in vec4 ciPosition;
    in vec4 ciTexCoord0;
    out highp vec2 TexCoord0;
    void main() {
        TexCoord0 = ciTexCoord0.st;
        gl_Position = ciModelViewProjection * ciPosition;
    }
)";
```