### PR TITLE
Add newline after user-provided shader version when using defines

### DIFF
--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -104,6 +104,9 @@ std::string ShaderPreprocessor::parseDirectives( const std::string &source )
 		version = "#version " + to_string( mVersion ) + "\n";
 #endif
 	}
+	else if( ! mDefineDirectives.empty() ) {
+		version += "\n";
+	}
 
 	// copy the preprocessor directives to a string starting with the version
 	std::string directivesString = version;


### PR DESCRIPTION
fixes #909 

Adding the newline all the time would change the line numbers regardless of if the preprocessor was actually changing the shader source and without a newline, defines will append to the version line like:
```glsl
#version 150#define VARIABLE
…
```
