### PR TITLE
Fixing outside of screen crash

### DIFF
--- a/src/cinder/app/AppImplCocoaBasic.mm
+++ b/src/cinder/app/AppImplCocoaBasic.mm
@@ -555,9 +555,15 @@
 
 	[mAppImpl setActiveWindow:self];
 
-	if( displayID != mDisplay->getCgDirectDisplayId() ) {
+	if( mDisplay ) {
+		if( displayID != mDisplay->getCgDirectDisplayId() ) {
+			mDisplay = cinder::Display::findFromCgDirectDisplayId( displayID );
+			mWindowRef->emitDisplayChange();
+		}
+	}
+	else {
 		mDisplay = cinder::Display::findFromCgDirectDisplayId( displayID );
-		mWindowRef->emitDisplayChange();
+		if ( mDisplay ) mWindowRef->emitDisplayChange();
 	}
 	
 	mWindowRef->emitMove();


### PR DESCRIPTION
This change should fix the crash when the output window is positioned fully outside of visible screen space and then moved again.

findFromCgDirectDisplayId() returns null when the window is outside of the monitor space. This is fine until the next time the event is triggered, when trying to compare the new display id to the one of the current (non-existing) display.

I chose to emitDisplayChange() only when the window re-appears in visible screen space.