### PR TITLE
AdaptiveThresholdT updates

### DIFF
--- a/include/cinder/ip/Threshold.h
+++ b/include/cinder/ip/Threshold.h
@@ -25,6 +25,8 @@
 #include "cinder/Cinder.h"
 #include "cinder/Surface.h"
 
+#include <vector>
+
 namespace cinder { namespace ip {
 
 //! Thresholds \a surface setting any values below \a value to zero and any values above to unity inside the Area \a area
@@ -58,19 +60,20 @@ void adaptiveThresholdZero( const ChannelT<T> &srcChannel, int32_t windowSize, C
 template<typename T>
 class AdaptiveThresholdT {
   public:
-	AdaptiveThresholdT();
-	AdaptiveThresholdT( ChannelT<T> *channel );
-	~AdaptiveThresholdT();
+	AdaptiveThresholdT()	{}
+	//! Uses \a channel as source, but not assume ownership
+	AdaptiveThresholdT( const ChannelT<T> *channel );
+
 	void calculate( int32_t windowSize, float percentageDelta, ChannelT<T> *dstChannel );
 
  private:
 	typedef typename CHANTRAIT<T>::Accum SUMT;
 
-	ChannelT<T>	* mChannel;
-	int32_t		mImageWidth;
-	int32_t		mImageHeight;
-	int8_t		mIncrement;
-	SUMT		* mIntegralImage;
+	const ChannelT<T>*	mChannel;
+	int32_t				mImageWidth;
+	int32_t				mImageHeight;
+	int8_t				mIncrement;
+	std::vector<SUMT>	mIntegralImage;
 };
 
 typedef AdaptiveThresholdT<uint8_t>		AdaptiveThreshold;

--- a/include/cinder/ip/Threshold.h
+++ b/include/cinder/ip/Threshold.h
@@ -57,31 +57,20 @@ void adaptiveThresholdZero( const ChannelT<T> &srcChannel, int32_t windowSize, C
 
 template<typename T>
 class AdaptiveThresholdT {
+  public:
+	AdaptiveThresholdT();
+	AdaptiveThresholdT( ChannelT<T> *channel );
+	~AdaptiveThresholdT();
+	void calculate( int32_t windowSize, float percentageDelta, ChannelT<T> *dstChannel );
+
  private:
 	typedef typename CHANTRAIT<T>::Accum SUMT;
-	struct Obj {
-		Obj( ChannelT<T> *channel );
-		~Obj();
-	
-		ChannelT<T>	* mChannel;
-		int32_t		mImageWidth;
-		int32_t		mImageHeight;
-		int8_t		mIncrement;
-		SUMT		* mIntegralImage;
-	};
- public:
-	AdaptiveThresholdT() {};
-	AdaptiveThresholdT( ChannelT<T> *channel );
-	void calculate( int32_t windowSize, float percentageDelta, ChannelT<T> *dstChannel );
-	
-	//@{
-	//! Emulates shared_ptr-like behavior
-	typedef std::shared_ptr<Obj> AdaptiveThresholdT::*unspecified_bool_type;
-	operator unspecified_bool_type() const { return ( mObj.get() == 0 ) ? 0 : &AdaptiveThresholdT::mObj; }
-	void reset() { mObj.reset(); }
-	//@}
- private:
-	std::shared_ptr<Obj>		mObj;
+
+	ChannelT<T>	* mChannel;
+	int32_t		mImageWidth;
+	int32_t		mImageHeight;
+	int8_t		mIncrement;
+	SUMT		* mIntegralImage;
 };
 
 typedef AdaptiveThresholdT<uint8_t>		AdaptiveThreshold;

--- a/src/cinder/ip/Threshold.cpp
+++ b/src/cinder/ip/Threshold.cpp
@@ -326,7 +326,7 @@ void adaptiveThresholdZero( const ChannelT<T> &srcChannel, int32_t windowSize, C
 }
 
 template<typename T>
-AdaptiveThresholdT<T>::AdaptiveThresholdT( ChannelT<T> *channel )
+AdaptiveThresholdT<T>::AdaptiveThresholdT( const ChannelT<T> *channel )
 	: mChannel( channel )
 {
 	mImageWidth = mChannel->getWidth();
@@ -334,23 +334,17 @@ AdaptiveThresholdT<T>::AdaptiveThresholdT( ChannelT<T> *channel )
 	mIncrement = mChannel->getIncrement();
 
 	// create the integral image
-	mIntegralImage = (SUMT *)malloc( mImageWidth * mImageHeight * sizeof( typename CHANTRAIT<T>::Accum ) );
-	calculateIntegralImage( *channel, mIntegralImage );
-}
-
-template<typename T>
-AdaptiveThresholdT<T>::~AdaptiveThresholdT()
-{
-	free( mIntegralImage );
+	mIntegralImage.resize( mImageWidth * mImageHeight );
+	calculateIntegralImage( *channel, mIntegralImage.data() );
 }
 
 template<typename T>
 void AdaptiveThresholdT<T>::calculate( int32_t windowSize, float percentageDelta, ChannelT<T> *dstChannel )
 {
 	if( percentageDelta < 0.0001f ) {
-		calculateAdaptiveThresholdZero( mChannel, mIntegralImage, windowSize, dstChannel );
+		calculateAdaptiveThresholdZero( mChannel, mIntegralImage.data(), windowSize, dstChannel );
 	} else {
-		calculateAdaptiveThreshold( mChannel, mIntegralImage, windowSize, percentageDelta, dstChannel );
+		calculateAdaptiveThreshold( mChannel, mIntegralImage.data(), windowSize, percentageDelta, dstChannel );
 	}
 }
 

--- a/src/cinder/ip/Threshold.cpp
+++ b/src/cinder/ip/Threshold.cpp
@@ -326,35 +326,32 @@ void adaptiveThresholdZero( const ChannelT<T> &srcChannel, int32_t windowSize, C
 }
 
 template<typename T>
-AdaptiveThresholdT<T>::Obj::Obj( ChannelT<T> *channel ) : mChannel( channel ) {
+AdaptiveThresholdT<T>::AdaptiveThresholdT( ChannelT<T> *channel )
+	: mChannel( channel )
+{
 	mImageWidth = mChannel->getWidth();
 	mImageHeight = mChannel->getHeight();
 	mIncrement = mChannel->getIncrement();
 
 	// create the integral image
-	mIntegralImage = (SUMT*)malloc( mImageWidth * mImageHeight * sizeof( typename CHANTRAIT<T>::Accum ) );
+	mIntegralImage = (SUMT *)malloc( mImageWidth * mImageHeight * sizeof( typename CHANTRAIT<T>::Accum ) );
 	calculateIntegralImage( *channel, mIntegralImage );
 }
 
 template<typename T>
-AdaptiveThresholdT<T>::Obj::~Obj() {
+AdaptiveThresholdT<T>::~AdaptiveThresholdT()
+{
 	free( mIntegralImage );
 }
 
 template<typename T>
-AdaptiveThresholdT<T>::AdaptiveThresholdT( ChannelT<T> *channel ) 
-	: mObj( new Obj( channel ) ) 
+void AdaptiveThresholdT<T>::calculate( int32_t windowSize, float percentageDelta, ChannelT<T> *dstChannel )
 {
-}
-
-template<typename T>
-void AdaptiveThresholdT<T>::calculate( int32_t windowSize, float percentageDelta, ChannelT<T> *dstChannel ) {
 	if( percentageDelta < 0.0001f ) {
-		calculateAdaptiveThresholdZero( mObj->mChannel, mObj->mIntegralImage, windowSize, dstChannel );
+		calculateAdaptiveThresholdZero( mChannel, mIntegralImage, windowSize, dstChannel );
 	} else {
-		calculateAdaptiveThreshold( mObj->mChannel, mObj->mIntegralImage, windowSize, percentageDelta, dstChannel );
+		calculateAdaptiveThreshold( mChannel, mIntegralImage, windowSize, percentageDelta, dstChannel );
 	}
-	
 }
 
 template class AdaptiveThresholdT<uint8_t>;

--- a/test/ThresholdTest/src/ThresholdTestApp.cpp
+++ b/test/ThresholdTest/src/ThresholdTestApp.cpp
@@ -21,12 +21,15 @@ class ThresholdTestApp : public App {
 	bool					mUseAdaptiveThreshold = false;
 	bool					mUseAdaptivePercentage = false;
 	bool					mShowOriginalGrayScale = false;
+	bool					mUseClassVersion = true;
 	int						mThresholdValue, mAdaptiveThresholdKernel;
 	float					mAdaptiveThresholdPercentage;
 	params::InterfaceGlRef	mParams;
 	gl::TextureRef			mTexture;
 	Surface8uRef			mSurface;
 	Channel8u				mGraySurface, mThresholded;
+
+	ip::AdaptiveThreshold		mThresholdClass;
 };
 
 void ThresholdTestApp::setup()
@@ -36,6 +39,7 @@ void ThresholdTestApp::setup()
 	mParams->addButton( "open file", [this] { loadFile( getOpenFilePath() ); }, "key=o" );
 	mParams->addSeparator();
 	mParams->addParam( "Use Adapative", &mUseAdaptiveThreshold );
+	mParams->addParam( "Use Adapative class", &mUseClassVersion );
 	mParams->addParam( "Use Adapative percentage", &mUseAdaptivePercentage );
 	mParams->addParam( "Show Grayscale", &mShowOriginalGrayScale );
 	mParams->addParam( "Adaptive Kernel", &mAdaptiveThresholdKernel, "min=0 max=1000 keyIncr=k keyDecr=K" );
@@ -55,13 +59,18 @@ void ThresholdTestApp::loadFile( const fs::path &path )
 		mGraySurface = Channel( mSurface->getWidth(), mSurface->getHeight() );
 		mThresholded = Channel( mSurface->getWidth(), mSurface->getHeight() );
 		ip::grayscale( *mSurface, &mGraySurface );
+
+		mThresholdClass = ip::AdaptiveThreshold( &mGraySurface );
 	}
 }
 
 void ThresholdTestApp::update()
 {
 	if( mSurface ) {
-		if( mUseAdaptiveThreshold ) {
+		if( mUseClassVersion ) {
+			mThresholdClass.calculate( mAdaptiveThresholdKernel, mAdaptiveThresholdPercentage, &mThresholded );
+		}
+		else if( mUseAdaptiveThreshold ) {
 			if( mUseAdaptivePercentage )
 				ip::adaptiveThreshold<uint8_t>( mGraySurface, mAdaptiveThresholdKernel, mAdaptiveThresholdPercentage, &mThresholded );
 			else {


### PR DESCRIPTION
Removes `ip::AdaptiveThresholdT`'s internal `shared_ptr<Obj>`, which is the last of its kind. Updated / added test code to test/ThresholdTest. Trying to adhere to current best practices for memory management / const correctness.

Closes #763.