### PR TITLE
sample updates for those who use MayaCamUI

### DIFF
--- a/include/cinder/MayaCamUI.h
+++ b/include/cinder/MayaCamUI.h
@@ -162,6 +162,9 @@ class MayaCamUI {
 	
 	const CameraPersp& getCamera() const				{ return *mCamera; }
 	void setCurrentCam( const CameraPersp &currentCam ) { *mCamera = currentCam; }
+
+	//! Convenience routine to set the internal Camera's aspect ratio
+	void setAspectRatio( float aspectRatio )	{ mCamera->setAspectRatio( aspectRatio ); }
 	
  private:
 	enum		{ ACTION_NONE, ACTION_ZOOM, ACTION_PAN, ACTION_TUMBLE };

--- a/samples/FrustumCullingRedux/src/FrustumCullingReduxApp.cpp
+++ b/samples/FrustumCullingRedux/src/FrustumCullingReduxApp.cpp
@@ -46,19 +46,16 @@ using namespace std;
 
 class FrustumCullingReduxApp : public App {
   public:
-	void prepareSettings( Settings *settings );
-	void setup();
-	void update();
-	void draw();
+	static void prepareSettings( Settings *settings );
+	void setup() override;
+	void keyDown( KeyEvent event ) override;
+	void update() override;
+	void draw() override;
 	
 	void toggleCullableFov();
 	void drawCullableFov();
 
-	void mouseDown( MouseEvent event );
-	void mouseDrag( MouseEvent event );
 
-	void keyDown( KeyEvent event );
-	
   protected:
 	//! load the heart shaped mesh 
 	void			loadObject();
@@ -105,7 +102,8 @@ class FrustumCullingReduxApp : public App {
 	gl::Texture2dRef	mHelp;
 };
 
-void FrustumCullingReduxApp::prepareSettings(Settings *settings)
+// static
+void FrustumCullingReduxApp::prepareSettings( Settings *settings )
 {
 	// setup our window
 	settings->setWindowSize( 1200, 675 );
@@ -164,7 +162,8 @@ void FrustumCullingReduxApp::setup()
 	mRenderCam.setPerspective( mCullingFov, getWindowAspectRatio(), 10, 10000 );
 	mRenderCam.lookAt( vec3( 200 ), vec3( 0 ) );
 	
-	mMayaCam.setCurrentCam( mRenderCam );
+	mMayaCam = MayaCamUI( &mRenderCam );
+	mMayaCam.connect( getWindow() );
 
 	// track current time so we can calculate elapsed time
 	mCurrentSeconds = getElapsedSeconds();
@@ -285,17 +284,6 @@ void FrustumCullingReduxApp::draw()
 		gl::draw( mHelp );
 		gl::disableAlphaBlending();
 	}
-}
-
-void FrustumCullingReduxApp::mouseDown( MouseEvent event )
-{
-	mMayaCam.mouseDown( event.getPos() );
-}
-
-void FrustumCullingReduxApp::mouseDrag( MouseEvent event )
-{
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
-	mRenderCam = mMayaCam.getCamera();
 }
 
 void FrustumCullingReduxApp::keyDown( KeyEvent event )
@@ -439,4 +427,4 @@ void FrustumCullingReduxApp::renderHelpToTexture()
 	mHelp = gl::Texture::create( layout.render( true, false ) );
 }
 
-CINDER_APP( FrustumCullingReduxApp, RendererGl )
+CINDER_APP( FrustumCullingReduxApp, RendererGl, FrustumCullingReduxApp::prepareSettings )

--- a/samples/Picking3D/src/Picking3DApp.cpp
+++ b/samples/Picking3D/src/Picking3DApp.cpp
@@ -16,8 +16,7 @@
 
 #include "cinder/app/App.h"
 #include "cinder/app/RendererGl.h"
-#include "cinder/gl/Texture.h"
-#include "cinder/gl/GlslProg.h"
+#include "cinder/gl/gl.h"
 #include "cinder/ImageIo.h"
 #include "cinder/MayaCamUI.h"
 #include "cinder/Rand.h"
@@ -289,7 +288,7 @@ void Picking3DApp::mouseMove( MouseEvent event )
 void Picking3DApp::mouseDown( MouseEvent event )
 {	
 	// let the camera handle the interaction
-	mMayaCam.mouseDown( event.getPos() );
+	mMayaCam.mouseDown( event );
 }
 
 void Picking3DApp::mouseDrag( MouseEvent event )
@@ -297,8 +296,8 @@ void Picking3DApp::mouseDrag( MouseEvent event )
 	// keep track of the mouse
 	mMousePos = event.getPos();
 
-	// let the camera handle the interaction
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
+	// let the MayaCamUI handle the interaction
+	mMayaCam.mouseDrag( event );
 }
 
 void Picking3DApp::resize()

