### PR TITLE
Added ci::gl::ShaderDef::lambert()

### DIFF
--- a/include/cinder/gl/Shader.h
+++ b/include/cinder/gl/Shader.h
@@ -40,6 +40,7 @@ class ShaderDef {
 	ShaderDef&		color();	
 	ShaderDef&		texture( const TextureRef &tex = TextureRef() );
 	ShaderDef&		texture( GLenum target );
+	ShaderDef&		lambert();
 	// Used by draw(TextureRef&) stock shader; scales ciPosition and ciTexCoord according to
 	// uniform "uPositionScale", "uPositionOffset", "uTexCoord0Scale", "uTexCoord0Offset"
 	ShaderDef&		uniformBasedPosAndTexCoord();
@@ -55,7 +56,8 @@ class ShaderDef {
 	std::array<GLint,4>		mTextureSwizzleMask;
 	bool					mUniformBasedPosAndTexCoord;
 
-	bool			mColor;
+	bool					mColor;
+	bool					mLambert;
 	
 	friend class EnvironmentCore;
 	friend class EnvironmentEs;

--- a/src/cinder/gl/Shader.cpp
+++ b/src/cinder/gl/Shader.cpp
@@ -30,7 +30,7 @@ using namespace std;
 namespace cinder { namespace gl {
 
 ShaderDef::ShaderDef()
-	: mTextureMapping( false ), mTextureMappingRectangleArb( false ), mColor( false ), mUniformBasedPosAndTexCoord( false )
+	: mTextureMapping( false ), mTextureMappingRectangleArb( false ), mColor( false ), mLambert( false ), mUniformBasedPosAndTexCoord( false )
 {
 	mTextureSwizzleMask[0] = GL_RED;
 	mTextureSwizzleMask[1] = GL_GREEN; 
@@ -70,6 +70,12 @@ ShaderDef& ShaderDef::uniformBasedPosAndTexCoord()
 ShaderDef& ShaderDef::color()
 {
 	mColor = true;
+	return *this;
+}
+
+ShaderDef& ShaderDef::lambert()
+{
+	mLambert = true;
 	return *this;
 }
 
@@ -120,6 +126,8 @@ bool ShaderDef::operator<( const ShaderDef &rhs ) const
 		return mTextureSwizzleMask[2] < rhs.mTextureSwizzleMask[2];	
 	else if( rhs.mTextureSwizzleMask[3] != mTextureSwizzleMask[3] )
 		return mTextureSwizzleMask[3] < rhs.mTextureSwizzleMask[3];	
+	if( rhs.mLambert != mLambert )
+		return rhs.mLambert;
 	
 	return false;
 }


### PR DESCRIPTION
Added support for simple directional diffuse lighting for stock shaders:

```auto shader = gl::getStockShader( gl::ShaderDef().lambert() );```

Can be combined with ```color()``` and ```texture()```, but by default will create a directional white light source at the camera's position.