### PR TITLE
ScopedVao const correctness.

### DIFF
--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -38,7 +38,7 @@ typedef std::shared_ptr<class Renderbuffer>		RenderbufferRef;
 
 struct ScopedVao : private Noncopyable {
 	ScopedVao( Vao *vao );
-	ScopedVao( VaoRef &vao );
+	ScopedVao( const VaoRef &vao );
 	~ScopedVao();
 
   private:

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -39,7 +39,7 @@ ScopedVao::ScopedVao( Vao *vao )
 	mCtx->pushVao( vao );
 }
 
-ScopedVao::ScopedVao( VaoRef &vao )
+ScopedVao::ScopedVao( const VaoRef &vao )
 	: mCtx( gl::context() )
 {
 	mCtx->pushVao( vao );


### PR DESCRIPTION
Receive a `const VaoRef &` in constructor.