### PR TITLE
add default Format to TriMesh constructor...

### DIFF
--- a/include/cinder/TriMesh.h
+++ b/include/cinder/TriMesh.h
@@ -100,7 +100,6 @@ class TriMesh : public geom::Source {
 	bool		hasTexCoords3() const { return ! mTexCoords3.empty(); }
 
 	//! Appends a vertex which can be referred to with appendTriangle() or appendIndices()
-	// TODO: shouldn't this be called appendPosition()?
 	void		appendVertex( const vec2 &v ) { appendVertices( &v, 1 ); }
 	//! Appends a vertex which can be referred to with appendTriangle() or appendIndices()
 	void		appendVertex( const vec3 &v ) { appendVertices( &v, 1 ); }

--- a/include/cinder/TriMesh.h
+++ b/include/cinder/TriMesh.h
@@ -71,7 +71,7 @@ class TriMesh : public geom::Source {
 	static TriMeshRef	create( const geom::Source &source ) { return TriMeshRef( new TriMesh( source ) ); }
 	static TriMeshRef	create( const geom::Source &source, const Format &format ) { return TriMeshRef( new TriMesh( source, format ) ); }
 
-	TriMesh( const Format &format );
+	TriMesh( const Format &format = Format().positions().normals().texCoords() );
 	TriMesh( const geom::Source &source );
 	TriMesh( const geom::Source &source, const Format &format );
 	
@@ -100,6 +100,7 @@ class TriMesh : public geom::Source {
 	bool		hasTexCoords3() const { return ! mTexCoords3.empty(); }
 
 	//! Appends a vertex which can be referred to with appendTriangle() or appendIndices()
+	// TODO: shouldn't this be called appendPosition()?
 	void		appendVertex( const vec2 &v ) { appendVertices( &v, 1 ); }
 	//! Appends a vertex which can be referred to with appendTriangle() or appendIndices()
 	void		appendVertex( const vec3 &v ) { appendVertices( &v, 1 ); }


### PR DESCRIPTION
 to allow it to be default constructed. As per #801, follows the same layout as `TriMesh::create()` currently provides.