### PR TITLE
gl::ScopedViewport overload for ivec2 size

### DIFF
--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -167,6 +167,7 @@ struct ScopedScissor : private Noncopyable {
 
 struct ScopedViewport : private Noncopyable {
 	ScopedViewport( const ivec2 &lowerLeftPosition, const ivec2 &dimension );
+	ScopedViewport( const ivec2 &size );
 	ScopedViewport( int lowerLeftX, int lowerLeftY, int width, int height );
 	~ScopedViewport();
 

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -324,19 +324,19 @@ ScopedRenderbuffer::~ScopedRenderbuffer()
 ScopedViewport::ScopedViewport( const ivec2 &lowerLeftPosition, const ivec2 &dimension )
 	: mCtx( gl::context() )
 {
-	mCtx->pushViewport( std::pair<ivec2, ivec2>( lowerLeftPosition, dimension ) );
+	mCtx->pushViewport( { lowerLeftPosition, dimension } );
 }
 
 ScopedViewport::ScopedViewport( const ivec2 &size )
 	: mCtx( gl::context() )
 {
-	mCtx->pushViewport( std::pair<ivec2, ivec2>( ivec2( 0 ), size ) );
+	mCtx->pushViewport( { ivec2( 0 ), size } );
 }
 
 ScopedViewport::ScopedViewport( int lowerLeftX, int lowerLeftY, int width, int height )
 	: mCtx( gl::context() )
 {
-	mCtx->pushViewport( std::pair<ivec2, ivec2>( ivec2( lowerLeftX, lowerLeftY ), ivec2( width, height ) ) );		
+	mCtx->pushViewport( { ivec2( lowerLeftX, lowerLeftY ), ivec2( width, height ) } );
 }
 	
 ScopedViewport::~ScopedViewport()

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -327,6 +327,12 @@ ScopedViewport::ScopedViewport( const ivec2 &lowerLeftPosition, const ivec2 &dim
 	mCtx->pushViewport( std::pair<ivec2, ivec2>( lowerLeftPosition, dimension ) );
 }
 
+ScopedViewport::ScopedViewport( const ivec2 &size )
+	: mCtx( gl::context() )
+{
+	mCtx->pushViewport( std::pair<ivec2, ivec2>( ivec2( 0 ), size ) );
+}
+
 ScopedViewport::ScopedViewport( int lowerLeftX, int lowerLeftY, int width, int height )
 	: mCtx( gl::context() )
 {


### PR DESCRIPTION
this mirrors `gl::viewport( ivec2 )` ([here](https://github.com/cinder/Cinder/blob/glNext/include/cinder/gl/wrapper.h#L102))