### PR TITLE
init ivars in Sphere’s default constructor to zero

### DIFF
--- a/include/cinder/Sphere.h
+++ b/include/cinder/Sphere.h
@@ -32,7 +32,9 @@ namespace cinder {
 
 class Sphere {
  public:
-	Sphere() {}
+	Sphere()
+		: mCenter( 0 ), mRadius( 0 )
+	{}
 	Sphere( const vec3 &center, float radius )
 		: mCenter( center ), mRadius( radius )
 	{}

--- a/include/cinder/Sphere.h
+++ b/include/cinder/Sphere.h
@@ -32,9 +32,7 @@ namespace cinder {
 
 class Sphere {
  public:
-	Sphere()
-		: mCenter( 0 ), mRadius( 0 )
-	{}
+	Sphere() {}
 	Sphere( const vec3 &center, float radius )
 		: mCenter( center ), mRadius( radius )
 	{}

--- a/src/cinder/Sphere.cpp
+++ b/src/cinder/Sphere.cpp
@@ -97,7 +97,7 @@ Sphere Sphere::calculateBoundingSphere( const vector<vec3> &points )
 Sphere Sphere::calculateBoundingSphere( const vec3 *points, size_t numPoints )
 {
 	if( ! numPoints )
-		return Sphere();
+		return Sphere( vec3( 0 ), 0 );
 	
 	// compute minimal and maximal bounds
 	vec3 min(points[0]), max(points[0]);

--- a/src/cinder/Sphere.cpp
+++ b/src/cinder/Sphere.cpp
@@ -96,6 +96,9 @@ Sphere Sphere::calculateBoundingSphere( const vector<vec3> &points )
 
 Sphere Sphere::calculateBoundingSphere( const vec3 *points, size_t numPoints )
 {
+	if( ! numPoints )
+		return Sphere();
+	
 	// compute minimal and maximal bounds
 	vec3 min(points[0]), max(points[0]);
 	for( size_t i = 1; i < numPoints; ++i ) {


### PR DESCRIPTION
Also make sure calculateBoundsSphere() doesn't crash when pased an empty array.