### PR TITLE
audio.h unbrella header

### DIFF
--- a/include/cinder/audio/audio.h
+++ b/include/cinder/audio/audio.h
@@ -1,0 +1,55 @@
+/*
+ Copyright (c) 2015, The Cinder Project
+
+ This code is intended to be used with the Cinder C++ library, http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// general
+#include "cinder/audio/Buffer.h"
+#include "cinder/audio/Context.h"
+#include "cinder/audio/Device.h"
+#include "cinder/audio/Exception.h"
+#include "cinder/audio/Param.h"
+#include "cinder/audio/Source.h"
+#include "cinder/audio/Target.h"
+#include "cinder/audio/Utilities.h"
+#include "cinder/audio/Voice.h"
+#include "cinder/audio/WaveTable.h"
+
+// audio::Nodes
+#include "cinder/audio/Node.h"
+#include "cinder/audio/NodeEffects.h"
+#include "cinder/audio/NodeMath.h"
+#include "cinder/audio/ChannelRouterNode.h"
+#include "cinder/audio/GenNode.h"
+#include "cinder/audio/MonitorNode.h"
+#include "cinder/audio/InputNode.h"
+#include "cinder/audio/OutputNode.h"
+#include "cinder/audio/SamplePlayerNode.h"
+#include "cinder/audio/SampleRecorderNode.h"
+
+// audio::dsp
+#include "cinder/audio/dsp/Dsp.h"
+#include "cinder/audio/dsp/Biquad.h"
+#include "cinder/audio/dsp/Converter.h"
+#include "cinder/audio/dsp/Fft.h"
+#include "cinder/audio/dsp/RingBuffer.h"

--- a/samples/_audio/BufferPlayer/src/BufferPlayerApp.cpp
+++ b/samples/_audio/BufferPlayer/src/BufferPlayerApp.cpp
@@ -1,9 +1,7 @@
 #include "cinder/app/App.h"
 #include "cinder/app/RendererGl.h"
 
-#include "cinder/audio/Context.h"
-#include "cinder/audio/NodeEffects.h"
-#include "cinder/audio/SamplePlayerNode.h"
+#include "cinder/audio/audio.h"
 
 #include "Resources.h"
 #include "../../common/AudioDrawUtils.h"

--- a/vc2013/cinder.vcxproj
+++ b/vc2013/cinder.vcxproj
@@ -663,6 +663,7 @@
     <ClInclude Include="..\include\cinder\app\winrt\AppImplWinRTBasic.h" />
     <ClInclude Include="..\include\cinder\app\winrt\PlatformWinRt.h" />
     <ClInclude Include="..\include\cinder\app\winrt\WinRTApp.h" />
+    <ClInclude Include="..\include\cinder\audio\audio.h" />
     <ClInclude Include="..\include\cinder\audio\Buffer.h" />
     <ClInclude Include="..\include\cinder\audio\ChannelRouterNode.h" />
     <ClInclude Include="..\include\cinder\audio\Context.h" />

--- a/vc2013/cinder.vcxproj.filters
+++ b/vc2013/cinder.vcxproj.filters
@@ -1640,5 +1640,8 @@
     <ClInclude Include="..\include\cinder\Breakpoint.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\cinder\audio\audio.h">
+      <Filter>Header Files\audio</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/vc2013_winrt/cinder.vcxproj
+++ b/vc2013_winrt/cinder.vcxproj
@@ -305,6 +305,7 @@
     <ClInclude Include="..\include\cinder\app\winrt\WindowImplWinRt.h" />
     <ClInclude Include="..\include\cinder\Arcball.h" />
     <ClInclude Include="..\include\cinder\Area.h" />
+    <ClInclude Include="..\include\cinder\audio\audio.h" />
     <ClInclude Include="..\include\cinder\audio\Buffer.h" />
     <ClInclude Include="..\include\cinder\audio\ChannelRouterNode.h" />
     <ClInclude Include="..\include\cinder\audio\Context.h" />

--- a/vc2013_winrt/cinder.vcxproj.filters
+++ b/vc2013_winrt/cinder.vcxproj.filters
@@ -724,6 +724,9 @@
     <ClInclude Include="..\include\cinder\Breakpoint.h">
       <Filter>Header Files\gl</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\cinder\audio\audio.h">
+      <Filter>Header Files\audio</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\cinder\app\RendererDx.cpp">

--- a/xcode/cinder.xcodeproj/project.pbxproj
+++ b/xcode/cinder.xcodeproj/project.pbxproj
@@ -1544,6 +1544,7 @@
 		116C06221ABD2C06004D8297 /* scoped.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = scoped.cpp; path = gl/scoped.cpp; sourceTree = "<group>"; };
 		116C06231ABD2C06004D8297 /* wrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wrapper.cpp; path = gl/wrapper.cpp; sourceTree = "<group>"; };
 		117C98081AC534C300957DC6 /* Breakpoint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Breakpoint.h; sourceTree = "<group>"; };
+		117C98151AC6815400957DC6 /* audio.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = audio.h; sourceTree = "<group>"; };
 		1181F7C31A7F8760001BBFA2 /* AppBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppBase.h; path = app/AppBase.h; sourceTree = "<group>"; };
 		1181F7C71A7F8792001BBFA2 /* AppBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AppBase.cpp; path = app/AppBase.cpp; sourceTree = "<group>"; };
 		118CA4081A9427F700841458 /* AppMac.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = AppMac.cpp; sourceTree = "<group>"; };
@@ -2622,6 +2623,7 @@
 				111A5EF6191F726A005C3166 /* cocoa */,
 				111A5F00191F726A005C3166 /* dsp */,
 				111A5F0F191F726A005C3166 /* msw */,
+				117C98151AC6815400957DC6 /* audio.h */,
 				111A5EF4191F726A005C3166 /* Buffer.h */,
 				111A5EF5191F726A005C3166 /* ChannelRouterNode.h */,
 				111A5EFC191F726A005C3166 /* Context.h */,


### PR DESCRIPTION
closes #740 

Convenience header file that includes most of the `ci::audio` namespace.