### PR TITLE
Added support for missing int and unsigned int samplers

### DIFF
--- a/src/cinder/gl/ConstantConversions.cpp
+++ b/src/cinder/gl/ConstantConversions.cpp
@@ -72,6 +72,10 @@ std::string	constantToString( GLenum constant )
 		sSymbols[GL_SAMPLER_2D_RECT] = "SAMPLER_2D_RECT";
 		sSymbols[GL_SAMPLER_1D_SHADOW] = "SAMPLER_1D_SHADOW";
 		sSymbols[GL_SAMPLER_2D_SHADOW] = "SAMPLER_2D_SHADOW";
+		sSymbols[GL_INT_SAMPLER_2D] = "INT_SAMPLER_2D";
+		sSymbols[GL_INT_SAMPLER_2D_RECT] = "INT_SAMPLER_2D_RECT";
+		sSymbols[GL_UNSIGNED_INT_SAMPLER_2D] = "UNSIGNED_INT_SAMPLER_2D";
+		sSymbols[GL_UNSIGNED_INT_SAMPLER_2D_RECT] = "UNSIGNED_INT_SAMPLER_2D_RECT";
 		sSymbols[GL_HALF_FLOAT] = "HALF_FLOAT";
 		sSymbols[GL_DOUBLE] = "DOUBLE";
 		sSymbols[GL_INT_2_10_10_10_REV] = "INT_2_10_10_10_REV";
@@ -281,7 +285,10 @@ uint8_t typeToBytes( GLenum type )
 #if ! defined( CINDER_GL_ES )
 		case GL_SAMPLER_BUFFER_EXT: return sizeof(int); break;
 		case GL_INT_SAMPLER_2D:		return sizeof(int); break;
+		case GL_INT_SAMPLER_2D_RECT: return sizeof(int); break;
 		case GL_SAMPLER_2D_RECT:	return sizeof(int); break;
+		case GL_UNSIGNED_INT_SAMPLER_2D: return sizeof(int); break;
+		case GL_UNSIGNED_INT_SAMPLER_2D_RECT: return sizeof(int); break;
 #endif
 #if ! defined( CINDER_GL_ES_2 )
 		case GL_SAMPLER_2D_SHADOW:	return sizeof(int); break;

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -1270,6 +1270,9 @@ bool GlslProg::checkUniformType( GLenum uniformType ) const
 		case GL_SAMPLER_BUFFER_EXT: return std::is_same<T, int32_t>::value;
 		case GL_INT_SAMPLER_2D: return std::is_same<T, int32_t>::value;
 		case GL_SAMPLER_2D_RECT: return std::is_same<T, int32_t>::value;
+		case GL_INT_SAMPLER_2D_RECT: return std::is_same<T, int32_t>::value;
+		case GL_UNSIGNED_INT_SAMPLER_2D: return std::is_same<T, int32_t>::value;
+		case GL_UNSIGNED_INT_SAMPLER_2D_RECT: return std::is_same<T, int32_t>::value;
 #endif
 #if ! defined( CINDER_GL_ES_2 )
 		case GL_UNSIGNED_INT_VEC2: return std::is_same<T,glm::uvec2>::value;


### PR DESCRIPTION
Without these type mismatch warnings and unknown uniform errors are displayed when a uniform of `GL_UNSIGNED_INT_SAMPLER_2D`, `GL_INT_SAMPLER_2D_RECT`, or `GL_UNSIGNED_INT_SAMPLER_2D_RECT` is set.