### PR TITLE
Added new Frustum constructor that doesn't need a Camera

### DIFF
--- a/include/cinder/Frustum.h
+++ b/include/cinder/Frustum.h
@@ -49,11 +49,14 @@ class Frustum {
   public:
 	Frustum() {}
 	Frustum( const Camera &cam );
+	Frustum( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr, const Vec3T &ftl, const Vec3T &ftr, const Vec3T &fbl, const Vec3T &fbr );
 
 	//! Creates a frustum based on the camera's parameters.
 	void set( const Camera &cam );
 	//! Creates a frustum based on the camera's parameters and four corners of a portal.
 	void set( const Camera &cam, const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr );
+	//! Creates a frustum based on the corners of a near and far portal.
+	void set( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr, const Vec3T &ftl, const Vec3T &ftr, const Vec3T &fbl, const Vec3T &fbr );
 
 	//! Returns true if point is within frustum.
 	bool contains( const Vec3T &loc ) const;

--- a/src/cinder/Frustum.cpp
+++ b/src/cinder/Frustum.cpp
@@ -38,6 +38,12 @@ Frustum<T>::Frustum( const Camera &cam )
 	// set planes using camera
 	set( cam );
 }
+	
+template<typename T>
+Frustum<T>::Frustum( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr, const Vec3T &ftl, const Vec3T &ftr, const Vec3T &fbl, const Vec3T &fbr )
+{
+	set( ntl, ntr, nbl, nbr, ftl, ftr, fbl, fbr );
+}
 
 template<typename T>
 void Frustum<T>::set( const Camera &cam )
@@ -47,13 +53,8 @@ void Frustum<T>::set( const Camera &cam )
 
 	vec3 ftl, ftr, fbl, fbr;
 	cam.getFarClipCoordinates( &ftl, &ftr, &fbl, &fbr );
-
-	mFrustumPlanes[TOP].set( ntr, ntl, ftl );
-	mFrustumPlanes[BOTTOM].set( nbl, nbr, fbr );
-	mFrustumPlanes[LEFT].set( ntl, nbl, fbl );
-	mFrustumPlanes[RIGHT].set( nbr, ntr, fbr );
-	mFrustumPlanes[NEAR].set( ntl, ntr, nbr );
-	mFrustumPlanes[FAR].set( ftr, ftl, fbl );
+	
+	set( ntl, ntr, nbl, nbr, ftl, ftr, fbl, fbr );
 }
 
 template<typename T>
@@ -66,7 +67,13 @@ void Frustum<T>::set( const Camera &cam, const Vec3T &ntl, const Vec3T &ntr, con
 	Vec3T ftr = normalize( ntr - eye ) * farClip;
 	Vec3T fbl = normalize( nbl - eye ) * farClip;
 	Vec3T fbr = normalize( nbr - eye ) * farClip;
-
+	
+	set( ntl, ntr, nbl, nbr, ftl, ftr, fbl, fbr );
+}
+	
+template<typename T>
+void Frustum<T>::set( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr, const Vec3T &ftl, const Vec3T &ftr, const Vec3T &fbl, const Vec3T &fbr )
+{
 	mFrustumPlanes[TOP].set( ntr, ntl, ftl );
 	mFrustumPlanes[BOTTOM].set( nbl, nbr, fbr );
 	mFrustumPlanes[LEFT].set( ntl, nbl, fbl );


### PR DESCRIPTION
Sometimes you don't have a Camera to construct the Frustum from and in those cases you can't use cinder's Frustum class because you can currently only construct one from a Camera.

Let me know if you see something wrong, it's basically only a new constructor and the corresponding Frustum::set function. I also replaced some recurring code thanks to the new Frustum::set but it's all minor modifications.