--- a/samples/StereoscopicRendering/src/StereoscopicRenderingApp.cpp
+++ b/samples/StereoscopicRendering/src/StereoscopicRenderingApp.cpp
@@ -65,10 +65,10 @@ using namespace std;
 
 class StereoscopicRenderingApp : public App {
 public:
-	typedef enum { SET_CONVERGENCE, SET_FOCUS, AUTO_FOCUS } FocusMethod;
-	typedef enum { MONO, ANAGLYPH_RED_CYAN, SIDE_BY_SIDE, OVER_UNDER, INTERLACED_HORIZONTAL } RenderMethod;
+	enum FocusMethod { SET_CONVERGENCE, SET_FOCUS, AUTO_FOCUS };
+	enum RenderMethod { MONO, ANAGLYPH_RED_CYAN, SIDE_BY_SIDE, OVER_UNDER, INTERLACED_HORIZONTAL };
 
-	typedef struct InstanceData {
+	struct InstanceData {
 		vec3 position;
 		vec3 color;
 	};

--- a/samples/StereoscopicRendering/src/StereoscopicRenderingApp.cpp
+++ b/samples/StereoscopicRendering/src/StereoscopicRenderingApp.cpp
@@ -318,13 +318,13 @@ void StereoscopicRenderingApp::draw()
 void StereoscopicRenderingApp::mouseDown( MouseEvent event )
 {
 	// Handle user interaction.
-	mMayaCam.mouseDown( event.getPos() );
+	mMayaCam.mouseDown( event );
 }
 
 void StereoscopicRenderingApp::mouseDrag( MouseEvent event )
 {
 	// Handle user interaction.
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
+	mMayaCam.mouseDrag( event );
 
 	// Update stereoscopic camera.
 	mCamera.setEyePoint( mMayaCam.getCamera().getEyePoint() );

--- a/samples/_opengl/DeferredShading/src/DeferredShadingApp.cpp
+++ b/samples/_opengl/DeferredShading/src/DeferredShadingApp.cpp
@@ -23,8 +23,6 @@ public:
 	DeferredShadingApp();
 
 	void						draw() override;
-	void						mouseDown( ci::app::MouseEvent event ) override;
-	void						mouseDrag( ci::app::MouseEvent event ) override;
 	void						resize() override;
 	void						update() override;
 private:
@@ -101,6 +99,7 @@ DeferredShadingApp::DeferredShadingApp()
 	cam.setEyePoint( vec3( -2.221f, -4.083f, 15.859f ) );
 	cam.setCenterOfInterestPoint( vec3( -0.635f, -4.266f, 1.565f ) );
 	mMayaCam.setCurrentCam( cam );
+	mMayaCam.connect( getWindow(), -1 ); // set priority to be lower than InterfaceGl
 
 	// Set up parameters
 	mParams = params::InterfaceGl::create( "Params", ivec2( 220, 220 ) );
@@ -389,16 +388,6 @@ void DeferredShadingApp::loadShaders()
 	mBatchLBufferCube->getGlslProg()->uniform(	"uSamplerNormalEmissive",	1 );
 	mBatchLBufferCube->getGlslProg()->uniform(	"uSamplerPosition",			2 );
 	mBatchLBufferCube->getGlslProg()->uniform(	"uSamplerShadowMap",		3 );
-}
-
-void DeferredShadingApp::mouseDown( MouseEvent event )
-{
-	mMayaCam.mouseDown( event.getPos() );
-}
-
-void DeferredShadingApp::mouseDrag( MouseEvent event )
-{
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
 }
 
 void DeferredShadingApp::resize()

--- a/samples/_opengl/DeferredShadingAdvanced/src/DeferredShadingAdvancedApp.cpp
+++ b/samples/_opengl/DeferredShadingAdvanced/src/DeferredShadingAdvancedApp.cpp
@@ -38,8 +38,6 @@ public:
 	DeferredShadingAdvancedApp();
 
 	void						draw() override;
-	void						mouseDown( ci::app::MouseEvent event ) override;
-	void						mouseDrag( ci::app::MouseEvent event ) override;
 	void						resize() override;
 	void						update() override;
 private:
@@ -170,6 +168,7 @@ DeferredShadingAdvancedApp::DeferredShadingAdvancedApp()
 	cam.setEyePoint( vec3( 2.664f, -6.484f, 5.939f ) );
 	cam.setCenterOfInterestPoint( vec3( 0.469f, -5.430f, 1.146f ) );
 	mMayaCam.setCurrentCam( cam );
+	mMayaCam.connect( getWindow(), -1 ); // set priority to be lower than InterfaceGl
 
 	// Set up parameters
 	mParams = params::InterfaceGl::create( "Params", ivec2( 220, 300 ) );
@@ -768,16 +767,6 @@ void DeferredShadingAdvancedApp::loadShaders()
 	mBatchDebugRect->getGlslProg()->uniformBlock( 0, 0 );
 	mBatchEmissiveRect->getGlslProg()->uniformBlock( 0, 0 );
 	mBatchLBufferCube->getGlslProg()->uniformBlock( 0, 0 );
-}
-
-void DeferredShadingAdvancedApp::mouseDown( MouseEvent event )
-{
-	mMayaCam.mouseDown( event.getPos() );
-}
-
-void DeferredShadingAdvancedApp::mouseDrag( MouseEvent event )
-{
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
 }
 
 void DeferredShadingAdvancedApp::resize()

--- a/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
+++ b/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
@@ -21,15 +21,12 @@ class ObjLoaderApp : public App {
 	void	setup() override;
 	void	resize() override;
 
-	void	mouseDown( MouseEvent event ) override;
-	void	mouseDrag( MouseEvent event ) override;
 	void	keyDown( KeyEvent event ) override;
 
 	void	loadObjFile( const fs::path &filePath );
 	void	frameCurrentObject();
 	void	draw() override;
 	
-	Arcball			mArcball;
 	MayaCamUI		mMayaCam;
 	TriMeshRef		mMesh;
 	gl::BatchRef	mBatch;
@@ -49,34 +46,20 @@ void ObjLoaderApp::setup()
 	CameraPersp initialCam;
 	initialCam.setPerspective( 45.0f, getWindowAspectRatio(), 0.1, 10000 );
 	mMayaCam.setCurrentCam( initialCam );
+	mMayaCam.connect( getWindow() );
 
 	mCheckerTexture = gl::Texture::create( ip::checkerboard( 512, 512, 32 ) );
 	mCheckerTexture->bind( 0 );
 
 	loadObjFile( getAssetPath( "8lbs.obj" ) );
+
+	gl::enableDepthWrite();
+	gl::enableDepthRead();
 }
 
 void ObjLoaderApp::resize()
 {
-	mArcball.setWindowSize( getWindowSize() );
-	mArcball.setCenter( vec2( getWindowWidth() / 2.0f, getWindowHeight() / 2.0f ) );
-	mArcball.setRadius( 150 );
-}
-
-void ObjLoaderApp::mouseDown( MouseEvent event )
-{
-	if( event.isAltDown() )
-		mMayaCam.mouseDown( event.getPos() );
-	else
-		mArcball.mouseDown( event.getPos() );
-}
-
-void ObjLoaderApp::mouseDrag( MouseEvent event )
-{
-	if( event.isAltDown() )
-		mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
-	else
-		mArcball.mouseDrag( event.getPos() );
+	mMayaCam.setAspectRatio( getWindowAspectRatio() );
 }
 
 void ObjLoaderApp::loadObjFile( const fs::path &filePath )
@@ -110,18 +93,13 @@ void ObjLoaderApp::keyDown( KeyEvent event )
 
 void ObjLoaderApp::draw()
 {
-	gl::enableDepthWrite();
-	gl::enableDepthRead();
-	
 	gl::clear( Color( 0.0f, 0.1f, 0.2f ) );
-
 	gl::setMatrices( mMayaCam.getCamera() );
 
-	gl::pushMatrices();
-		gl::rotate( mArcball.getQuat() );
-		mBatch->draw();
-	gl::popMatrices();
+	mBatch->draw();
 }
 
 
-CINDER_APP( ObjLoaderApp, RendererGl )
+CINDER_APP( ObjLoaderApp, RendererGl, []( App::Settings *settings ) {
+	settings->setMultiTouchEnabled( false );
+} )

--- a/samples/_opengl/PickingFBO/src/PickingFBOApp.cpp
+++ b/samples/_opengl/PickingFBO/src/PickingFBOApp.cpp
@@ -169,14 +169,14 @@ void PickingFBOApp::mouseDown( MouseEvent event )
 		setSelectedColors( selection );
 	}
 	else {
-		mMayaCam.mouseDown( mPickPos );
+		mMayaCam.mouseDown( event );
 	}
 	mNeedsRedraw = true;
 }
 
 void PickingFBOApp::mouseDrag( MouseEvent event )
 {
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
+	mMayaCam.mouseDrag( event );
 	mNeedsRedraw = true;
 }
 

