### PR TITLE
Replace deprecated OS X power management API use

### DIFF
--- a/include/cinder/app/cocoa/AppImplMac.h
+++ b/include/cinder/app/cocoa/AppImplMac.h
@@ -63,6 +63,9 @@
 - (void)applicationWillResignActive:(NSNotification *)notification;
 - (void)quit;
 
+- (void)setPowerManagementEnabled:(BOOL)flag;
+- (BOOL)isPowerManagementEnabled;
+
 - (cinder::app::WindowRef)createWindow:(const cinder::app::Window::Format &)format;
 
 - (float)getFrameRate;

--- a/include/cinder/app/cocoa/AppMac.h
+++ b/include/cinder/app/cocoa/AppMac.h
@@ -40,6 +40,9 @@ class AppMac : public AppBase {
 	AppMac();
 	virtual ~AppMac();
 
+    void		enablePowerManagement( bool powerManagement = true ) override;
+    bool		isPowerManagementEnabled() const override;
+
 	WindowRef	createWindow( const Window::Format &format = Window::Format() ) override;
 	void		quit() override;
 

--- a/include/cinder/app/cocoa/AppMac.h
+++ b/include/cinder/app/cocoa/AppMac.h
@@ -40,8 +40,8 @@ class AppMac : public AppBase {
 	AppMac();
 	virtual ~AppMac();
 
-    void		enablePowerManagement( bool powerManagement = true ) override;
-    bool		isPowerManagementEnabled() const override;
+	void		enablePowerManagement( bool powerManagement = true ) override;
+	bool		isPowerManagementEnabled() const override;
 
 	WindowRef	createWindow( const Window::Format &format = Window::Format() ) override;
 	void		quit() override;

--- a/src/cinder/app/cocoa/AppCocoaView.mm
+++ b/src/cinder/app/cocoa/AppCocoaView.mm
@@ -457,16 +457,6 @@ using namespace cinder::app;
 
 - (void)timerFired:(NSTimer *)t
 {
-	// note: this would not work if the frame rate were set to something absurdly low
-	if( ! mApp->isPowerManagementEnabled() ) {
-		static double lastSystemActivity = 0;
-		double curTime = cinder::app::getElapsedSeconds();
-		if( curTime - lastSystemActivity >= 30 ) { // every thirty seconds call this to prevent sleep
-			::UpdateSystemActivity( OverallAct );
-			lastSystemActivity = curTime;
-		}
-	}
-
 	// issue update() event
 	mApp->privateUpdate__();
 	

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -25,11 +25,13 @@
 #include "cinder/app/Renderer.h"
 #include "cinder/app/Window.h"
 #include "cinder/app/cocoa/PlatformCocoa.h"
+#include "cinder/Log.h"
 #import "cinder/cocoa/CinderCocoa.h"
 
 #include <memory>
 
 #import <OpenGL/OpenGL.h>
+#import <IOKit/pwr_mgt/IOPMLib.h>
 
 using namespace cinder;
 using namespace cinder::app;
@@ -48,6 +50,12 @@ using namespace cinder::app;
 @implementation CinderWindow
 - (BOOL)canBecomeMainWindow { return YES; }
 - (BOOL)canBecomeKeyWindow { return YES; }
+@end
+
+// private properties
+@interface AppImplMac()
+@property(nonatomic) IOPMAssertionID idleSleepAssertionID;
+@property(nonatomic) IOPMAssertionID displaySleepAssertionID;
 @end
 
 @implementation AppImplMac
@@ -130,16 +138,6 @@ using namespace cinder::app;
 
 - (void)timerFired:(NSTimer *)t
 {
-	// note: this would not work if the frame rate were set to something absurdly low
-	if( ! mApp->isPowerManagementEnabled() ) {
-		static double lastSystemActivity = 0;
-		double curTime = mApp->getElapsedSeconds();
-		if( curTime - lastSystemActivity >= 30 ) { // every thirty seconds call this to prevent sleep
-			::UpdateSystemActivity( OverallAct );
-			lastSystemActivity = curTime;
-		}
-	}
-
 	if( ! ((PlatformCocoa*)Platform::get())->isInsideModalLoop() ) {
 		// issue update() event
 		mApp->privateUpdate__();
@@ -342,6 +340,39 @@ using namespace cinder::app;
 		return;
 
 	[NSApp terminate:nil];
+}
+
+- (void)setPowerManagementEnabled:(BOOL)flag
+{
+	if( flag && ![self isPowerManagementEnabled] ) {
+		CFStringRef reasonForActivity = CFSTR( "Cinder Application Execution" );
+		IOReturn status = IOPMAssertionCreateWithName( kIOPMAssertPreventUserIdleSystemSleep, kIOPMAssertionLevelOn, reasonForActivity, &_idleSleepAssertionID );
+		if( status != kIOReturnSuccess ) {
+			CI_LOG_E( "failed to create power management assertion to prevent idle system sleep" );
+		}
+
+		status = IOPMAssertionCreateWithName( kIOPMAssertPreventUserIdleDisplaySleep, kIOPMAssertionLevelOn, reasonForActivity, &_displaySleepAssertionID );
+		if( status != kIOReturnSuccess ) {
+			CI_LOG_E( "failed to create power management assertion to prevent idle display sleep" );
+		}
+	} else if( !flag && [self isPowerManagementEnabled] ) {
+		IOReturn status = IOPMAssertionRelease( self.idleSleepAssertionID );
+		if( status != kIOReturnSuccess ) {
+			CI_LOG_E( "failed to release and deactivate power management assertion that prevents idle system sleep" );
+		}
+		self.idleSleepAssertionID = 0;
+
+		status = IOPMAssertionRelease( self.displaySleepAssertionID );
+		if( status != kIOReturnSuccess ) {
+			CI_LOG_E( "failed to release and deactivate power management assertion that prevents idle display sleep" );
+		}
+		self.displaySleepAssertionID = 0;
+	}
+}
+
+- (BOOL)isPowerManagementEnabled
+{
+	return self.idleSleepAssertionID != 0 && self.displaySleepAssertionID != 0;
 }
 
 - (float)getFrameRate

--- a/src/cinder/app/cocoa/AppMac.cpp
+++ b/src/cinder/app/cocoa/AppMac.cpp
@@ -51,6 +51,16 @@ void AppMac::launch()
 	[[NSApplication sharedApplication] run];
 }
 
+void AppMac::enablePowerManagement( bool powerManagement )
+{
+	[mImpl setPowerManagementEnabled:powerManagement ? YES : NO];
+}
+
+bool AppMac::isPowerManagementEnabled() const
+{
+	return 	[mImpl isPowerManagementEnabled];
+}
+
 WindowRef AppMac::createWindow( const Window::Format &format )
 {
 	return [mImpl createWindow:format];

--- a/xcode/cinder.xcodeproj/project.pbxproj
+++ b/xcode/cinder.xcodeproj/project.pbxproj
@@ -1084,6 +1084,7 @@
 		C7FA5FC312124A960065683B /* CaptureImplAvFoundation.mm in Sources */ = {isa = PBXBuildFile; fileRef = C7FA5FC112124A790065683B /* CaptureImplAvFoundation.mm */; };
 		C7FA5FC712124B230065683B /* CaptureImplAvFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = C7FA5FC512124B1C0065683B /* CaptureImplAvFoundation.h */; };
 		D2AAC088055469A000DB518D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */; };
+		D88CA7E51AF56661005C31C8 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D88CA7E41AF56661005C31C8 /* IOKit.framework */; };
 		D8A5A81A19BFDE8700811132 /* CaptureImplAvFoundation.mm in Sources */ = {isa = PBXBuildFile; fileRef = C7FA5FC112124A790065683B /* CaptureImplAvFoundation.mm */; };
 		EAC3D1A91011F2E700FFBC9E /* Serial.h in Headers */ = {isa = PBXBuildFile; fileRef = EAC3D1A81011F2E700FFBC9E /* Serial.h */; };
 		EAC3D1AD1011F3AC00FFBC9E /* Serial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EAC3D1AB1011F3AC00FFBC9E /* Serial.cpp */; };
