### PR TITLE
made gl::ScopedBlend* more consistent

### DIFF
--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -75,7 +75,9 @@ struct ScopedColor : private Noncopyable {
 	ColorAf		mColor;
 };
 
+//! Controls the current blend mode for the current scope.
 struct ScopedBlend : private Noncopyable {
+	//! Enables or disables blending (`GL_BLEND`) state.
 	ScopedBlend( GLboolean enable );
 	//! Parallels glBlendFunc(), and implicitly enables blending
 	ScopedBlend( GLenum sfactor, GLenum dfactor );
@@ -88,15 +90,24 @@ struct ScopedBlend : private Noncopyable {
 	bool		mSaveFactors; // whether we should also set the blend factors rather than just the blend state
 };
 
-struct ScopedAlphaBlend : private ScopedBlend {
-	ScopedAlphaBlend( bool premultipliedAlpha )
-		: ScopedBlend( premultipliedAlpha ? GL_ONE : GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA )
+//! Enables blending state for the current scope and sets the blending function for standard alpha blending (`sfactor = GL_SRC_ALPHA, dfactor = GL_ONE_MINUS_SRC_ALPHA`).
+struct ScopedBlendAlpha : private ScopedBlend {
+	ScopedBlendAlpha()
+		: ScopedBlend( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA )
 	{}
 };
 
-struct ScopedAdditiveBlend : public ScopedBlend
+//! Enables blending state for the current scope and sets the blending function for premultiplied alpha blending (`sfactor = GL_ONE, dfactor = GL_ONE_MINUS_SRC_ALPHA`).
+struct ScopedBlendPremult : private ScopedBlend {
+	ScopedBlendPremult()
+		: ScopedBlend( GL_ONE, GL_ONE_MINUS_SRC_ALPHA )
+	{}
+};
+
+//! Enables blending state for the current scope and sets the blending function additive blending (`sfactor = GL_SRC_ALPHA, dfactor = GL_ONE`).
+struct ScopedBlendAdditive : public ScopedBlend
 {
-	ScopedAdditiveBlend()
+	ScopedBlendAdditive()
 		: ScopedBlend( GL_SRC_ALPHA, GL_ONE )
 	{}
 };

--- a/samples/Geometry/src/GeometryApp.cpp
+++ b/samples/Geometry/src/GeometryApp.cpp
@@ -201,7 +201,7 @@ void GeometryApp::draw()
 
 			if( mViewMode == WIREFRAME ) {
 				// We're using alpha blending, so render the back side first.
-				gl::ScopedAlphaBlend blendScope( false );
+				gl::ScopedBlendAlpha blendScope;
 				gl::ScopedFaceCulling cullScope( true, GL_FRONT );
 
 				mWireframeShader->uniform( "uBrightness", 0.5f );
@@ -215,7 +215,7 @@ void GeometryApp::draw()
 			}
 			else if( mTexturingMode == TRANSPARENT ) {
 				// We're using alpha blending, so render the back side first.
-				gl::ScopedAlphaBlend blendScope( false );
+				gl::ScopedBlendAlpha blendScope;
 				gl::ScopedFaceCulling cullScope( true, GL_FRONT );
 
 				mPrimitive->draw();

--- a/samples/StereoscopicRendering/src/StereoAutoFocuser.cpp
+++ b/samples/StereoscopicRendering/src/StereoAutoFocuser.cpp
@@ -90,7 +90,7 @@ void StereoAutoFocuser::draw()
 	gl::ScopedColor color( ColorA( 0, 1, 1, 0.1f ) );
 	gl::drawSolidRect( mArea );
 	gl::color( ColorA( 0, 1, 1, 0.8f ) );
-	glLineWidth( 2.0f );
+	gl::lineWidth( 2.0f );
 	gl::drawLine( vec2( (float) mArea.getX1() + 0.5f, (float) mArea.getY2() - mNearest.y ),
 				  vec2( (float) mArea.getX2() + 0.5f, (float) mArea.getY2() - mNearest.y ) );
 	gl::drawLine( vec2( (float) mArea.getX1() + mNearest.x, (float) mArea.getY1() + 0.5f ),

--- a/samples/StereoscopicRendering/src/StereoAutoFocuser.cpp
+++ b/samples/StereoscopicRendering/src/StereoAutoFocuser.cpp
@@ -86,7 +86,7 @@ void StereoAutoFocuser::autoFocus( CameraStereo *cam, const Area &area, GLuint b
 void StereoAutoFocuser::draw()
 {
 	// visual debugging 
-	gl::ScopedAlphaBlend blend( false );
+	gl::ScopedBlendAlpha blend;
 	gl::ScopedColor color( ColorA( 0, 1, 1, 0.1f ) );
 	gl::drawSolidRect( mArea );
 	gl::color( ColorA( 0, 1, 1, 0.8f ) );

--- a/samples/StereoscopicRendering/src/StereoscopicRenderingApp.cpp
+++ b/samples/StereoscopicRendering/src/StereoscopicRenderingApp.cpp
@@ -73,15 +73,15 @@ public:
 		vec3 color;
 	} InstanceData;
 public:
-	void prepareSettings( Settings *settings );
+	static void prepareSettings( Settings *settings );
 
-	void setup();
-	void update();
-	void draw();
+	void setup() override;
+	void update() override;
+	void draw() override;
 
-	void keyDown( KeyEvent event );
+	void keyDown( KeyEvent event ) override;
 
-	void resize();
+	void resize() override;
 private:
 	void createFbo();
 	void createGrid();
@@ -613,4 +613,4 @@ void StereoscopicRenderingApp::renderUI()
 #endif
 }
 
-CINDER_APP( StereoscopicRenderingApp, RendererGl( RendererGl::Options() ) )
+CINDER_APP( StereoscopicRenderingApp, RendererGl, StereoscopicRenderingApp::prepareSettings )

--- a/samples/_opengl/DeferredShading/src/DeferredShadingApp.cpp
+++ b/samples/_opengl/DeferredShading/src/DeferredShadingApp.cpp
@@ -248,7 +248,7 @@ void DeferredShadingApp::draw()
 		gl::ScopedViewport scopedViewport( ivec2( 0 ), mFbo->getSize() );
 		gl::clear();
 		gl::ScopedMatrices scopedMatrices;
-		gl::ScopedAdditiveBlend scopedAdditiveBlend;
+		gl::ScopedBlendAdditive scopedAdditiveBlend;
 		gl::ScopedFaceCulling scopedFaceCulling( true, GL_FRONT );
 		gl::setMatrices( mCamera );
 		gl::enableDepthRead();

--- a/samples/_opengl/DeferredShadingAdvanced/src/DeferredShadingAdvancedApp.cpp
+++ b/samples/_opengl/DeferredShadingAdvanced/src/DeferredShadingAdvancedApp.cpp
@@ -373,7 +373,7 @@ void DeferredShadingAdvancedApp::draw()
 		gl::ScopedFramebuffer scopedFrameBuffer( mFboPingPong );
 		gl::ScopedViewport scopedViewport( ivec2( 0 ), mFboPingPong->getSize() );
 		gl::drawBuffer( GL_COLOR_ATTACHMENT0 + ping );
-		gl::ScopedAdditiveBlend scopedAdditiveBlend;
+		gl::ScopedBlendAdditive scopedAdditiveBlend;
 		gl::ScopedMatrices scopedMatrices;
 		gl::ScopedFaceCulling scopedFaceCulling( true, GL_FRONT );
 		gl::setMatrices( mCamera );
@@ -433,12 +433,12 @@ void DeferredShadingAdvancedApp::draw()
 				
 		// Dim last frame (produces light trails)
 		{
-			gl::ScopedAlphaBlend scopedAlphaBlend( false );
+			gl::ScopedBlendAlpha scopedAlphaBlend;
 			gl::ScopedColor scopedColor( ColorAf( Colorf::black(), 0.43f ) );
 			mBatchStockColorRect->draw();
 		}
 		{
-			gl::ScopedAdditiveBlend scopedAdditiveBlend;
+			gl::ScopedBlendAdditive scopedAdditiveBlend;
 			gl::ScopedTextureBind scopedTextureBind0( mTextureFboGBuffer[ 0 ], 0 );
 			gl::ScopedTextureBind scopedTextureBind1( mTextureFboGBuffer[ 1 ], 1 );
 			mBatchEmissiveRect->draw();
@@ -472,7 +472,7 @@ void DeferredShadingAdvancedApp::draw()
 		// SSAO
 
 		if ( mEnabledSsao ) {
-			gl::ScopedAlphaBlend scopedAlphaBlend( true );
+			gl::ScopedBlendAdditive scopedAdditiveBlend;
 			
 			// SSAO pass
 			{
@@ -650,14 +650,14 @@ void DeferredShadingAdvancedApp::draw()
 
 		// Draw light accumulation
 		{
-			gl::ScopedAdditiveBlend scopedAdditiveBlend;
+			gl::ScopedBlendAdditive scopedAdditiveBlend;
 			gl::ScopedTextureBind scopedTextureBind( mTextureFboSmall[ mEnabledBloom ? 2 : 0 ], 0 );
 			mBatchStockTextureRect->draw();
 		}
 
 		// Draw light volumes
 		if ( mDrawLightVolume ) {
-			gl::ScopedAlphaBlend scopedAlphaBlend( false );
+			gl::ScopedBlendAlpha scopedBlend;
 			gl::ScopedPolygonMode scopedPolygonMode( GL_LINE );
 			gl::ScopedMatrices scopedMatrices;
 			gl::setMatrices( mCamera );

--- a/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
+++ b/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
@@ -215,7 +215,7 @@ void MotionBlurVelocityBufferApp::fillGBuffer()
 	gl::enableDepthWrite();
 
 	gl::ScopedFramebuffer fbo( mGBuffer );
-	gl::ScopedAlphaBlend blend( false );
+	gl::ScopedBlendAlpha blend;
 	gl::clear( ColorA( 0.0f, 0.0f, 0.0f, 0.0f ) );
 
 	gl::ScopedGlslProg prog( mVelocityProg );
@@ -267,7 +267,7 @@ void MotionBlurVelocityBufferApp::drawBlurredContent()
 	gl::ScopedTextureBind velTex( mGBuffer->getTexture( G_VELOCITY ), 1 );
 	gl::ScopedTextureBind neigborTex( mVelocityDilationBuffer->getTexture( DILATE_NEIGHBOR_MAX ), 2 );
 	gl::ScopedGlslProg prog( mMotionBlurProg );
-	gl::ScopedAlphaBlend blend( true );
+	gl::ScopedBlendPremult blend;
 
 	mMotionBlurProg->uniform( "uColorMap", 0 );
 	mMotionBlurProg->uniform( "uVelocityMap", 1 );
@@ -293,7 +293,7 @@ void MotionBlurVelocityBufferApp::draw()
 	fillGBuffer();
 
 	if( ! mBlurEnabled ) {
-		gl::ScopedAlphaBlend blend( false );
+		gl::ScopedBlendAlpha blend;
 		gl::draw( mGBuffer->getColorTexture() );
 	}
 	else {

--- a/samples/_opengl/StencilReflection/src/StencilReflectionApp.cpp
+++ b/samples/_opengl/StencilReflection/src/StencilReflectionApp.cpp
@@ -102,7 +102,7 @@ void StencilReflectionApp::drawScene()
 			// draw into that stenciled area
 			{
 				gl::ScopedModelMatrix	scopeModel;
-				gl::ScopedAlphaBlend	scopeAlphaBlend( false );
+				gl::ScopedBlendAlpha	scopeAlphaBlend;
 				gl::ScopedState			scopeCull( GL_CULL_FACE, true );
 				gl::multModelMatrix( translate( vec3( 0, 0, 1 ) ) );
 				gl::color( ColorA( 1.0f, 1.0f, 1.0f, .09f ) );


### PR DESCRIPTION
Resulting from the decisions made in #629, The three most common forms of blending are made explicit with `ScopedBlendAlpha`, `ScopedBlendPremult`, and `ScopedBlendAdditive`. Auto completion is a feature here. Updated samples that were making use of the previous versions.

For disabling blending altogether, you call (prexisting):

```cpp
ScopedBlend blend( false );
```