--- a/samples/_opengl/ShadowMapping/src/ShadowMappingApp.cpp
+++ b/samples/_opengl/ShadowMapping/src/ShadowMappingApp.cpp
@@ -201,6 +201,8 @@ void ShadowMappingApp::setup()
 	mParams->addParam( "Auto normal slope offset", &mEnableNormSlopeOffset );
 	mParams->addParam( "Num samples", &mNumRandomSamples ).min( 1 );
 //	mParams->minimize();
+
+	mMayaCam.connect( getWindow() );
 	
 	auto positionGlsl = gl::getStockShader( gl::ShaderDef() );
 	
@@ -331,7 +333,6 @@ void ShadowMappingApp::draw()
 void ShadowMappingApp::mouseDown( MouseEvent event )
 {
 	mMousePos = event.getPos();
-	mMayaCam.mouseDown( mMousePos );
 }
 
 void ShadowMappingApp::mouseMove( MouseEvent event )
@@ -342,11 +343,6 @@ void ShadowMappingApp::mouseMove( MouseEvent event )
 void ShadowMappingApp::mouseDrag( MouseEvent event )
 {
 	mMousePos = event.getPos();
-	
-	// Added/hacked support for international mac laptop keyboards.
-	bool middle = event.isMiddleDown() || ( event.isMetaDown() && event.isLeftDown() );
-	bool right = event.isRightDown() || ( event.isControlDown() && event.isLeftDown() );
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown() && !middle && !right, middle, right );
 }
 
 void ShadowMappingApp::keyDown( KeyEvent event )

