### PR TITLE
added missing includes to opengl samples

### DIFF
--- a/samples/_opengl/Cube/src/CubeApp.cpp
+++ b/samples/_opengl/Cube/src/CubeApp.cpp
@@ -4,6 +4,7 @@
 #include "cinder/gl/Batch.h"
 #include "cinder/gl/VboMesh.h"
 #include "cinder/gl/Texture.h"
+#include "cinder/gl/scoped.h"
 #include "cinder/ImageIo.h"
 #include "cinder/Utilities.h"
 

--- a/samples/_opengl/FBOBasic/src/FBOBasicApp.cpp
+++ b/samples/_opengl/FBOBasic/src/FBOBasicApp.cpp
@@ -3,6 +3,8 @@
 #include "cinder/Camera.h"
 #include "cinder/gl/Shader.h"
 #include "cinder/gl/Fbo.h"
+#include "cinder/gl/draw.h"
+#include "cinder/gl/scoped.h"
 
 using namespace ci;
 using namespace ci::app;

--- a/samples/_opengl/HighDynamicRange/src/HighDynamicRangeApp.cpp
+++ b/samples/_opengl/HighDynamicRange/src/HighDynamicRangeApp.cpp
@@ -2,6 +2,8 @@
 #include "cinder/app/RendererGl.h"
 #include "cinder/gl/GlslProg.h"
 #include "cinder/gl/Texture.h"
+#include "cinder/gl/draw.h"
+#include "cinder/gl/scoped.h"
 
 using namespace ci;
 using namespace ci::app;

--- a/samples/_opengl/MotionBlurFbo/src/MotionBlurFboApp.cpp
+++ b/samples/_opengl/MotionBlurFbo/src/MotionBlurFboApp.cpp
@@ -14,6 +14,8 @@
 #include "cinder/gl/VboMesh.h"
 #include "cinder/gl/Fbo.h"
 #include "cinder/gl/Shader.h"
+#include "cinder/gl/draw.h"
+#include "cinder/gl/scoped.h"
 
 using namespace ci;
 using namespace ci::app;

--- a/samples/_opengl/NormalMappingBasic/src/NormalMappingBasicApp.cpp
+++ b/samples/_opengl/NormalMappingBasic/src/NormalMappingBasicApp.cpp
@@ -4,6 +4,7 @@
 #include "cinder/gl/Batch.h"
 #include "cinder/gl/VboMesh.h"
 #include "cinder/gl/Texture.h"
+#include "cinder/gl/scoped.h"
 #include "cinder/ImageIo.h"
 #include "cinder/Utilities.h"
 

--- a/samples/_opengl/PickingFBO/src/PickingFBOApp.cpp
+++ b/samples/_opengl/PickingFBO/src/PickingFBOApp.cpp
@@ -4,6 +4,8 @@
 #include "cinder/gl/Shader.h"
 #include "cinder/gl/Fbo.h"
 #include "cinder/gl/Batch.h"
+#include "cinder/gl/draw.h"
+#include "cinder/gl/scoped.h"
 #include "cinder/MayaCamUI.h"
 #include "cinder/Utilities.h"
 #include "cinder/CinderAssert.h"

--- a/samples/_opengl/TessellationBezier/src/TessellationBezierApp.cpp
+++ b/samples/_opengl/TessellationBezier/src/TessellationBezierApp.cpp
@@ -3,6 +3,7 @@
 #include "cinder/gl/Batch.h"
 #include "cinder/gl/GlslProg.h"
 #include "cinder/gl/VboMesh.h"
+#include "cinder/gl/draw.h"
 
 using namespace ci;
 using namespace ci::app;


### PR DESCRIPTION
I had to add these missing includes to build the samples in the _opengl sample directory.