### PR TITLE
Gl next debug break

### DIFF
--- a/include/cinder/Breakpoint.h
+++ b/include/cinder/Breakpoint.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014, The Cinder Project
+ Copyright (c) 2015, The Cinder Project
 
  This code is intended to be used with the Cinder C++ library, http://libcinder.org
 
@@ -19,31 +19,14 @@
  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
- */
+*/
 
-#include "cinder/CinderAssert.h"
-#include "cinder/Breakpoint.h"
+#pragma once
 
-#include <iostream>
+#if ! defined( CINDER_MSW )
+	#include <csignal>
+	#define CI_BREAKPOINT()	std::raise( SIGINT )
+#else // MSW
+	#define CI_BREAKPOINT() __debugbreak()
+#endif
 
-namespace cinder { namespace detail {
-
-void assertionFailedBreak( char const *expr, char const *function, char const *file, long line )
-{
-	std::cerr << "*** Assertion Failed (break) *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << std::endl;
-	CI_BREAKPOINT();
-}
-
-void assertionFailedMessageBreak( char const *expr, char const *msg, char const *function, char const *file, long line )
-{
-	std::cerr << "*** Assertion Failed (break) *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << "\n\tmessage: " << msg << std::endl;
-	CI_BREAKPOINT();
-}
-
-void assertionFailedMessageAbort( char const *expr, char const *msg, char const *function, char const *file, long line )
-{
-	std::cerr << "*** Assertion Failed *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << "\n\tmessage: " << msg << std::endl;
-	std::abort();
-}
-
-} } // namespace cinder::detail

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -35,48 +35,6 @@
 #include <memory>
 #include <mutex>
 
