### PR TITLE
log::manager interface improvments

### DIFF
--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -173,26 +173,26 @@ public:
 
 	void enableConsoleLogging();
 	void disableConsoleLogging();
-	void setConsoleLoggingEnabled( bool b = true )		{ b ? enableConsoleLogging() : disableConsoleLogging(); }
+	void setConsoleLoggingEnabled( bool enable )		{ enable ? enableConsoleLogging() : disableConsoleLogging(); }
 	bool isConsoleLoggingEnabled() const				{ return mConsoleLoggingEnabled; }
 
 	void enableFileLogging( const fs::path &filePath = fs::path(), bool appendToExisting = true );
 	void enableFileLogging( const fs::path &folder, const std::string& formatStr, bool appendToExisting = true);
 	void disableFileLogging();
-	void setFileLoggingEnabled( bool b = true, const fs::path &filePath = fs::path(), bool appendToExisting = true )
-														{ b ? enableFileLogging( filePath, appendToExisting )
+	void setFileLoggingEnabled( bool enable, const fs::path &filePath = fs::path(), bool appendToExisting = true )
+														{ enable ? enableFileLogging( filePath, appendToExisting )
 															: disableFileLogging(); }
 
-	void setFileLoggingEnabled( bool b = true, const fs::path &folder = fs::path(),
+	void setFileLoggingEnabled( bool enable, const fs::path &folder = fs::path(),
 								const std::string& formatStr = "", bool appendToExisting = true )
-														{ b ? enableFileLogging( folder, formatStr, appendToExisting )
+														{ enable ? enableFileLogging( folder, formatStr, appendToExisting )
 															: disableFileLogging(); }
 
 	bool isFileLoggingEnabled() const					{ return mFileLoggingEnabled; }
 
 	void enableSystemLogging();
 	void disableSystemLogging();
-	void setSystemLoggingEnabled( bool b = true )		{ b ? enableSystemLogging() : disableSystemLogging(); }
+	void setSystemLoggingEnabled( bool enable = true )		{ enable ? enableSystemLogging() : disableSystemLogging(); }
 	bool isSystemLoggingEnabled() const					{ return mSystemLoggingEnabled; }
 	void setSystemLoggingLevel( Level level );
 	Level getSystemLoggingLevel() const					{ return mSystemLoggingLevel; }

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -179,15 +179,8 @@ public:
 	void enableFileLogging( const fs::path &filePath = fs::path(), bool appendToExisting = true );
 	void enableFileLogging( const fs::path &folder, const std::string& formatStr, bool appendToExisting = true);
 	void disableFileLogging();
-	void setFileLoggingEnabled( bool enable, const fs::path &filePath = fs::path(), bool appendToExisting = true )
-														{ enable ? enableFileLogging( filePath, appendToExisting )
-															: disableFileLogging(); }
-
-	void setFileLoggingEnabled( bool enable, const fs::path &folder = fs::path(),
-								const std::string& formatStr = "", bool appendToExisting = true )
-														{ enable ? enableFileLogging( folder, formatStr, appendToExisting )
-															: disableFileLogging(); }
-
+	void setFileLoggingEnabled( bool enable, const fs::path &filePath = fs::path(), bool appendToExisting = true );
+	void setFileLoggingEnabled( bool enable, const fs::path &folder, const std::string &formatStr, bool appendToExisting = true );
 	bool isFileLoggingEnabled() const					{ return mFileLoggingEnabled; }
 
 	void enableSystemLogging();

--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -244,6 +244,23 @@ void LogManager::enableFileLogging( const fs::path &folder, const std::string &f
 	mFileLoggingEnabled = true;
 }
 
+void LogManager::setFileLoggingEnabled( bool enable, const fs::path &filePath, bool appendToExisting )
+{
+	if( enable )
+		enableFileLogging( filePath, appendToExisting );
+	else
+		disableFileLogging();
+}
+
+
+void LogManager::setFileLoggingEnabled( bool enable, const fs::path &folder, const string &formatStr, bool appendToExisting )
+{
+	if( enable )
+		enableFileLogging( folder, formatStr, appendToExisting );
+	else
+		disableFileLogging();
+}
+
 void LogManager::enableSystemLogging()
 {
 	if( mSystemLoggingEnabled )


### PR DESCRIPTION
Removed default bool param, which was redundant. Removed default params for `setFileLoggingEnabled()` file-rolling variant, which was ambiguius on VC.