### PR TITLE
rename Texture::getMaxMaxAnisotropy() -> getMaxAnisotropyMax()

### DIFF
--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -106,7 +106,7 @@ class TextureBase {
 	/** Sets the filtering behavior when a texture is displayed at a higher resolution than its native resolution.
 	 * Possible values are \li \c GL_NEAREST \li \c GL_LINEAR **/
 	void			setMagFilter( GLenum magFilter );
-	//! Sets the anisotropic filtering amount. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxMaxAnisotropy();
+	//! Sets the anisotropic filtering amount. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxAnisotropyMax();
 	void			setMaxAnisotropy( GLfloat maxAnisotropy );
 	//! Returns whether the Texture has Mipmapping enabled
 	bool			hasMipmapping() const { return mMipmapping; }
@@ -131,7 +131,7 @@ class TextureBase {
 	//! calculate the size of mipMap for the corresponding level
 	static ivec2	calcMipLevelSize( int level, GLint width, GLint height );
 	//! Returns the maximum anisotropic filtering maximum allowed by the hardware
-	static GLfloat	getMaxMaxAnisotropy();
+	static GLfloat	getMaxAnisotropyMax();
 
 	//! Returns the Texture's swizzle mask (corresponding to \c GL_TEXTURE_SWIZZLE_RGBA)	
 	std::array<GLint,4>	getSwizzleMask() const { return mSwizzleMask; }
@@ -198,7 +198,7 @@ class TextureBase {
 		void	setMinFilter( GLenum minFilter ) { mMinFilter = minFilter; mMinFilterSpecified = true; }
 		//! Sets the filtering behavior when a texture is displayed at a higher resolution than its native resolution. Default is \c GL_LINEAR.
 		void	setMagFilter( GLenum magFilter ) { mMagFilter = magFilter; }
-		//! Sets the anisotropic filter amount. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxMaxAnisotropy();
+		//! Sets the anisotropic filter amount. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxAnisotropyMax();
 		void    setMaxAnisotropy( GLfloat maxAnisotropy ) { mMaxAnisotropy = maxAnisotropy; }
 		
 		//! Returns the texture's target
@@ -384,7 +384,7 @@ class Texture1d : public TextureBase {
 		//! Sets the target, defaults to \c GL_TEXTURE_1D
 		Format& target( GLenum target ) { mTarget = target; return *this; }
 		Format& mipmap( bool enableMipmapping = true ) { mMipmapping = enableMipmapping; return *this; }
-		//! Sets the maximum amount of anisotropic filtering. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxMaxAnisotropy();
+		//! Sets the maximum amount of anisotropic filtering. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxAnisotropyMax();
 		Format& maxAnisotropy( float maxAnisotropy ) { mMaxAnisotropy = maxAnisotropy; return *this; }
 		Format& internalFormat( GLint internalFormat ) { mInternalFormat = internalFormat; return *this; }
 		Format& wrap( GLenum wrap ) { mWrapS = wrap; return *this; }
@@ -439,7 +439,7 @@ class Texture2d : public TextureBase {
 		//! Chaining functions for Format class.
 		Format& target( GLenum target ) { mTarget = target; return *this; }
 		Format& mipmap( bool enableMipmapping = true ) { mMipmapping = enableMipmapping; return *this; }
-		//! Sets the maximum amount of anisotropic filtering. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxMaxAnisotropy();
+		//! Sets the maximum amount of anisotropic filtering. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxAnisotropyMax();
 		Format& maxAnisotropy( float maxAnisotropy ) { mMaxAnisotropy = maxAnisotropy; return *this; }
 		//! Specifies the internal format for the Texture, used by glTexImage2D or glTexStorage2D when available. Defaults to \c -1 which implies automatic determination.
 		Format& internalFormat( GLint internalFormat ) { mInternalFormat = internalFormat; return *this; }
@@ -615,7 +615,7 @@ class Texture3d : public TextureBase {
 		//! Sets the target, defaults to \c GL_TEXTURE_3D, also supports \c GL_TEXTURE_2D_ARRAY
 		Format& target( GLenum target ) { mTarget = target; return *this; }
 		Format& mipmap( bool enableMipmapping = true ) { mMipmapping = enableMipmapping; return *this; }
-		//! Sets the maximum amount of anisotropic filtering. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxMaxAnisotropy();
+		//! Sets the maximum amount of anisotropic filtering. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxAnisotropyMax();
 		Format& maxAnisotropy( float maxAnisotropy ) { mMaxAnisotropy = maxAnisotropy; return *this; }
 		Format& internalFormat( GLint internalFormat ) { mInternalFormat = internalFormat; return *this; }
 		Format& wrap( GLenum wrap ) { mWrapS = mWrapT = mWrapR = wrap; return *this; }
@@ -670,7 +670,7 @@ class TextureCubeMap : public TextureBase
 		//! Chaining functions for Format class.
 		Format& target( GLenum target ) { mTarget = target; return *this; }
 		Format& mipmap( bool enableMipmapping = true ) { mMipmapping = enableMipmapping; return *this; }
-		//! Sets the maximum amount of anisotropic filtering. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxMaxAnisotropy();
+		//! Sets the maximum amount of anisotropic filtering. A value greater than 1.0 "enables" anisotropic filtering. Maximum of getMaxAnisotropyMax();
 		Format& maxAnisotropy( float maxAnisotropy ) { mMaxAnisotropy = maxAnisotropy; return *this; }
 		Format& internalFormat( GLint internalFormat ) { mInternalFormat = internalFormat; return *this; }
 		Format& wrap( GLenum wrap ) { mWrapS = mWrapT = mWrapR = wrap; return *this; }

--- a/samples/_opengl/MipMap/src/MipMapApp.cpp
+++ b/samples/_opengl/MipMap/src/MipMapApp.cpp
@@ -136,7 +136,7 @@ void TextureMipmappingApp::setup()
 	int heightFraction = getWindowHeight() / 10;
 	
 	// getting max Anisotropic maximum sampling available on the graphics card above 1
-	mMaxAnisoFilterAmount = gl::Texture::getMaxMaxAnisotropy() - 1.0f;
+	mMaxAnisoFilterAmount = gl::Texture::getMaxAnisotropyMax() - 1.0f;
 	
 	mLeftControl = shared_ptr<FilterControl>( new FilterControl( Rectf( widthFraction - 50, heightFraction * 1, widthFraction + 50, heightFraction * 1 + 30 ),
 													Rectf( widthFraction - 50, heightFraction * 2, widthFraction + 50, heightFraction * 2 + 30 ),

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -601,11 +601,11 @@ int TextureBase::requiredMipLevels( GLint width, GLint height, GLint depth )
 	return floor( std::log2( maxDim ) ) + 1;
 }
 
-GLfloat TextureBase::getMaxMaxAnisotropy()
+GLfloat TextureBase::getMaxAnisotropyMax()
 {
-	GLfloat maxMaxAnisotropy;
-	glGetFloatv( GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxMaxAnisotropy );
-	return maxMaxAnisotropy;
+	GLfloat maxAnisotropyMax;
+	glGetFloatv( GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAnisotropyMax );
+	return maxAnisotropyMax;
 }
 
 bool TextureBase::supportsHardwareSwizzle()


### PR DESCRIPTION
There's a few benefits to this rename that I see:

* reads a little clearer
* doesn't look funny 
* auto completes nicely