-#define CINDER_LOG_STREAM( level, stream ) ::cinder::log::Entry( level, ::cinder::log::Location( CINDER_CURRENT_FUNCTION, __FILE__, __LINE__ ) ) << stream
-
-// CI_MAX_LOG_LEVEL is designed so that if you set it to 0, nothing logs, 1 only fatal, 2 fatal + error, etc...
-
-#if ! defined( CI_MAX_LOG_LEVEL )
-	#if ! defined( NDEBUG )
-		#define CI_MAX_LOG_LEVEL 5	// debug mode default is LEVEL_VERBOSE
-	#else
-		#define CI_MAX_LOG_LEVEL 4	// release mode default is LEVEL_INFO
-	#endif
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 5 )
-	#define CI_LOG_V( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_VERBOSE, stream )
-#else
-	#define CI_LOG_V( stream )	((void)0)
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 4 )
-	#define CI_LOG_I( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_INFO, stream )
-#else
-	#define CI_LOG_I( stream )	((void)0)
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 3 )
-	#define CI_LOG_W( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_WARNING, stream )
-#else
-	#define CI_LOG_W( stream )	((void)0)
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 2 )
-	#define CI_LOG_E( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_ERROR, stream )
-#else
-	#define CI_LOG_E( stream )	((void)0)
-#endif
-
-#if( CI_MAX_LOG_LEVEL >= 1 )
-	#define CI_LOG_F( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_FATAL, stream )
-#else
-	#define CI_LOG_F( stream )	((void)0)
-#endif
-
 namespace cinder { namespace log {
 
 typedef enum {
@@ -319,6 +277,51 @@ typedef ThreadSafeT<LoggerConsole>		LoggerConsoleThreadSafe;
 typedef ThreadSafeT<LoggerFile>			LoggerFileThreadSafe;
 
 } } // namespace cinder::log
+
+// ----------------------------------------------------------------------------------
+// Logging macros
+
+#define CINDER_LOG_STREAM( level, stream ) ::cinder::log::Entry( level, ::cinder::log::Location( CINDER_CURRENT_FUNCTION, __FILE__, __LINE__ ) ) << stream
+
+// CI_MAX_LOG_LEVEL is designed so that if you set it to 0, nothing logs, 1 only fatal, 2 fatal + error, etc...
+
+#if ! defined( CI_MAX_LOG_LEVEL )
+	#if ! defined( NDEBUG )
+		#define CI_MAX_LOG_LEVEL 5	// debug mode default is LEVEL_VERBOSE
+	#else
+		#define CI_MAX_LOG_LEVEL 4	// release mode default is LEVEL_INFO
+	#endif
+#endif
+
+#if( CI_MAX_LOG_LEVEL >= 5 )
+	#define CI_LOG_V( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_VERBOSE, stream )
+#else
+	#define CI_LOG_V( stream )	((void)0)
+#endif
+
+#if( CI_MAX_LOG_LEVEL >= 4 )
+	#define CI_LOG_I( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_INFO, stream )
+#else
+	#define CI_LOG_I( stream )	((void)0)
+#endif
+
+#if( CI_MAX_LOG_LEVEL >= 3 )
+	#define CI_LOG_W( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_WARNING, stream )
+#else
+	#define CI_LOG_W( stream )	((void)0)
+#endif
+
+#if( CI_MAX_LOG_LEVEL >= 2 )
+	#define CI_LOG_E( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_ERROR, stream )
+#else
+	#define CI_LOG_E( stream )	((void)0)
+#endif
+
+#if( CI_MAX_LOG_LEVEL >= 1 )
+	#define CI_LOG_F( stream )	CINDER_LOG_STREAM( ::cinder::log::LEVEL_FATAL, stream )
+#else
+	#define CI_LOG_F( stream )	((void)0)
+#endif
 
 //! Debug macro to simplify logging an exception, which also prints the exception type
 #define CI_LOG_EXCEPTION( str, exc )	\

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -133,8 +133,6 @@ class Logger {
 
 class LoggerConsole : public Logger {
   public:
-	virtual ~LoggerConsole()	{}
-
 	void write( const Metadata &meta, const std::string &text ) override;
 };
 

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -161,6 +161,21 @@ class LoggerFile : public Logger {
 	std::ofstream	mStream;
 };
 
+//! Logger that doesn't actually print anything, but triggers a breakpoint if a log event happens past a specified threshold
+class LoggerBreakpoint : public Logger {
+  public:
+	LoggerBreakpoint( Level triggerLevel = LEVEL_ERROR )
+		: mTriggerLevel( triggerLevel )
+	{}
+
+	void write( const Metadata &meta, const std::string &text ) override;
+
+	void	setTriggerLevel( Level triggerLevel )	{ mTriggerLevel = triggerLevel; }
+	Level	getTriggerLevel() const					{ return mTriggerLevel; }
+  private:
+	Level	mTriggerLevel;
+};
+
 #if defined( CINDER_COCOA )
 
 class LoggerSysLog : public Logger {
@@ -223,6 +238,13 @@ public:
 	void setSystemLoggingLevel( Level level );
 	Level getSystemLoggingLevel() const					{ return mSystemLoggingLevel; }
 
+	//! Enables a breakpoint to be triggered when a log message happens at `LEVEL_ERROR` or higher
+	void enableBreakOnError()							{ enableBreakOnLevel( LEVEL_ERROR ); }
+	//! Enables a breakpoint to be triggered when a log message happens at \a trigerLevel or higher.
+	void enableBreakOnLevel( Level trigerLevel );
+	//! Disables any breakpoints set for logging.
+	void disableBreakOnLog();
+
 protected:
 	LogManager();
 
@@ -231,7 +253,7 @@ protected:
 	std::unique_ptr<Logger>	mLogger;
 	LoggerImplMulti			*mLoggerMulti;
 	mutable std::mutex		mMutex;
-	bool					mConsoleLoggingEnabled, mFileLoggingEnabled, mSystemLoggingEnabled;
+	bool					mConsoleLoggingEnabled, mFileLoggingEnabled, mSystemLoggingEnabled, mBreakOnLogEnabled;
 	Level					mSystemLoggingLevel;
 
 	static LogManager *sInstance;

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -27,6 +27,7 @@
 #include "cinder/Filesystem.h"
 #include "cinder/CurrentFunction.h"
 #include "cinder/CinderAssert.h"
+#include "cinder/System.h"
 
 #include <sstream>
 #include <fstream>
@@ -318,3 +319,10 @@ typedef ThreadSafeT<LoggerConsole>		LoggerConsoleThreadSafe;
 typedef ThreadSafeT<LoggerFile>			LoggerFileThreadSafe;
 
 } } // namespace cinder::log
+
+//! Debug macro to simplify logging an exception, which also prints the exception type
+#define CI_LOG_EXCEPTION( str, exc )	\
+{										\
+	CI_LOG_E( str << ", exception type: " << cinder::System::demangleTypeName( typeid( exc ).name() ) << ", what: " << exc.what() );	\
+}
+

--- a/samples/_opengl/PostProcessingAA/src/fxaa/FXAA.cpp
+++ b/samples/_opengl/PostProcessingAA/src/fxaa/FXAA.cpp
@@ -22,7 +22,6 @@
 
 #include "cinder/app/App.h"
 #include "cinder/Log.h"
-#include "cinder/System.h"
 
 #include "FXAA.h"
 
@@ -36,7 +35,7 @@ FXAA::FXAA()
 		mGlslProg->uniform( "uTexture", 0 );
 	}
 	catch( const std::exception &e ) {
-		CI_LOG_E( "exception caught, type: " << System::demangleTypeName( typeid( e ).name() ) << ", what: " << e.what() );
+		CI_LOG_EXCEPTION( "exception caught loading fxaa.vert / frag", e );
 	}
 }
 

