### PR TITLE
ShaderPreprocessor: remove extra line for user provided #version

### DIFF
--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -93,9 +93,7 @@ std::string ShaderPreprocessor::parseDirectives( const std::string &source )
 		version = "#version " + to_string( mVersion ) + "\n";
 #endif
 	}
-	else
-		version += "\n";
-	
+
 	// copy the preprocessor directives to a string starting with the version
 	std::string directivesString = version;
 	for( auto define : mDefineDirectives ) {

--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -81,6 +81,7 @@ std::string ShaderPreprocessor::parseDirectives( const std::string &source )
 		}
 		else
 			output << line;
+
 		output << endl;
 	}
 	
@@ -103,7 +104,7 @@ std::string ShaderPreprocessor::parseDirectives( const std::string &source )
 	
 	return directivesString + output.str();
 }
-	
+
 string ShaderPreprocessor::parseTopLevel( const string &source, const fs::path &currentDirectory )
 {
 	set<fs::path> includeTree;


### PR DESCRIPTION
This is a partial fix for #850, where an extra "\n" was being added and was causing the error log's line number to be off by one.