@@ -1631,6 +1632,7 @@
 		C7FA5FC512124B1C0065683B /* CaptureImplAvFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CaptureImplAvFoundation.h; sourceTree = "<group>"; };
 		D2AAC07E0554694100DB518D /* libcinder_d.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libcinder_d.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2F7E8BE07B2D77200F64583 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = /System/Library/Frameworks/CoreData.framework; sourceTree = "<absolute>"; };
+		D88CA7E41AF56661005C31C8 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		EAC3D1A81011F2E700FFBC9E /* Serial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Serial.h; sourceTree = "<group>"; };
 		EAC3D1AB1011F3AC00FFBC9E /* Serial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Serial.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1672,6 +1674,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D88CA7E51AF56661005C31C8 /* IOKit.framework in Frameworks */,
 				5391FE660E95CB01002A13D5 /* AppKit.framework in Frameworks */,
 				D2AAC088055469A000DB518D /* Cocoa.framework in Frameworks */,
 				0091D8F10E81B9110029341E /* OpenGL.framework in Frameworks */,
@@ -2275,6 +2278,7 @@
 		1058C7B0FEA5585E11CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D88CA7E41AF56661005C31C8 /* IOKit.framework */,
 				C7BA40880FA8C13A00AADC07 /* AudioToolbox.framework */,
 				C7BA408A0FA8C13A00AADC07 /* AudioUnit.framework */,
 				C7BA408C0FA8C13A00AADC07 /* CoreAudio.framework */,


### PR DESCRIPTION
`UpdateSystemActivity()` is deprecated as of OS X 10.8 and the recommended IOKit replacement `IOPMAssertionCreateWithName ` works on Mac OS X 10.6 and later.

Separate power management assertions are required to prevent idle system sleep and idle display sleep and as such this complicates the `isPowerManagementEnabled` situation - to prevent leaking power management assertions look to see if both are valid and report that, this should allow power management to be disabled and attempt to re-enable while the opposite situation would leak an assertion (though they get cleaned up at app quit time). 

Power assertions can be checked via:
```sh
$ pmset -g assertions
```

**NOTE**: OS X applications will need to link to _IOKit.framework_