--- a/samples/_opengl/PostProcessingAA/src/smaa/SMAA.cpp
+++ b/samples/_opengl/PostProcessingAA/src/smaa/SMAA.cpp
@@ -22,7 +22,6 @@
 
 #include "cinder/app/App.h"
 #include "cinder/Log.h"
-#include "cinder/System.h"
 
 #include "SMAA.h"
 #include "AreaTex.h"
@@ -40,7 +39,7 @@ SMAA::SMAA()
 		mGlslThirdPass = gl::GlslProg::create( app::loadAsset( "smaa3.vert" ), app::loadAsset( "smaa3.frag" ) );
 	}
 	catch( const std::exception& e ) {
-		CI_LOG_E( "exception caught, type: " << System::demangleTypeName( typeid( e ).name() ) << ", what: " << e.what() );
+		CI_LOG_EXCEPTION( "exception caught loading smaa shaders", e );
 	}
 
 	// Create lookup textures

--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -53,7 +53,7 @@ public:
 	void add( std::unique_ptr<Logger> &&logger )		{ mLoggers.emplace_back( move( logger ) ); }
 
 	template <typename LoggerT>
-	Logger* findType();
+	LoggerT* findType();
 
 	void remove( Logger *logger );
 
@@ -326,11 +326,12 @@ void LoggerConsole::write( const Metadata &meta, const string &text )
 // ----------------------------------------------------------------------------------------------------
 
 template <typename LoggerT>
