### PR TITLE
Signal Connections can be blocked/unblocked.

### DIFF
--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -52,6 +52,28 @@ bool Connection::isConnected() const
 	return ! mDisconnector.expired() && mLink;
 }
 
+void Connection::block()
+{
+	if( mLink ) {
+		mLink->block();
+	}
+}
+
+void Connection::unblock()
+{
+	if( mLink ) {
+		mLink->unblock();
+	}
+}
+
+bool Connection::isActive() const
+{
+	if( mLink ) {
+		return mLink->isActive();
+	}
+	return false;
+}
+
 ScopedConnection::ScopedConnection()
 {
 }

--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -52,24 +52,24 @@ bool Connection::isConnected() const
 	return ! mDisconnector.expired() && mLink;
 }
 
-void Connection::block()
+void Connection::disable()
 {
 	if( mLink ) {
-		mLink->block();
+		mLink->disable();
 	}
 }
 
-void Connection::unblock()
+void Connection::enable()
 {
 	if( mLink ) {
-		mLink->unblock();
+		mLink->enable();
 	}
 }
 
-bool Connection::isActive() const
+bool Connection::isEnabled() const
 {
 	if( mLink ) {
-		return mLink->isActive();
+		return mLink->isEnabled();
 	}
 	return false;
 }

--- a/test/SignalsTest/src/SignalsTest.cpp
+++ b/test/SignalsTest/src/SignalsTest.cpp
@@ -496,6 +496,28 @@ struct TestCollectorAppEvent {
 	}
 };
 
+struct TestConnectionToggling {
+	static void run()
+	{
+		Signal<void (int)> signal;
+		int sum = 0;
+
+		auto connection = signal.connect( [&]( int amount ){ sum += amount; } );
+		signal.emit( 5 );
+		assert( sum == 5 );
+
+		connection.disable();
+		signal.emit( 5 );
+		assert( ! connection.isEnabled() );
+		assert( sum == 5 );
+
+		connection.enable();
+		signal.emit( 5 );
+		assert( connection.isEnabled() );
+		assert( sum == 10 );
+	}
+};
+
 template <typename TestT>
 void runTest()
 {
@@ -518,5 +540,6 @@ int main()
 	runTest<TestCollectorBooleanAnd>();
 	runTest<TestCollectorBitwiseAnd>();
 	runTest<TestCollectorAppEvent>();
+	runTest<TestConnectionToggling>();
 	return 0;
 }

--- a/test/SignalsTest/xcode/SignalsTest.xcodeproj/project.pbxproj
+++ b/test/SignalsTest/xcode/SignalsTest.xcodeproj/project.pbxproj
@@ -85,7 +85,10 @@
 				1168DB5B1A8D9B5200660ED3 /* Frameworks */,
 				1118C09719AD3AC500F0D18B /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 1;
 		};
 		1118C09719AD3AC500F0D18B /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
boost::signals2 provided a shared_connection_block type that let users temporarily block calling of a given connection. This was pretty useful for pausing/unpausing type behavior.

This adds a `block`/`unblock` method pair to `ci::signals::Connection` that lets users temporarily suspend calling of a connected function.