### PR TITLE
glNext gl::ScopedDepthBuffer

### DIFF
--- a/include/cinder/gl/Context.h
+++ b/include/cinder/gl/Context.h
@@ -325,9 +325,28 @@ class Context {
 	void		popLineWidth( bool forceRestore = false );	
 	//! Returns the current line width.
 	float		getLineWidth();
-
-	//! Analogous to glDepthMask()
+	
+	//! Analogous to glDepthMask(). Enables or disables writing into the depth buffer.
 	void		depthMask( GLboolean enable );
+	//! Push the depth buffer writing flag.
+	void		pushDepthMask( GLboolean enable );
+	//! Push the depth buffer writing flag.
+	void		pushDepthMask();
+	//! Pops the depth buffer writing flag. If \a forceRestore then redundancy checks are skipped and the hardware state is always set.
+	void		popDepthMask( bool forceRestore = false );
+	//! Returns the depth buffer writing flag.
+	GLboolean	getDepthMask();
+	
+	//! Set the depth buffer comparison function. Analogous to glDepthFunc(). Valid arguments are \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS. Default is \c GL_LESS.
+	void		depthFunc( GLenum func );
+	//! Push the depth buffer comparison function. Valid arguments are \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS. Default is \c GL_LESS.
+	void		pushDepthFunc( GLenum func );
+	//! Push the depth buffer comparison function.
+	void		pushDepthFunc();
+	//! Pops the depth buffer comparison function. If \a forceRestore then redundancy checks are skipped and the hardware state is always set.
+	void		popDepthFunc( bool forceRestore = false );
+	//! Returns the depth buffer comparison function, either \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL or \c GL_ALWAYS.
+	GLenum		getDepthFunc();
 
 #if ! defined( CINDER_GL_ES )
 	//! Sets the current polygon rasterization mode. \a face must be \c GL_FRONT_AND_BACK. \c GL_POINT, \c GL_LINE & \c GL_FILL are legal values for \a mode.
@@ -454,6 +473,8 @@ class Context {
 	std::vector<GLenum>			mCullFaceStack;
 	std::vector<GLenum>			mFrontFaceStack;
 	std::vector<GLenum>			mPolygonModeStack;
+	std::vector<GLboolean>		mDepthMaskStack;
+	std::vector<GLenum>			mDepthFuncStack;
 	
 	std::map<GLenum,std::vector<GLboolean>>	mBoolStateStack;
 	// map<TextureUnit,map<TextureTarget,vector<Binding ID Stack>>>

--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -210,12 +210,11 @@ struct ScopedFaceCulling : private Noncopyable {
 };
 
 //! Scopes state of depth testing.
-struct ScopedDepthTesting : private Noncopyable {
-	ScopedDepthTesting();
-	ScopedDepthTesting( bool read );
-	ScopedDepthTesting( bool read, bool write );
-	ScopedDepthTesting( bool read, bool write, GLenum depthFunc );
-	~ScopedDepthTesting();
+struct ScopedDepthBuffer : private Noncopyable {
+	ScopedDepthBuffer( bool enableReadAndWrite = true );
+	ScopedDepthBuffer( bool enableRead, bool enableWrite );
+	ScopedDepthBuffer( bool enableRead, bool enableWrite, GLenum depthFunc );
+	~ScopedDepthBuffer();
 	
   private:
 	Context		*mCtx;

--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -211,8 +211,11 @@ struct ScopedFaceCulling : private Noncopyable {
 
 //! Scopes state of depth testing.
 struct ScopedDepthBuffer : private Noncopyable {
-	ScopedDepthBuffer( bool enableReadAndWrite = true );
+	//! Enables or disables both depth comparisons and writing to the depth buffer
+	ScopedDepthBuffer( bool enableReadAndWrite );
+	//! Enables or disables depth comparisons and/or writing to the depth buffer
 	ScopedDepthBuffer( bool enableRead, bool enableWrite );
+	//! Enables or disables depth comparisons, writing to the depth buffer and specifies a depth comparison function, either \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS.
 	ScopedDepthBuffer( bool enableRead, bool enableWrite, GLenum depthFunc );
 	~ScopedDepthBuffer();
 	

--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -209,6 +209,20 @@ struct ScopedFaceCulling : private Noncopyable {
 	bool		mSaveFace;
 };
 
+//! Scopes state of depth testing.
+struct ScopedDepthTesting : private Noncopyable {
+	ScopedDepthTesting();
+	ScopedDepthTesting( bool read );
+	ScopedDepthTesting( bool read, bool write );
+	ScopedDepthTesting( bool read, bool write, GLenum depthFunc );
+	~ScopedDepthTesting();
+	
+  private:
+	Context		*mCtx;
+	bool		mSaveMask;
+	bool		mSaveFunc;
+};
+
 //! Scopes state of Renderbuffer binding
 struct ScopedRenderbuffer : private Noncopyable {
 	ScopedRenderbuffer( const RenderbufferRef &renderBuffer );

--- a/src/cinder/gl/Context.cpp
+++ b/src/cinder/gl/Context.cpp
@@ -1382,7 +1382,88 @@ float Context::getLineWidth()
 // DepthMask
 void Context::depthMask( GLboolean enable )
 {
-	setBoolState( GL_DEPTH_WRITEMASK, enable, glDepthMask );
+	if( setStackState( mDepthMaskStack, enable ) ) {
+		glDepthMask( enable );
+	}
+}
+
+void Context::pushDepthMask( GLboolean enable )
+{
+	if( pushStackState( mDepthMaskStack, enable ) ) {
+		glDepthMask( enable );
+	}
+}
+
+void Context::pushDepthMask()
+{
+	mDepthMaskStack.push_back( getDepthMask() );
+}
+
+void Context::popDepthMask( bool forceRestore )
+{
+	if( mDepthMaskStack.empty() )
+		CI_LOG_E( "Depth mask stack underflow" );
+	else if( popStackState( mDepthMaskStack ) || forceRestore )
+		glDepthMask( getDepthMask() );
+}
+
+GLboolean Context::getDepthMask()
+{
+	if( mDepthMaskStack.empty() ) {
+		GLint queriedInt;
+		glGetIntegerv( GL_DEPTH_WRITEMASK, &queriedInt );
+		mDepthMaskStack.push_back( queriedInt ); // push twice
+		mDepthMaskStack.push_back( queriedInt );
+	}
+
+	return mDepthMaskStack.back();
+}
+
+//////////////////////////////////////////////////////////////////
+// DepthFunc
+void Context::depthFunc( GLenum func )
+{
+	if( func != GL_NEVER && func != GL_LESS && func != GL_EQUAL && func != GL_LEQUAL && func != GL_GREATER && func != GL_NOTEQUAL && func != GL_GEQUAL && func != GL_ALWAYS )
+		CI_LOG_E( "Wrong enum for the depth buffer comparison function" );
+	
+	if( setStackState( mDepthFuncStack, func ) ) {
+		glDepthFunc( func );
+	}
+}
+
+void Context::pushDepthFunc( GLenum func )
+{
+	if( func != GL_NEVER && func != GL_LESS && func != GL_EQUAL && func != GL_LEQUAL && func != GL_GREATER && func != GL_NOTEQUAL && func != GL_GEQUAL && func != GL_ALWAYS )
+		CI_LOG_E( "Wrong enum for the depth buffer comparison function" );
+	
+	if( pushStackState( mDepthFuncStack, func ) ) {
+		glDepthFunc( func );
+	}
+}
+
+void Context::pushDepthFunc()
+{
+	mDepthFuncStack.push_back( getDepthFunc() );
+}
+
+void Context::popDepthFunc( bool forceRestore )
+{
+	if( mDepthFuncStack.empty() )
+		CI_LOG_E( "Depth function stack underflow" );
+	else if( popStackState( mDepthFuncStack ) || forceRestore )
+		glDepthFunc( getDepthFunc() );
+}
+
+GLenum Context::getDepthFunc()
+{
+	if( mDepthFuncStack.empty() ) {
+		GLint queriedInt;
+		glGetIntegerv( GL_DEPTH_FUNC, &queriedInt );
+		mDepthFuncStack.push_back( queriedInt ); // push twice
+		mDepthFuncStack.push_back( queriedInt );
+	}
+
+	return mDepthFuncStack.back();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -299,35 +299,30 @@ ScopedFaceCulling::~ScopedFaceCulling()
 }
 	
 ///////////////////////////////////////////////////////////////////////////////////////////
-// ScopedDepthTesting
-ScopedDepthTesting::ScopedDepthTesting()
+// ScopedDepthBuffer
+ScopedDepthBuffer::ScopedDepthBuffer( bool enableReadAndWrite )
 	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( false )
 {
-	mCtx->pushBoolState( GL_DEPTH_TEST, true );
-	mCtx->pushDepthMask( true );
-}
-ScopedDepthTesting::ScopedDepthTesting( bool read )
-	: mCtx( gl::context() ), mSaveMask( false ), mSaveFunc( false )
-{
-	mCtx->pushBoolState( GL_DEPTH_TEST, read );
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableReadAndWrite );
+	mCtx->pushDepthMask( enableReadAndWrite );
 }
 	
-ScopedDepthTesting::ScopedDepthTesting( bool read, bool write )
+ScopedDepthBuffer::ScopedDepthBuffer( bool enableRead, bool enableWrite )
 	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( false )
 {
-	mCtx->pushBoolState( GL_DEPTH_TEST, read );
-	mCtx->pushDepthMask( write );
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableRead );
+	mCtx->pushDepthMask( enableWrite );
 }
 	
-ScopedDepthTesting::ScopedDepthTesting( bool read, bool write, GLenum depthFunc )
+ScopedDepthBuffer::ScopedDepthBuffer( bool enableRead, bool enableWrite, GLenum depthFunc )
 	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( true )
 {
-	mCtx->pushBoolState( GL_DEPTH_TEST, read );
-	mCtx->pushDepthMask( write );
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableRead );
+	mCtx->pushDepthMask( enableWrite );
 	mCtx->pushDepthFunc( depthFunc );
 }
 
-ScopedDepthTesting::~ScopedDepthTesting()
+ScopedDepthBuffer::~ScopedDepthBuffer()
 {
 	mCtx->popBoolState( GL_DEPTH_TEST );
 	if( mSaveMask )

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -297,6 +297,44 @@ ScopedFaceCulling::~ScopedFaceCulling()
 	if( mSaveFace )
 		mCtx->popCullFace();
 }
+	
+///////////////////////////////////////////////////////////////////////////////////////////
+// ScopedDepthTesting
+ScopedDepthTesting::ScopedDepthTesting()
+	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( false )
+{
+	mCtx->pushBoolState( GL_DEPTH_TEST, true );
+	mCtx->pushDepthMask( true );
+}
+ScopedDepthTesting::ScopedDepthTesting( bool read )
+	: mCtx( gl::context() ), mSaveMask( false ), mSaveFunc( false )
+{
+	mCtx->pushBoolState( GL_DEPTH_TEST, read );
+}
+	
+ScopedDepthTesting::ScopedDepthTesting( bool read, bool write )
+	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( false )
+{
+	mCtx->pushBoolState( GL_DEPTH_TEST, read );
+	mCtx->pushDepthMask( write );
+}
+	
+ScopedDepthTesting::ScopedDepthTesting( bool read, bool write, GLenum depthFunc )
+	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( true )
+{
+	mCtx->pushBoolState( GL_DEPTH_TEST, read );
+	mCtx->pushDepthMask( write );
+	mCtx->pushDepthFunc( depthFunc );
+}
+
+ScopedDepthTesting::~ScopedDepthTesting()
+{
+	mCtx->popBoolState( GL_DEPTH_TEST );
+	if( mSaveMask )
+		mCtx->popDepthMask();
+	if( mSaveFunc )
+		mCtx->popDepthFunc();
+}
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // ScopedRenderbuffer


### PR DESCRIPTION
This PR adds a new RAII object for depth testing... see the discussion going [here](https://github.com/cinder/Cinder/issues/824).