### PR TITLE
avoid deprecated Gestalt function to fetch OS X version when possible

### DIFF
--- a/src/cinder/System.cpp
+++ b/src/cinder/System.cpp
@@ -32,8 +32,8 @@
 		#import <CFNetwork/CFNetwork.h>
 		#import <UIKit/UIDevice.h>
 	#endif
-    #import <Foundation/Foundation.h>
-    #import <objc/objc-runtime.h>
+	#import <Foundation/Foundation.h>
+	#import <objc/objc-runtime.h>
 	#import <netinet/in.h>
 	#import <netdb.h>
 	#import <ifaddrs.h>
@@ -450,9 +450,9 @@ int System::getNumCores()
 
 #if defined( CINDER_COCOA )
 typedef struct {
-    NSInteger majorVersion;
-    NSInteger minorVersion;
-    NSInteger patchVersion;
+	NSInteger majorVersion;
+	NSInteger minorVersion;
+	NSInteger patchVersion;
 } ShadowOSVersion;
 #endif
 
@@ -460,20 +460,20 @@ int System::getOsMajorVersion()
 {
 	if( ! instance()->mCachedValues[OS_MAJOR] ) {
 #if defined( CINDER_COCOA)
-        if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
-            ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
-            instance()->mOSMajorVersion = (int32_t)version.majorVersion;
-        } else {
-    #if defined( CINDER_COCOA_TOUCH )
-            NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-            instance()->mOSMajorVersion = [[sysVerComponents firstObject] intValue];
-    #elif defined( CINDER_MAC )
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            if( Gestalt(gestaltSystemVersionMajor, reinterpret_cast<SInt32*>( &(instance()->mOSMajorVersion) ) ) != noErr )
-                throw SystemExcFailedQuery();
-        #pragma clang diagnostic pop
-    #endif
+		if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
+			ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
+			instance()->mOSMajorVersion = (int32_t)version.majorVersion;
+		} else {
+	#if defined( CINDER_COCOA_TOUCH )
+			NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+			instance()->mOSMajorVersion = [[sysVerComponents firstObject] intValue];
+	#elif defined( CINDER_MAC )
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+			if( Gestalt(gestaltSystemVersionMajor, reinterpret_cast<SInt32*>( &(instance()->mOSMajorVersion) ) ) != noErr )
+				throw SystemExcFailedQuery();
+		#pragma clang diagnostic pop
+	#endif
 		}
 #elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;
@@ -494,20 +494,20 @@ int System::getOsMinorVersion()
 {
 	if( ! instance()->mCachedValues[OS_MINOR] ) {
 #if defined( CINDER_COCOA)
-        if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
-            ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
-            instance()->mOSMinorVersion = (int32_t)version.minorVersion;
-        } else {
-    #if defined( CINDER_COCOA_TOUCH )
-            NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-            instance()->mOSMinorVersion = [[sysVerComponents objectAtIndex:1] intValue];	
-    #elif defined( CINDER_MAC )
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
+			ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
+			instance()->mOSMinorVersion = (int32_t)version.minorVersion;
+		} else {
+	#if defined( CINDER_COCOA_TOUCH )
+			NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+			instance()->mOSMinorVersion = [[sysVerComponents objectAtIndex:1] intValue];	
+	#elif defined( CINDER_MAC )
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			if( Gestalt(gestaltSystemVersionMinor, reinterpret_cast<SInt32*>( &(instance()->mOSMinorVersion) ) ) != noErr )
 				throw SystemExcFailedQuery();
-        #pragma clang diagnostic pop
-    #endif
+		#pragma clang diagnostic pop
+	#endif
 		}
 #elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;
@@ -528,23 +528,23 @@ int System::getOsBugFixVersion()
 {
 	if( ! instance()->mCachedValues[OS_BUGFIX] ) {
 #if defined( CINDER_COCOA )
-        if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
-            ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
-            instance()->mOSBugFixVersion = (int32_t)version.patchVersion;
-        } else {
-    #if defined( CINDER_COCOA_TOUCH )
-            NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-            if( [sysVerComponents count] > 2 )
-                instance()->mOSBugFixVersion = [[sysVerComponents objectAtIndex:2] intValue];
-            else
-                instance()->mOSBugFixVersion = 0;
-    #elif defined( CINDER_MAC )
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
+			ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
+			instance()->mOSBugFixVersion = (int32_t)version.patchVersion;
+		} else {
+	#if defined( CINDER_COCOA_TOUCH )
+			NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+			if( [sysVerComponents count] > 2 )
+				instance()->mOSBugFixVersion = [[sysVerComponents objectAtIndex:2] intValue];
+			else
+				instance()->mOSBugFixVersion = 0;
+	#elif defined( CINDER_MAC )
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			if( Gestalt(gestaltSystemVersionBugFix, reinterpret_cast<SInt32*>( &(instance()->mOSBugFixVersion) ) ) != noErr )
 				throw SystemExcFailedQuery();
-        #pragma clang diagnostic pop
-    #endif
+		#pragma clang diagnostic pop
+	#endif
 		}
 #elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;

--- a/src/cinder/System.cpp
+++ b/src/cinder/System.cpp
@@ -30,9 +30,10 @@
 #if defined( CINDER_COCOA )
 	#if defined( CINDER_COCOA_TOUCH )
 		#import <CFNetwork/CFNetwork.h>
-		#import <Foundation/NSArray.h>
 		#import <UIKit/UIDevice.h>
 	#endif
+    #import <Foundation/Foundation.h>
+    #import <objc/objc-runtime.h>
 	#import <netinet/in.h>
 	#import <netdb.h>
 	#import <ifaddrs.h>
@@ -41,9 +42,6 @@
 	#import <net/if_dl.h>
 	#include <sys/sysctl.h>
 	#include <cxxabi.h>
-		#if defined( CINDER_MAC )
-		#include <CoreServices/CoreServices.h>
-	#endif
 #elif defined( CINDER_MSW )
 	#include <windows.h>
 	#include <windowsx.h>
@@ -52,7 +50,7 @@
 	namespace cinder {
 		void cpuidwrap( int *p, unsigned int param );
 	}
-#elif defined( CINDER_WINRT)
+#elif defined( CINDER_WINRT )
 	#include <collection.h>
 	#include "cinder/winrt/WinRTUtils.h"
 	using namespace Windows::Devices::Input;
@@ -450,15 +448,33 @@ int System::getNumCores()
 	return instance()->mLogicalCPUs;
 }
 
+#if defined( CINDER_COCOA )
+typedef struct {
+    NSInteger majorVersion;
+    NSInteger minorVersion;
+    NSInteger patchVersion;
+} ShadowOSVersion;
+#endif
+
 int System::getOsMajorVersion()
 {
 	if( ! instance()->mCachedValues[OS_MAJOR] ) {
-#if defined( CINDER_COCOA_TOUCH )
-		NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-		instance()->mOSMajorVersion = [[sysVerComponents firstObject] intValue];
-#elif defined( CINDER_COCOA )	
-		if( Gestalt(gestaltSystemVersionMajor, reinterpret_cast<SInt32*>( &(instance()->mOSMajorVersion) ) ) != noErr)
-			throw SystemExcFailedQuery();
+#if defined( CINDER_COCOA)
+        if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
+            ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
+            instance()->mOSMajorVersion = (int32_t)version.majorVersion;
+        } else {
+    #if defined( CINDER_COCOA_TOUCH )
+            NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+            instance()->mOSMajorVersion = [[sysVerComponents firstObject] intValue];
+    #elif defined( CINDER_MAC )
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            if( Gestalt(gestaltSystemVersionMajor, reinterpret_cast<SInt32*>( &(instance()->mOSMajorVersion) ) ) != noErr )
+                throw SystemExcFailedQuery();
+        #pragma clang diagnostic pop
+    #endif
+		}
 #elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;
 		::ZeroMemory( &info, sizeof( OSVERSIONINFOEX ) );
@@ -477,12 +493,22 @@ int System::getOsMajorVersion()
 int System::getOsMinorVersion()
 {
 	if( ! instance()->mCachedValues[OS_MINOR] ) {
-#if defined( CINDER_COCOA_TOUCH )
-		NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-		instance()->mOSMinorVersion = [[sysVerComponents objectAtIndex:1] intValue];	
-#elif defined( CINDER_COCOA )	
-		if( Gestalt(gestaltSystemVersionMinor, reinterpret_cast<SInt32*>( &(instance()->mOSMinorVersion) ) ) != noErr)
-			throw SystemExcFailedQuery();
+#if defined( CINDER_COCOA)
+        if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
+            ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
+            instance()->mOSMinorVersion = (int32_t)version.minorVersion;
+        } else {
+    #if defined( CINDER_COCOA_TOUCH )
+            NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+            instance()->mOSMinorVersion = [[sysVerComponents objectAtIndex:1] intValue];	
+    #elif defined( CINDER_MAC )
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+			if( Gestalt(gestaltSystemVersionMinor, reinterpret_cast<SInt32*>( &(instance()->mOSMinorVersion) ) ) != noErr )
+				throw SystemExcFailedQuery();
+        #pragma clang diagnostic pop
+    #endif
+		}
 #elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;
 		::ZeroMemory( &info, sizeof( OSVERSIONINFOEX ) );
@@ -501,16 +527,26 @@ int System::getOsMinorVersion()
 int System::getOsBugFixVersion()
 {
 	if( ! instance()->mCachedValues[OS_BUGFIX] ) {
-#if defined( CINDER_COCOA_TOUCH )
-		NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-		if( [sysVerComponents count] > 2 )
-			instance()->mOSBugFixVersion = [[sysVerComponents objectAtIndex:2] intValue];
-		else
-			instance()->mOSBugFixVersion = 0;
-#elif defined( CINDER_COCOA )	
-		if( Gestalt(gestaltSystemVersionBugFix, reinterpret_cast<SInt32*>( &(instance()->mOSBugFixVersion) ) ) != noErr)
-			throw SystemExcFailedQuery();
-#elif defined( CINDER_MSW )	
+#if defined( CINDER_COCOA )
+        if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
+            ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
+            instance()->mOSBugFixVersion = (int32_t)version.patchVersion;
+        } else {
+    #if defined( CINDER_COCOA_TOUCH )
+            NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+            if( [sysVerComponents count] > 2 )
+                instance()->mOSBugFixVersion = [[sysVerComponents objectAtIndex:2] intValue];
+            else
+                instance()->mOSBugFixVersion = 0;
+    #elif defined( CINDER_MAC )
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+			if( Gestalt(gestaltSystemVersionBugFix, reinterpret_cast<SInt32*>( &(instance()->mOSBugFixVersion) ) ) != noErr )
+				throw SystemExcFailedQuery();
+        #pragma clang diagnostic pop
+    #endif
+		}
+#elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;
 		::ZeroMemory( &info, sizeof( OSVERSIONINFOEX ) );
 		info.dwOSVersionInfoSize = sizeof( OSVERSIONINFOEX );
@@ -729,8 +765,6 @@ std::string System::getIpAddress()
 }
 #endif
 
-
-
 #if defined( CINDER_COCOA_TOUCH )
 bool System::isDeviceIphone()
 {
@@ -749,8 +783,6 @@ bool System::isDeviceIpad()
 	
 	return instance()->mCachedValues[IS_IPAD]; 
 }
-
 #endif
-
 
 } // namespace cinder

--- a/src/cinder/System.cpp
+++ b/src/cinder/System.cpp
@@ -31,9 +31,10 @@
 	#if defined( CINDER_COCOA_TOUCH )
 		#import <CFNetwork/CFNetwork.h>
 		#import <UIKit/UIDevice.h>
+	#elif defined( CINDER_MAC )
+		#import <objc/message.h>
 	#endif
 	#import <Foundation/Foundation.h>
-	#import <objc/objc-runtime.h>
 	#import <netinet/in.h>
 	#import <netdb.h>
 	#import <ifaddrs.h>
@@ -459,21 +460,19 @@ typedef struct {
 int System::getOsMajorVersion()
 {
 	if( ! instance()->mCachedValues[OS_MAJOR] ) {
-#if defined( CINDER_COCOA)
+#if defined( CINDER_COCOA_TOUCH )
+		NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+		instance()->mOSMajorVersion = [[sysVerComponents firstObject] intValue];
+#elif defined( CINDER_MAC )
 		if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
 			ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
 			instance()->mOSMajorVersion = (int32_t)version.majorVersion;
 		} else {
-	#if defined( CINDER_COCOA_TOUCH )
-			NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-			instance()->mOSMajorVersion = [[sysVerComponents firstObject] intValue];
-	#elif defined( CINDER_MAC )
-		#pragma clang diagnostic push
-		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			if( Gestalt(gestaltSystemVersionMajor, reinterpret_cast<SInt32*>( &(instance()->mOSMajorVersion) ) ) != noErr )
 				throw SystemExcFailedQuery();
-		#pragma clang diagnostic pop
-	#endif
+	#pragma clang diagnostic pop
 		}
 #elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;
@@ -493,21 +492,19 @@ int System::getOsMajorVersion()
 int System::getOsMinorVersion()
 {
 	if( ! instance()->mCachedValues[OS_MINOR] ) {
-#if defined( CINDER_COCOA)
+#if defined( CINDER_COCOA_TOUCH )
+		NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+		instance()->mOSMinorVersion = [[sysVerComponents objectAtIndex:1] intValue];
+#elif defined( CINDER_MAC )
 		if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
 			ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
 			instance()->mOSMinorVersion = (int32_t)version.minorVersion;
 		} else {
-	#if defined( CINDER_COCOA_TOUCH )
-			NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-			instance()->mOSMinorVersion = [[sysVerComponents objectAtIndex:1] intValue];	
-	#elif defined( CINDER_MAC )
-		#pragma clang diagnostic push
-		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			if( Gestalt(gestaltSystemVersionMinor, reinterpret_cast<SInt32*>( &(instance()->mOSMinorVersion) ) ) != noErr )
 				throw SystemExcFailedQuery();
-		#pragma clang diagnostic pop
-	#endif
+	#pragma clang diagnostic pop
 		}
 #elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;
@@ -527,24 +524,22 @@ int System::getOsMinorVersion()
 int System::getOsBugFixVersion()
 {
 	if( ! instance()->mCachedValues[OS_BUGFIX] ) {
-#if defined( CINDER_COCOA )
+#if defined( CINDER_COCOA_TOUCH )
+		NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
+		if( [sysVerComponents count] > 2 )
+			instance()->mOSBugFixVersion = [[sysVerComponents objectAtIndex:2] intValue];
+		else
+			instance()->mOSBugFixVersion = 0;
+#elif defined( CINDER_MAC )
 		if( [[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)] ) {
 			ShadowOSVersion version = ((ShadowOSVersion(*)(id, SEL))objc_msgSend_stret)([NSProcessInfo processInfo], @selector(operatingSystemVersion));
 			instance()->mOSBugFixVersion = (int32_t)version.patchVersion;
 		} else {
-	#if defined( CINDER_COCOA_TOUCH )
-			NSArray *sysVerComponents = [[[UIDevice currentDevice] systemVersion] componentsSeparatedByString:@"."];
-			if( [sysVerComponents count] > 2 )
-				instance()->mOSBugFixVersion = [[sysVerComponents objectAtIndex:2] intValue];
-			else
-				instance()->mOSBugFixVersion = 0;
-	#elif defined( CINDER_MAC )
-		#pragma clang diagnostic push
-		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			if( Gestalt(gestaltSystemVersionBugFix, reinterpret_cast<SInt32*>( &(instance()->mOSBugFixVersion) ) ) != noErr )
 				throw SystemExcFailedQuery();
-		#pragma clang diagnostic pop
-	#endif
+	#pragma clang diagnostic pop
 		}
 #elif defined( CINDER_MSW )
 		::OSVERSIONINFOEX info;


### PR DESCRIPTION
The `Gestalt` functions have been deprecated since 10.8 (and are said to incorrectly report 10.10 as 10.9, though I was unable to reproduce on 10.10.3) and API was added to `NSProcessInfo` to replace it. Though the API wasn't made public until OS X 10.10 / iOS 8, it is available on earlier releases (possibly backported when using newer base SDKs due to `Gestalt` being deprecated without a replacement) so the Objective-C runtime is used to divine availability and execute, falling back to `Gestalt` with the deprecation warning hushed.

The `NSProcessInfo` API is also available on iOS and is a bit cleaner than the `-[UIDevice systemVersion]` string parsing, so it is use when available, falling back to the `UIDevice` method.

So far, I have only tested on 10.10.3 / Xcode 6.3 building the OS X and iOS static libs, I'll fire up a VM and make sure things are good in 10.9 as well.