### PR TITLE
ShaderPreprocessor features

### DIFF
--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -438,6 +438,9 @@ class GlslProg {
 	
 	std::string		getShaderLog( GLuint handle ) const;
 
+	//! Returns a list of included files (via the `#include` directive) detected and parsed by the ShaderPreprocessor.
+	std::vector<fs::path>	getIncludedFiles() const	{ return mShaderPreprocessorIncludedFiles; }
+
 	//! Returns the debugging label associated with the Program.
 	const std::string&	getLabel() const { return mLabel; }
 	//! Sets the debugging label associated with the Program. Calls glObjectLabel() when available.
@@ -537,6 +540,7 @@ class GlslProg {
 	mutable std::set<int>					mLoggedUniformLocations;
 	std::string								mLabel; // debug label
 	std::unique_ptr<ShaderPreprocessor>		mShaderPreprocessor;
+	std::vector<fs::path>					mShaderPreprocessorIncludedFiles;
 
 	friend class Context;
 	friend std::ostream& operator<<( std::ostream &os, const GlslProg &rhs );

--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -243,6 +243,8 @@ class GlslProg {
 		int	getVersion() const										{ return mVersion; }
 		//! Returns the list of `#define` directives.
 		const std::vector<std::string>& getDefineDirectives() const { return mDefineDirectives; }
+		//! Adds a custom search directory to the ShaderPreprocessor's search list.
+		Format&	addPreprocessorSearchDirectory( const fs::path &dir )	{ mPreprocessorSearchDirectories.push_back( dir ); return *this; }
 		
 		//! Returns the debugging label associated with the Program.
 		const std::string&	getLabel() const { return mLabel; }
@@ -299,6 +301,7 @@ class GlslProg {
 		
 		bool									mPreprocessingEnabled;
 		std::string								mLabel;
+		std::vector<fs::path>					mPreprocessorSearchDirectories;
 
 		friend class		GlslProg;
 	};

--- a/include/cinder/gl/ShaderPreprocessor.h
+++ b/include/cinder/gl/ShaderPreprocessor.h
@@ -45,10 +45,10 @@ namespace cinder { namespace gl {
 class ShaderPreprocessor {
   public:
 	ShaderPreprocessor();
-	//! \brief Parses and processes the shader source at \a sourcePath.  \return a preprocessed source string.
-	std::string		parse( const fs::path &sourcePath );
-	//! Parses and processes the shader source \a source, which can be found at \a sourcePath. \return a preprocessed source string.
-	std::string		parse( const std::string &source, const fs::path &sourcePath );
+	//! \brief Parses and processes the shader source at \a sourcePath. If \a includedFiles is provided, this will be filled with paths to any files detected as `#include`ed. \return a preprocessed source string.
+	std::string		parse( const fs::path &sourcePath, std::set<fs::path> *includedFiles = nullptr );
+	//! Parses and processes the shader source \a source, which can be found at \a sourcePath. If \a includedFiles is provided, this will be filled with paths to any files detected as `#include`ed. \return a preprocessed source string.
+	std::string		parse( const std::string &source, const fs::path &sourcePath, std::set<fs::path> *includedFiles = nullptr );
 
 	//! Adds a custom search directory to the search list. The last directory added will be searched first.
 	void	addSearchDirectory( const fs::path &directory );
@@ -63,9 +63,9 @@ class ShaderPreprocessor {
 	void	setDefineDirectives( const std::vector<std::string> &defines );
 	//! Specifies the #version directive to add to the shader sources
 	void	setVersion( int version )	{ mVersion = version; }
-	
+
   private:
-	std::string		parseTopLevel( const std::string &source, const fs::path &currentDirectory );
+	std::string		parseTopLevel( const std::string &source, const fs::path &currentDirectory, std::set<fs::path> &includeTree );
 	std::string		parseRecursive( const fs::path &path, const fs::path &currentDirectory, std::set<fs::path> &includeTree );
 	std::string		parseDirectives( const std::string &source );
 	fs::path		findFullPath( const fs::path &includePath, const fs::path &currentPath );

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -435,6 +435,10 @@ GlslProg::GlslProg( const Format &format )
 		for( const auto &define : format.getDefineDirectives() )
 			mShaderPreprocessor->addDefine( define );
 
+		// copy search directories
+		for( const auto &dir : format.mPreprocessorSearchDirectories )
+			mShaderPreprocessor->addSearchDirectory( dir );
+
 		if( format.getVersion() )
 			mShaderPreprocessor->setVersion( format.getVersion() );
 	}

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -624,7 +624,10 @@ void GlslProg::loadShader( const string &shaderSource, const fs::path &shaderPat
 {
 	GLuint handle = glCreateShader( shaderType );
 	if( mShaderPreprocessor ) {
-		string preprocessedSource = mShaderPreprocessor->parse( shaderSource, shaderPath );
+		set<fs::path> includedFiles;
+		string preprocessedSource = mShaderPreprocessor->parse( shaderSource, shaderPath, &includedFiles );
+		mShaderPreprocessorIncludedFiles.insert( mShaderPreprocessorIncludedFiles.end(), includedFiles.begin(), includedFiles.end() );
+
 		const char *cStr = preprocessedSource.c_str();
 		glShaderSource( handle, 1, reinterpret_cast<const GLchar**>( &cStr ), NULL );
 	}


### PR DESCRIPTION
1) Adding custom search directory to `GlslProg::Format()` for includes
2) `GlslProg::getIncludedFiles()` returns a vector of `fs::path`s, handy for passing to a file watcher to live update the shader when an included file is modified.