### PR TITLE
Remove duplicate quit and getContentScale method declarations

### DIFF
--- a/include/cinder/app/cocoa/AppImplMac.h
+++ b/include/cinder/app/cocoa/AppImplMac.h
@@ -69,7 +69,6 @@
 - (void)setFrameRate:(float)frameRate;
 - (void)disableFrameRate;
 - (bool)isFrameRateEnabled;
-- (void)quit;
 
 - (cinder::app::RendererRef)findSharedRenderer:(cinder::app::RendererRef)match;
 - (cinder::app::WindowRef)getWindow;
@@ -105,7 +104,6 @@
 - (cinder::ivec2)getPos;
 - (float)getContentScale;
 - (void)setPos:(cinder::ivec2)pos;
-- (float)getContentScale;
 - (void)close;
 - (NSString *)getTitle;
 - (void)setTitle:(NSString *)title;


### PR DESCRIPTION
Trivial tweak to resolve two warnings when building with Xcode 6.3.1 and the Cinder project has updated warning settings - both methods are already declared in above in the header.