### PR TITLE
Fixed shader preprocessor for es2 / iOS

### DIFF
--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -23,6 +23,7 @@
 
 #include "cinder/gl/ShaderPreprocessor.h"
 #include "cinder/app/Platform.h"
+#include "cinder/gl/Platform.h"
 #include "cinder/Utilities.h"
 #include "cinder/Log.h"
 
@@ -45,7 +46,7 @@ ShaderPreprocessor::ShaderPreprocessor()
 #if defined( CINDER_GL_ES_3 )
 	mVersion = 300;
 #elif defined( CINDER_GL_ES_2 )
-	mVersion = 110;
+	mVersion = 100;
 #else // desktop
 	mVersion = 150;
 #endif
@@ -85,9 +86,9 @@ std::string ShaderPreprocessor::parseDirectives( const std::string &source )
 	
 	// if we don't have a version yet, add the default one
 	if( version.empty() ) {
-#if defined( CINDER_GL_ES )
-		version = "#version " + to_string( mVersion ) + "es\n";
-#else
+#if defined( CINDER_GL_ES_3 )
+		version = "#version " + to_string( mVersion ) + " es\n";
+#elif defined( CINDER_GL_ES_2 )
 		version = "#version " + to_string( mVersion ) + "\n";
 #endif
 	}

--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -88,7 +88,7 @@ std::string ShaderPreprocessor::parseDirectives( const std::string &source )
 	if( version.empty() ) {
 #if defined( CINDER_GL_ES_3 )
 		version = "#version " + to_string( mVersion ) + " es\n";
-#elif defined( CINDER_GL_ES_2 )
+#else
 		version = "#version " + to_string( mVersion ) + "\n";
 #endif
 	}


### PR DESCRIPTION
This fixes glsl shader support on iOS devices which don't have an explicit version macro. 

• Prior to this change, shaders would not compile on iOS because CINDER_GL_ES is defined in cinder/gl/Platform.h, not cinder/app/Platform.h, and would therefore default to version 150, which is not supported.

• Changed the default ES_2 version to 100, as 110 is not supported on iOS.

• Removed "es" from the version macro in ES_2 (I believe this is ES_3 syntax?)