### PR TITLE
Added a drawStrokedCircle that supports a lineWidth setting.

### DIFF
--- a/include/cinder/GeomIo.h
+++ b/include/cinder/GeomIo.h
@@ -408,6 +408,32 @@ class Circle : public Source {
 	size_t		mNumVertices;
 };
 
+class Ring : public Source {
+public:
+	Ring();
+
+	Ring&		center( const vec2 &center ) { mCenter = center; return *this; }
+	Ring&		radius( float radius );
+	Ring&		width( float width );
+	Ring&		subdivisions( int subdivs );
+
+	size_t		getNumVertices() const override;
+	size_t		getNumIndices() const override { return 0; }
+	Primitive	getPrimitive() const override { return Primitive::TRIANGLE_STRIP; }
+	uint8_t		getAttribDims( Attrib attr ) const override;
+	AttribSet	getAvailableAttribs() const override;
+	void		loadInto( Target *target, const AttribSet &requestedAttribs ) const override;
+
+private:
+	void	updateVertexCounts();
+
+	vec2		mCenter;
+	float		mRadius;
+	float		mWidth;
+	int			mRequestedSubdivisions, mNumSubdivisions;
+	size_t		mNumVertices;
+};
+
 class Sphere : public Source {
   public:
 	Sphere();

--- a/include/cinder/gl/draw.h
+++ b/include/cinder/gl/draw.h
@@ -106,6 +106,8 @@ void drawStrokedRect( const Rectf &rect, float lineWidth );
 void drawStrokedRoundedRect( const Rectf &rect, float cornerRadius, int numSegmentsPerCorner = 0 );
 //! Draws a stroked circle centered around \a center with a radius of \a radius
 void drawStrokedCircle( const vec2 &center, float radius, int numSegments = -1 );
+//! Draws a stroked circle centered around \a center with a radius of \a radius and a line width of \a lineWidth.
+void drawStrokedCircle( const vec2 &center, float radius, float lineWidth, int numSegments = -1 );
 //! Draws a stroked ellipse centered around \a center with an X-axis radius of \a radiusX and a Y-axis radius of \a radiusY
 void drawStrokedEllipse( const vec2 &center, float radiusX, float radiusY, int numSegments = -1 );
 

--- a/samples/Geometry/assets/phong_es2.frag
+++ b/samples/Geometry/assets/phong_es2.frag
@@ -1,5 +1,7 @@
 #version 100
 
+#extension GL_OES_standard_derivatives : enable
+
 precision highp float;
 
 varying vec4 Position;
@@ -10,8 +12,8 @@ varying vec2 TexCoord;
 // Based on OpenGL Programming Guide (8th edition), p 457-459.
 highp float checkered( in vec2 uv, in int freq )
 {
-	highp vec2 checker = fract( uv * freq );
-	highp vec2 edge = fwidth( uv ) * freq;
+	highp vec2 checker = fract( uv * float( freq ) );
+	highp vec2 edge = fwidth( uv ) * float( freq );
 	highp float mx = max( edge.x, edge.y );
 
 	highp vec2 pattern = smoothstep( vec2(0.5), vec2(0.5) + edge, checker );
@@ -41,7 +43,7 @@ void main()
 	vec3 diffuse = max( dot( vNormal, vToLight ), 0.0 ) * cDiffuse;
 
 	// texCoord checkerboard
-	diffuse *= 0.5 + 0.5 * checkered( TexCoord );
+	diffuse *= 0.5 + 0.5 * checkered( TexCoord, 20 );
 
 	// texCoord checkerboard with protection against edge case\n"
 	const float kEpsilon = 0.0001;

--- a/samples/Geometry/src/GeometryApp.cpp
+++ b/samples/Geometry/src/GeometryApp.cpp
@@ -21,7 +21,7 @@ void prepareSettings( App::Settings* settings );
 
 class GeometryApp : public App {
 public:
-	enum Primitive { CAPSULE, CONE, CUBE, CYLINDER, HELIX, ICOSAHEDRON, ICOSPHERE, SPHERE, TEAPOT, TORUS, PLANE };
+	enum Primitive { CAPSULE, CONE, CUBE, CYLINDER, HELIX, ICOSAHEDRON, ICOSPHERE, SPHERE, TEAPOT, TORUS, PLANE, RECT, ROUNDEDRECT, CIRCLE, RING };
 	enum Quality { LOW, DEFAULT, HIGH };
 	enum ViewMode { SHADED, WIREFRAME };
 	enum TexturingMode { NONE, PROCEDURAL, SAMPLER, TRANSPARENT };
@@ -225,8 +225,11 @@ void GeometryApp::draw()
 
 				mPrimitive->draw();
 			}
-			else
+			else {
+				gl::ScopedFaceCulling cullScope( mEnableFaceFulling, GL_BACK );
+
 				mPrimitive->draw();
+			}
 		}
 	}
 
