### PR TITLE
Add MayaCamUI overloads that take MouseEvent

### DIFF
--- a/include/cinder/MayaCamUI.h
+++ b/include/cinder/MayaCamUI.h
@@ -30,9 +30,8 @@ namespace cinder {
 
 class MayaCamUI {
  public:
-	MayaCamUI() { mInitialCam = mCurrentCam = CameraPersp(); }
-	MayaCamUI( const CameraPersp &aInitialCam ) { mInitialCam = mCurrentCam = aInitialCam; }
-	
+	MayaCamUI()									{ mInitialCam = mCurrentCam = CameraPersp(); }
+	MayaCamUI( const CameraPersp &initialCam )	{ mInitialCam = mCurrentCam = initialCam; }
 
 	void mouseDown( const app::MouseEvent &event )
 	{
@@ -113,8 +112,8 @@ class MayaCamUI {
 		}
 	}	
 	
-	const CameraPersp& getCamera() const { return mCurrentCam; }
-	void setCurrentCam( const CameraPersp &aCurrentCam ) { mCurrentCam = aCurrentCam; }
+	const CameraPersp& getCamera() const				{ return mCurrentCam; }
+	void setCurrentCam( const CameraPersp &currentCam ) { mCurrentCam = currentCam; }
 	
  private:
 	enum		{ ACTION_NONE, ACTION_ZOOM, ACTION_PAN, ACTION_TUMBLE };

--- a/include/cinder/MayaCamUI.h
+++ b/include/cinder/MayaCamUI.h
@@ -24,6 +24,7 @@
 
 #include "cinder/Vector.h"
 #include "cinder/Camera.h"
+#include "cinder/app/MouseEvent.h"
 
 namespace cinder {
 
@@ -32,13 +33,31 @@ class MayaCamUI {
 	MayaCamUI() { mInitialCam = mCurrentCam = CameraPersp(); }
 	MayaCamUI( const CameraPersp &aInitialCam ) { mInitialCam = mCurrentCam = aInitialCam; }
 	
+
+	void mouseDown( const app::MouseEvent &event )
+	{
+		mouseDown( event.getPos() );
+	}
+
 	void mouseDown( const ivec2 &mousePos )
 	{
 		mInitialMousePos = mousePos;
 		mInitialCam = mCurrentCam;
 		mLastAction = ACTION_NONE;
 	}
-	
+
+	void mouseDrag( const app::MouseEvent &event )
+	{
+		bool isLeftDown = event.isLeftDown();
+		bool isMiddleDown = event.isMiddleDown() || event.isAltDown();
+		bool isRightDown = event.isRightDown() || event.isMetaDown();
+
+		if( isMiddleDown )
+			isLeftDown = false;
+
+		mouseDrag( event.getPos(), isLeftDown, isMiddleDown, isRightDown );
+	}
+
 	void mouseDrag( const ivec2 &mousePos, bool leftDown, bool middleDown, bool rightDown )
 	{
 		int action;

--- a/samples/Geometry/src/GeometryApp.cpp
+++ b/samples/Geometry/src/GeometryApp.cpp
@@ -213,7 +213,7 @@ void GeometryApp::mouseDown( MouseEvent event )
 	mRecenterCamera = false;
 
 	mMayaCam.setCurrentCam( mCamera );
-	mMayaCam.mouseDown( event.getPos() );
+	mMayaCam.mouseDown( event );
 
 	if( getElapsedSeconds() - mLastMouseDownTime < 0.2f ) {
 		mPrimitiveSelected = static_cast<Primitive>( static_cast<int>(mPrimitiveSelected) + 1 );
@@ -225,7 +225,7 @@ void GeometryApp::mouseDown( MouseEvent event )
 
 void GeometryApp::mouseDrag( MouseEvent event )
 {
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
+	mMayaCam.mouseDrag( event );
 	mCamera = mMayaCam.getCamera();
 }
 

--- a/samples/_opengl/NormalMapping/src/NormalMappingApp.cpp
+++ b/samples/_opengl/NormalMapping/src/NormalMappingApp.cpp
@@ -277,7 +277,7 @@ void NormalMappingApp::update()
 	mShaderNormalMapping->uniform( "uLights[1].position", mLightAmbient.position );
 
 #if ! defined( CINDER_GL_ES )
-	if(mShaderWireframe)
+	if( mShaderWireframe )
 		mShaderWireframe->uniform( "uViewportSize", vec2( getWindowSize() ) );
 #endif
 }
@@ -366,12 +366,12 @@ void NormalMappingApp::resize()
 void NormalMappingApp::mouseDown( MouseEvent event )
 {
 	mMayaCamera.setCurrentCam( mCamera );
-	mMayaCamera.mouseDown( event.getPos() );
+	mMayaCamera.mouseDown( event );
 }
 
 void NormalMappingApp::mouseDrag( MouseEvent event )
 {
-	mMayaCamera.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
+	mMayaCamera.mouseDrag( event );
 	mCamera = mMayaCamera.getCamera();
 }
 


### PR DESCRIPTION
This is in order to add support for pan and zoom to touchpads such as mac laptops, which otherwise require the user to add custom mappings.

The `MayaCamUI::mouseDown( MouseEvent )` overload isn't particularly needed, I added it for symmetry.