### PR TITLE
Avoid NSWindow warning on contentView assignment

### DIFF
--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -818,8 +818,9 @@ using namespace cinder::app;
 															highDensityDisplay:appImpl->mApp->isHighDensityDisplayEnabled()
 															enableMultiTouch:appImpl->mApp->isMultiTouchEnabled()];
 
-	[winImpl->mWin setDelegate:self];	
-	[winImpl->mWin setContentView:winImpl->mCinderView];
+	[winImpl->mWin setDelegate:self];
+	// add CinderView as subview of window's content view to avoid NSWindow warning: https://github.com/cinder/Cinder/issues/584
+	[winImpl->mWin.contentView addSubview:winImpl->mCinderView];
 
 	[winImpl->mWin makeKeyAndOrderFront:nil];
 	// after showing the window, the size may have changed (see NSWindow::constrainFrameRect) so we need to update our internal variable


### PR DESCRIPTION
Resolves #584 (or at least works around it).

When a window's content view is directly assigned, an odd warning is spewed to the console about an unknown subview being added to `NSThemeFrame`, which is occurring in AppKit - this can be sidestepped by instead adding the CinderView as a subview of the window's content view.