@@ -320,7 +323,7 @@ void GeometryApp::keyDown( KeyEvent event )
 void GeometryApp::createParams()
 {
 #if ! defined( CINDER_GL_ES )
-	vector<string> primitives = { "Capsule", "Cone", "Cube", "Cylinder", "Helix", "Icosahedron", "Icosphere", "Sphere", "Teapot", "Torus", "Plane" };
+	vector<string> primitives = { "Capsule", "Cone", "Cube", "Cylinder", "Helix", "Icosahedron", "Icosphere", "Sphere", "Teapot", "Torus", "Plane", "Rectangle", "Rounded Rectangle", "Circle", "Ring" };
 	vector<string> qualities = { "Low", "Default", "High" };
 	vector<string> viewModes = { "Shaded", "Wireframe" };
 	vector<string> texturingModes = { "None", "Procedural", "Sampler", "Transparent" };
@@ -453,6 +456,31 @@ void GeometryApp::createGeometry()
 		case HIGH:		loadGeomSource( geom::Plane().subdivisions( ivec2( 100, 100 ) ), geom::WirePlane().subdivisions( ivec2( 100, 100 ) ) ); break;
 		}
 		break;
+
+	case RECT:
+			loadGeomSource( geom::Rect(), geom::WirePlane() ); break;
+		break;
+	case ROUNDEDRECT:
+		switch( mQualityCurrent ) {
+			case DEFAULT:	loadGeomSource( geom::RoundedRect().cornerSubdivisions( 3 ), geom::WireRoundedRect().cornerSubdivisions( 3 ) ); break;
+			case LOW:		loadGeomSource( geom::RoundedRect().cornerSubdivisions( 1 ), geom::WireRoundedRect().cornerSubdivisions( 1 ) ); break;
+			case HIGH:		loadGeomSource( geom::RoundedRect().cornerSubdivisions( 9 ), geom::WireRoundedRect().cornerSubdivisions( 9 ) ); break;
+		}
+		break;
+	case CIRCLE:
+		switch( mQualityCurrent ) {
+			case DEFAULT:	loadGeomSource( geom::Circle().subdivisions( 24 ), geom::WireCircle().subdivisions( 24 ) ); break;
+			case LOW:		loadGeomSource( geom::Circle().subdivisions( 8 ), geom::WireCircle().subdivisions( 8 ) ); break;
+			case HIGH:		loadGeomSource( geom::Circle().subdivisions( 120 ), geom::WireCircle().subdivisions( 120 ) ); break;
+		}
+		break;
+	case RING:
+		switch( mQualityCurrent ) {
+			case DEFAULT:	loadGeomSource( geom::Ring().subdivisions( 24 ), geom::WireCircle().subdivisions( 24 ).radius( 1.25f ) ); break;
+			case LOW:		loadGeomSource( geom::Ring().subdivisions( 8 ), geom::WireCircle().subdivisions( 8 ).radius( 1.25f ) ); break;
+			case HIGH:		loadGeomSource( geom::Ring().subdivisions( 120 ), geom::WireCircle().subdivisions( 120 ).radius( 1.25f ) ); break;
+		}
+		break;
 	}
 }
 
@@ -532,4 +560,4 @@ void GeometryApp::createWireframeShader()
 #endif // ! defined( CINDER_GL_ES )
 }
 
-CINDER_APP( GeometryApp, RendererGl, prepareSettings )
+CINDER_APP( GeometryApp, RendererGl( RendererGl::Options().msaa( 16 ) ), prepareSettings )