-Logger* LoggerImplMulti::findType()
+LoggerT* LoggerImplMulti::findType()
 {
 	for( const auto &logger : mLoggers ) {
-		if( dynamic_cast<LoggerT *>( logger.get() ) )
-			return logger.get();
+		auto result = dynamic_cast<LoggerT *>( logger.get() );
+		if( result )
+			return result;
 	}
 
 	return nullptr;

--- a/test/DebugTest/src/DebugTestApp.cpp
+++ b/test/DebugTest/src/DebugTestApp.cpp
@@ -21,6 +21,7 @@ class DebugTestApp : public App {
 	void testAddFile();
 	void testAddRemove();
 	void testAsserts();
+	void testBreakOnLog();
 
 
 	void keyDown( KeyEvent event );
@@ -34,12 +35,13 @@ void DebugTestApp::setup()
 //	testEnableBadFilePath();
 //	testEnableDisable();
 //	testAddRemove();
-	testRotatingFile();
+	//testRotatingFile();
 	//testEnableDisable();
 //	testSystemLevel();
 	//testAddFile();
 	//testAddRemove();
 	//testAsserts();
+	testBreakOnLog();
 }
 
 void DebugTestApp::testAsserts()
@@ -51,6 +53,18 @@ void DebugTestApp::testAsserts()
 
 //	CI_ASSERT( false );
 //	CI_ASSERT_MSG( false, "blarg" );
+}
+
+void DebugTestApp::testBreakOnLog()
+{
+	log::manager()->enableBreakOnError();
+	//log::manager()->enableBreakOnLevel( log::LEVEL_WARNING );
+
+	CI_LOG_V( "bang" );
+	CI_LOG_I( "bang" );
+	CI_LOG_W( "bang" );
+	CI_LOG_E( "bang" );
+	CI_LOG_F( "bang" );
 }
 
 void DebugTestApp::testEnableFileLogger()
@@ -111,11 +125,12 @@ void DebugTestApp::testAddFile()
 
 void DebugTestApp::testAddRemove()
 {
-	auto logger = new log::LoggerSysLog;
-	log::manager()->addLogger( logger );
-	CI_LOG_I( "added LoggerSysLog" );
-	log::manager()->removeLogger( logger );
-	CI_LOG_I( "removed LoggerSysLog" );
+	// TEMPORARY: commented out to build on windows, until LoggerSysLog is implemented there.
+// 	auto logger = new log::LoggerSysLog;
+// 	log::manager()->addLogger( logger );
+// 	CI_LOG_I( "added LoggerSysLog" );
+// 	log::manager()->removeLogger( logger );
+// 	CI_LOG_I( "removed LoggerSysLog" );
 }
 
 void DebugTestApp::testEnableBadFilePath()

--- a/test/DebugTest/vc2013/DebugTest.vcxproj
+++ b/test/DebugTest/vc2013/DebugTest.vcxproj
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?><Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -14,26 +15,28 @@
     <RootNamespace>DebugTest</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-  <PlatformToolset>v110_xp</PlatformToolset></PropertyGroup>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-  <PlatformToolset>v110_xp</PlatformToolset></PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
-    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"/>
+    <Import Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros"/>
+  <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
@@ -57,8 +60,8 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>cinder_d.lib;QTMLClient.lib;CVClient.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\lib;..\..\..\..\QuickTimeSDK-7.3\Libraries;..\..\..\lib\msw;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cinder-$(PlatformToolset)_d.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>"..\..\..\\lib\msw\$(PlatformTarget)"</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -79,8 +82,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>cinder.lib;QTMLClient.lib;CVClient.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\lib;..\..\..\..\QuickTimeSDK-7.3\Libraries;..\..\..\lib\msw;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cinder-$(PlatformToolset).lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>"..\..\..\\lib\msw\$(PlatformTarget)"</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -92,12 +95,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\DebugTestApp.cpp"/>
+    <ClCompile Include="..\src\DebugTestApp.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\include\flint\Flint.h"/>
+    <ClInclude Include="..\..\..\include\flint\Flint.h" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>

--- a/vc2013/cinder.vcxproj
+++ b/vc2013/cinder.vcxproj
@@ -704,6 +704,7 @@
     <ClInclude Include="..\include\cinder\audio\WaveformType.h" />
     <ClInclude Include="..\include\cinder\audio\WaveTable.h" />
     <ClInclude Include="..\include\cinder\Base64.h" />
+    <ClInclude Include="..\include\cinder\Breakpoint.h" />
     <ClInclude Include="..\include\cinder\CaptureImplDirectShow.h" />
     <ClInclude Include="..\include\cinder\CinderAssert.h" />
     <ClInclude Include="..\include\cinder\CinderGlm.h" />