--- a/samples/rayMarcher/src/rayMarcherApp.cpp
+++ b/samples/rayMarcher/src/rayMarcherApp.cpp
@@ -18,15 +18,14 @@ class RayMarcherApp : public App {
  public:	
 	RayMarcherApp() : mMarcher( &mMayaCam.getCamera() ) {}
 	
-	void		prepareSettings( Settings *settings );
+	static void	prepareSettings( Settings *settings );
 
-	void		setup();
-	void		mouseDown( MouseEvent event );
-	void		mouseDrag( MouseEvent event );
-	void		keyDown( KeyEvent event );	
-	void		resize();
-	void		update();
-	void		draw();
+	void		setup() override;
+	void		mouseDrag( MouseEvent event ) override;
+	void		keyDown( KeyEvent event ) override;
+	void		resize() override;
+	void		update() override;
+	void		draw() override;
 
 	std::shared_ptr<Surface8u>	mImageSurface;
 	gl::Texture2dRef			mImageTexture;
@@ -39,6 +38,7 @@ class RayMarcherApp : public App {
 	gl::GlslProgRef	mGlsl;
 };
 
+// static
 void RayMarcherApp::prepareSettings( Settings *settings )
 {
 	settings->setWindowSize( 400, 300 );
@@ -54,6 +54,8 @@ void RayMarcherApp::setup()
 	cam.lookAt( mStartEyePoint, vec3( 0 ), vec3( 0, 1, 0 ) );
 	cam.setCenterOfInterest( distance( mStartEyePoint, vec3( 0 ) ) );
 	mMayaCam.setCurrentCam( cam );
+	mMayaCam.connect( getWindow() );
+	mMarcher = RayMarcher( &mMayaCam.getCamera() );
 	
 	mGlsl = gl::GlslProg::create( gl::GlslProg::Format()
 								 .vertex( CI_GLSL( 150,
@@ -79,15 +81,9 @@ void RayMarcherApp::setup()
 													) ) );
 }
 
-void RayMarcherApp::mouseDown( MouseEvent event )
-{		
-	mMayaCam.mouseDown( event.getPos() );
-}
-
 void RayMarcherApp::mouseDrag( MouseEvent event )
 {
-	mMayaCam.mouseDrag( event.getPos(), event.isLeftDown(), event.isMiddleDown(), event.isRightDown() );
-	mCurrentLine = 0;	
+	mCurrentLine = 0;
 }
 
 void RayMarcherApp::keyDown( KeyEvent event )
@@ -142,4 +138,4 @@ void RayMarcherApp::draw()
 					   vec2( 1, 1 - mCurrentLine / float(mImageTexture->getHeight()) ) );
 }
 
-CINDER_APP( RayMarcherApp, RendererGl )
+CINDER_APP( RayMarcherApp, RendererGl, RayMarcherApp::prepareSettings )


### PR DESCRIPTION
This is mainly to take advantage of the features introduced in #808.  Also added `MayaCamUI::setAspectRatio( float )`, which is many times easier to use than getting a copy of the `Camera`, updating its aspect ratio, then re-setting the new `Camera`. Some sample-specific notes:

* `rayMarcher`: this sample has been updated and seems to be working, but the way that it constructs the `RayMarcher` class (from RayMarcherApp's constructor) doesn't work so well anymore. It was causing an exc_bad_access, which I fixed by later resetting the Camera pointer. Perhaps this sample should be improved for the latest glNext. 
* `_opengl/ObjLoader`: I removed the optional `ArcBall` usage, instead only `MayaCamUI` is in use. For iOS, disabled multitouch to make this possible. Main reason was that the `ArcBall` vertical rotation was flipped, but otherwise did the exact same thing as mayacam left-click drag.