--- a/src/cinder/gl/draw.cpp
+++ b/src/cinder/gl/draw.cpp
@@ -756,97 +756,12 @@ void drawStrokedRoundedRect( const Rectf &r, float cornerRadius, int numSegments
 
 void drawStrokedCircle( const vec2 &center, float radius, int numSegments )
 {
-	auto ctx = context();
-	const GlslProg* curGlslProg = ctx->getGlslProg();
-	if( ! curGlslProg ) {
-		CI_LOG_E( "No GLSL program bound" );
-		return;
-	}
-	
-	if( numSegments <= 0 ) {
-		numSegments = static_cast<int>(math<double>::floor( radius * M_PI * 2 ) );
-	}
-	if( numSegments < 3 ) {
-		numSegments = 3;
-	}
-	// construct circle
-	const size_t numVertices = numSegments;
-	vector<vec2> positions;
-	positions.assign( numVertices, center );	// all vertices start at center
-	const float tDelta = 2.0f * static_cast<float>(M_PI) * (1.0f / numVertices);
-	float t = 0;
-	for( auto &pos : positions ) {
-		const vec2 unit( math<float>::cos( t ), math<float>::sin( t ) );
-		pos += unit * radius;	// push out from center
-		t += tDelta;
-	}
-	// copy data to GPU
-	const size_t size = positions.size() * sizeof( vec2 );
-	auto arrayVbo = ctx->getDefaultArrayVbo( size );
-	arrayVbo->bufferSubData( 0, size, (GLvoid*)positions.data() );
-	// set attributes
-	ctx->pushVao();
-	ctx->getDefaultVao()->replacementBindBegin();
-	ScopedBuffer bufferBindScp( arrayVbo );
-
-	int posLoc = curGlslProg->getAttribSemanticLocation( geom::Attrib::POSITION );
-	if( posLoc >= 0 ) {
-		enableVertexAttribArray( posLoc );
-		vertexAttribPointer( posLoc, 2, GL_FLOAT, GL_FALSE, 0, (GLvoid*)nullptr );
-	}
-	ctx->getDefaultVao()->replacementBindEnd();
-	ctx->setDefaultShaderVars();
-	// draw
-	drawArrays( GL_LINE_LOOP, 0, (GLsizei)positions.size() );
-	ctx->popVao();
+	gl::draw( geom::WireCircle().center( center ).radius( radius ).subdivisions( numSegments ) );
 }
 
 void drawStrokedCircle( const vec2 &center, float radius, float lineWidth, int numSegments )
 {
-	auto ctx = context();
-	const GlslProg* curGlslProg = ctx->getGlslProg();
-	if( !curGlslProg ) {
-		CI_LOG_E( "No GLSL program bound" );
-		return;
-	}
-
-	if( numSegments <= 0 ) {
-		numSegments = static_cast<int>( math<double>::floor( radius * M_PI * 2 ) );
-	}
-	if( numSegments < 3 ) {
-		numSegments = 3;
-	}
-	// construct circle
-	const size_t numVertices = numSegments * 2;
-	vector<vec2> positions;
-	positions.assign( numVertices + 2, center );	// all vertices start at center
-	const float tDelta = 2.0f * static_cast<float>( M_PI ) * ( 2.0f / numVertices );
-	float t = 0;
-	for( size_t i = 0; i <= numVertices; ) {
-		const vec2 unit( math<float>::cos( t ), math<float>::sin( t ) );
-		positions[i++] += unit * ( radius - 0.5f * lineWidth );	// push out from center
-		positions[i++] += unit * ( radius + 0.5f * lineWidth );	// push out from center
-		t += tDelta;
-	}
-	// copy data to GPU
-	const size_t size = positions.size() * sizeof( vec2 );
-	auto arrayVbo = ctx->getDefaultArrayVbo( size );
-	arrayVbo->bufferSubData( 0, size, (GLvoid*) positions.data() );
-	// set attributes
-	ctx->pushVao();
-	ctx->getDefaultVao()->replacementBindBegin();
-	ScopedBuffer bufferBindScp( arrayVbo );
-
-	int posLoc = curGlslProg->getAttribSemanticLocation( geom::Attrib::POSITION );
-	if( posLoc >= 0 ) {
-		enableVertexAttribArray( posLoc );
-		vertexAttribPointer( posLoc, 2, GL_FLOAT, GL_FALSE, 0, ( GLvoid* )nullptr );
-	}
-	ctx->getDefaultVao()->replacementBindEnd();
-	ctx->setDefaultShaderVars();
-	// draw
-	drawArrays( GL_TRIANGLE_STRIP, 0, (GLsizei) positions.size() );
-	ctx->popVao();
+	gl::draw( geom::Ring().center( center ).radius( radius ).width( lineWidth ).subdivisions( numSegments ) );
 }
 
 void drawStrokedEllipse( const vec2 &center, float radiusX, float radiusY, int numSegments )


### PR DESCRIPTION
In response to https://forum.libcinder.org/#Topic/23286000002349013 , I have created a version of ```drawStrokedCircle``` that supports an arbitrary line width. It creates a triangle strip instead of a line loop. 

I should not have to mention that for line width values smaller than 1.0, you need proper (msaa) sub-sampling to make it look good.