--- a/vc2013/cinder.vcxproj.filters
+++ b/vc2013/cinder.vcxproj.filters
@@ -1637,5 +1637,8 @@
     <ClInclude Include="..\include\cinder\gl\wrapper.h">
       <Filter>Header Files\gl</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\cinder\Breakpoint.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/vc2013_winrt/cinder.vcxproj
+++ b/vc2013_winrt/cinder.vcxproj
@@ -345,6 +345,7 @@
     <ClInclude Include="..\include\cinder\audio\WaveformType.h" />
     <ClInclude Include="..\include\cinder\audio\WaveTable.h" />
     <ClInclude Include="..\include\cinder\AxisAlignedBox.h" />
+    <ClInclude Include="..\include\cinder\Breakpoint.h" />
     <ClInclude Include="..\include\cinder\BSpline.h" />
     <ClInclude Include="..\include\cinder\BSplineFit.h" />
     <ClInclude Include="..\include\cinder\Buffer.h" />

--- a/vc2013_winrt/cinder.vcxproj.filters
+++ b/vc2013_winrt/cinder.vcxproj.filters
@@ -721,6 +721,9 @@
     <ClInclude Include="..\include\cinder\gl\wrapper.h">
       <Filter>Header Files\gl</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\cinder\Breakpoint.h">
+      <Filter>Header Files\gl</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\cinder\app\RendererDx.cpp">

--- a/xcode/cinder.xcodeproj/project.pbxproj
+++ b/xcode/cinder.xcodeproj/project.pbxproj
@@ -1543,6 +1543,7 @@
 		116C06211ABD2C06004D8297 /* draw.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = draw.cpp; path = gl/draw.cpp; sourceTree = "<group>"; };
 		116C06221ABD2C06004D8297 /* scoped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scoped.cpp; path = gl/scoped.cpp; sourceTree = "<group>"; };
 		116C06231ABD2C06004D8297 /* wrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wrapper.cpp; path = gl/wrapper.cpp; sourceTree = "<group>"; };
+		117C98081AC534C300957DC6 /* Breakpoint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Breakpoint.h; sourceTree = "<group>"; };
 		1181F7C31A7F8760001BBFA2 /* AppBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppBase.h; path = app/AppBase.h; sourceTree = "<group>"; };
 		1181F7C71A7F8792001BBFA2 /* AppBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AppBase.cpp; path = app/AppBase.cpp; sourceTree = "<group>"; };
 		118CA4081A9427F700841458 /* AppMac.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = AppMac.cpp; sourceTree = "<group>"; };
@@ -1933,6 +1934,7 @@
 				0049A34C116EE675007DDFB0 /* AxisAlignedBox.h */,
 				009EE5760F803F7A00F17CB1 /* BandedMatrix.h */,
 				005C0CE814CBB3DB00A12CD2 /* Base64.h */,
+				117C98081AC534C300957DC6 /* Breakpoint.h */,
 				009EE5750F803F7A00F17CB1 /* BSpline.h */,
 				009EE5740F803F7A00F17CB1 /* BSplineFit.h */,
 				C70E19FE106AA38700E63577 /* Buffer.h */,


### PR DESCRIPTION
- Added `LoggerBreakpoint`, a logger that doesn't print anything but instead triggers a breakpoint. You don't need to use it directly, instead you can write:

```
log::manager()->enableBreakOnError();
// or
log::manager()->enableBreakOnLevel( log::LEVEL_WARNING );
```
- Added `CI_BREAKPOINT()`, a cross-platform macro to trigger breakpoints at runtime. Resides in cinder/Breakpoint.h 
- Added a new macro called `CI_LOG_EXCEPTION`, which takes a user description ostream and the exception itself, and prints something informative like:

```
|error  | FXAA::FXAA()[38] exception caught loading fxaa.vert / frag, exception type: cinder::gl::GlslProgCompileExc, what: FRAGMENT: ERROR: 0:44: '.0' : syntax error: syntax error
```

I find that I almost exclusively log exceptions with this now in my projects, as it is usually much more verbose and helpful than anything else you'd code on the spot.