### PR TITLE
Ignore non-core CinderBlocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ ipch/
 # doxygen generated files
 docs/html
 docs/doxygen/cinder.tag
+
+# CinderBlocks
+blocks/
+!blocks/[__AppTemplates,Box2D,Cairo,FMOD,LocationManager,MotionManager,OSC,QuickTime,TUIO]
+


### PR DESCRIPTION
My local Cinder repo state is usually a bit polluted with statuses of a bunch of unknown non-core CinderBlocks and this tweak will ignore them. One catch is that if a new block were added or renamed, it would need to be reflected in the ignore file as well - initially I thought this was going to be a big deal, but it doesn't appear as though a block has been added in quite some time.

While I'm not sure others will find this as useful as I do, I thought I'd at least propose it.