### PR TITLE
Removed f suffix from Rand::randVec2f and randVec3f

### DIFF
--- a/include/cinder/Rand.h
+++ b/include/cinder/Rand.h
@@ -106,7 +106,7 @@ class Rand {
 	}
 	
 	//! returns a random vec3 that represents a point on the unit sphere	
-	vec3 nextVec3f()
+	vec3 nextVec3()
 	{
 		float phi = nextFloat( (float)M_PI * 2.0f );
 		float costheta = nextFloat( -1.0f, 1.0f );
@@ -120,7 +120,7 @@ class Rand {
 	}
 
 	//! returns a random vec2 that represents a point on the unit circle	
-	vec2 nextVec2f()
+	vec2 nextVec2()
 	{
 		float theta = nextFloat( (float)M_PI * 2.0f );
 		return vec2( math<float>::cos( theta ), math<float>::sin( theta ) );

--- a/include/cinder/Rand.h
+++ b/include/cinder/Rand.h
@@ -225,7 +225,7 @@ class Rand {
 	}
 	
 	//! returns a random vec3 that represents a point on the unit sphere
-	static vec3 randVec3f()
+	static vec3 randVec3()
 	{
 		float phi = randFloat( (float)M_PI * 2.0f );
 		float costheta = randFloat( -1.0f, 1.0f );
@@ -239,7 +239,7 @@ class Rand {
 	}
 
 	//! returns a random vec2 that represents a point on the unit circle
-	static vec2 randVec2f()
+	static vec2 randVec2()
 	{
 		float theta = randFloat( (float)M_PI * 2.0f );
 		return vec2( math<float>::cos( theta ), math<float>::sin( theta ) );
@@ -312,10 +312,10 @@ inline float randFloat( float a, float b ) { return Rand::randFloat( a, b ); }
 inline float randPosNegFloat( float a, float b ) { return Rand::randPosNegFloat( a, b ); }
 
 //! returns a random vec3 that represents a point on the unit sphere
-inline vec3 randVec3f() { return Rand::randVec3f(); }
+inline vec3 randVec3() { return Rand::randVec3(); }
 
 //! returns a random vec2 that represents a point on the unit circle
-inline vec2 randVec2f() { return Rand::randVec2f(); }
+inline vec2 randVec2() { return Rand::randVec2(); }
 
 //! returns a random float via Gaussian distribution
 inline float randGaussian() { return Rand::randGaussian(); }    

--- a/samples/Earthquake/src/Earth.cpp
+++ b/samples/Earthquake/src/Earth.cpp
@@ -32,7 +32,7 @@ Earth::Earth( ci::gl::Texture aTexDiffuse, ci::gl::Texture aTexNormal, ci::gl::T
 void Earth::setQuakeLocTip()
 {
 	for( list<Quake>::iterator quake = mQuakes.begin(); quake != mQuakes.end(); ++quake ) {
-		quake->mLoc += Rand::randVec3f() * 0.001f;
+		quake->mLoc += Rand::randVec3() * 0.001f;
 		quake->mLocTip = mLoc + quake->mLoc * ( mRadius + quake->mMag * quake->mMag );
 		quake->mLocTipAnchor = mLoc + quake->mLoc * mRadius;
 	}

--- a/samples/HodginParticlesRedux/src/Emitter.cpp
+++ b/samples/HodginParticlesRedux/src/Emitter.cpp
@@ -24,7 +24,7 @@ void Emitter::update( vec3 mouseLoc, bool enableConstraints, bool mouseIsDown )
 	mVel *= 0.9f;
 	
 	if( mIsTouchingConstraint && mouseIsDown )
-		mVel += Rand::randVec3f() * 3.0f * mHeat;
+		mVel += Rand::randVec3() * 3.0f * mHeat;
 			
 	if( mouseIsDown  ) {
 		mSpinSpeed -= ( mSpinSpeed - 1.0f ) * 0.04f;

--- a/samples/HodginParticlesRedux/src/ParticleController.cpp
+++ b/samples/HodginParticlesRedux/src/ParticleController.cpp
@@ -56,7 +56,7 @@ void ParticleController::update( Emitter &emitter, int counter )
 					mParticles.push_back( Particle( particleIt->mLoc[0], vec3::zero() ) );
 					mParticles.back().mIsDying = true;
 					particleIt->mIsDying = true;
-					//particleIt->mVel += Rand::randVec3f() * Rand::randFloat( 2.0f, 3.0f );
+					//particleIt->mVel += Rand::randVec3() * Rand::randFloat( 2.0f, 3.0f );
 				}
 			}
 			
@@ -118,9 +118,9 @@ void ParticleController::renderTrails()
 void ParticleController::addParticles( int amt, vec3 loc, vec3 vel, float heat, float radius )
 {
 	for( int i = 0; i < amt; i++ ) {
-		vec3 lOffset = Rand::randVec3f();
+		vec3 lOffset = Rand::randVec3();
 		vec3 l = loc + lOffset * radius * 0.25f;
-		vec3 v = -vel + lOffset * Rand::randFloat( 6.0f, 10.5f ) * ( heat + 0.75f ) + Rand::randVec3f() * Rand::randFloat( 1.0f, 2.0f );
+		vec3 v = -vel + lOffset * Rand::randFloat( 6.0f, 10.5f ) * ( heat + 0.75f ) + Rand::randVec3() * Rand::randFloat( 1.0f, 2.0f );
 		v.y *= 0.65f;
 		mParticles.push_back( Particle( l, v ) );
 	}

--- a/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
+++ b/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
@@ -117,7 +117,7 @@ void MotionBlurVelocityBufferApp::createGeometry()
 		float height = randFloat( 100.0f, 300.0f );
 
 		auto mesh = make_shared<BlurrableMesh>( gl::VboMesh::create( geom::Cone().height( height ).base( base ) ), pos );
-		mesh->setAxis( randVec3f() );
+		mesh->setAxis( randVec3() );
 		mesh->setColor( ColorA( CM_HSV, randFloat( 0.05f, 0.33f ), 1.0f, 1.0f ) );
 		mesh->setOscillation( vec3( randFloat( -150.0f, 150.0f ), randFloat( -300.0f, 300.0f ), randFloat( -500.0f, 200.0f ) ) );
 		mesh->setTheta( randFloat( M_PI * 2 ) );

--- a/samples/_opengl/ParticleSphereCPU/src/ParticleSphereCPUApp.cpp
+++ b/samples/_opengl/ParticleSphereCPU/src/ParticleSphereCPUApp.cpp
@@ -73,7 +73,7 @@ void ParticleSphereCPUApp::setup()
 		auto &p = mParticles.at( i );
 		p.pos = center + vec3( x, y, z );
 		p.home = p.pos;
-		p.ppos = p.home + Rand::randVec3f() * 10.0f; // random initial velocity
+		p.ppos = p.home + Rand::randVec3() * 10.0f; // random initial velocity
 		p.damping = Rand::randFloat( 0.965f, 0.985f );
 		p.color = Color( CM_HSV, lmap<float>( i, 0.0f, mParticles.size(), 0.0f, 0.66f ), 1.0f, 1.0f );
 	}

--- a/samples/_opengl/ParticleSphereGPU/src/ParticleSphereGPUApp.cpp
+++ b/samples/_opengl/ParticleSphereGPU/src/ParticleSphereGPUApp.cpp
@@ -87,7 +87,7 @@ void ParticleSphereGPUApp::setup()
 		auto &p = particles.at( i );
 		p.pos = center + vec3( x, y, z );
 		p.home = p.pos;
-		p.ppos = p.home + Rand::randVec3f() * 10.0f; // random initial velocity
+		p.ppos = p.home + Rand::randVec3() * 10.0f; // random initial velocity
 		p.damping = Rand::randFloat( 0.965f, 0.985f );
 		p.color = Color( CM_HSV, lmap<float>( i, 0.0f, particles.size(), 0.0f, 0.66f ), 1.0f, 1.0f );
 	}

--- a/samples/_opengl/ShadowMapping/src/ShadowMappingApp.cpp
+++ b/samples/_opengl/ShadowMapping/src/ShadowMappingApp.cpp
@@ -209,12 +209,12 @@ void ShadowMappingApp::setup()
 	mSphereShadowed = gl::Batch::create( sphere, mShadowShader );
 		
 	for ( size_t i = 0; i < 10; ++i ) {
-		vec3 v( 25.0f * randVec3f() );
+		vec3 v( 25.0f * randVec3() );
 		mat4 m{};
 		m *= translate( v );
 		m *= scale( vec3( 6 * ( randFloat() + 1.1f ) ) );
-		m *= rotate( 2 * glm::pi<float>() * randFloat(), randVec3f() );
-		mTransforms.emplace_back( m, randVec3f() );
+		m *= rotate( 2 * glm::pi<float>() * randFloat(), randVec3() );
+		mTransforms.emplace_back( m, randVec3() );
 	}
 	
 	gl::enableDepthRead();

--- a/samples/_opengl/TransformFeedbackSmokeParticles/src/TransformFeedbackSmokeParticlesApp.cpp
+++ b/samples/_opengl/TransformFeedbackSmokeParticles/src/TransformFeedbackSmokeParticlesApp.cpp
@@ -148,7 +148,7 @@ void TransformFeedbackSmokeParticlesApp::loadBuffers()
 	
 	for( auto normalIt = normals.begin(); normalIt != normals.end(); ++normalIt ) {
 		// Creating a random velocity for each particle in a unit sphere
-		*normalIt = ci::randVec3f() * mix( 0.0f, 1.5f, mRand.nextFloat() );
+		*normalIt = ci::randVec3() * mix( 0.0f, 1.5f, mRand.nextFloat() );
 	}
 	
 	// Create the Velocity Buffer using the newly buffered velocities

--- a/samples/_timeline/TextInputTween/src/TextInputTweenApp.cpp
+++ b/samples/_timeline/TextInputTween/src/TextInputTweenApp.cpp
@@ -101,8 +101,8 @@ void TextInputTweenApp::addChar( char c )
 		mSceneDestMatrix *= translate( vec3( mCharacters.back().getKernBounds().getWidth() / 2.0f, 0.0f, 0.0f ) );
 
 	mat4 randStartMatrix = mSceneDestMatrix;
-	randStartMatrix *= translate( randVec3f() * randFloat( 100.0f, 600.0f ) );
-	randStartMatrix *= rotate( randFloat( 2.0f, 6.0f ), randVec3f() );
+	randStartMatrix *= translate( randVec3() * randFloat( 100.0f, 600.0f ) );
+	randStartMatrix *= rotate( randFloat( 2.0f, 6.0f ), randVec3() );
 	mCharacters.push_back( Character( mTextureFont, string( &c, 1 ), randStartMatrix ) );
 
 	mSceneDestMatrix *= translate( vec3( mCharacters.back().getKernBounds().getWidth() / 2.0f, 0.0f, 0.0f ) );
@@ -128,8 +128,8 @@ void TextInputTweenApp::removeChar()
 			mSceneDestMatrix = mat4();
 
 		mat4 randStartMatrix = mSceneDestMatrix;
-		randStartMatrix *= translate( randVec3f() * randFloat( 100.0f, 600.0f ) );
-		randStartMatrix *= rotate( randFloat( 2.0f, 6.0f ), randVec3f() );
+		randStartMatrix *= translate( randVec3() * randFloat( 100.0f, 600.0f ) );
+		randStartMatrix *= rotate( randFloat( 2.0f, 6.0f ), randVec3() );
 
 		mDyingCharacters.back().animOut( timeline(), randStartMatrix );
 

--- a/samples/rayMarcher/src/RayMarcher.cpp
+++ b/samples/rayMarcher/src/RayMarcher.cpp
@@ -21,7 +21,7 @@ void RayMarcher::randomScene()
 {
 	mSpheres.clear();
 	for( int s = 0; s < 50; ++s ) {
-		mSpheres.push_back( Sphere( Rand::randVec3f() * Rand::randFloat( 8 ), Rand::randFloat( 1, 4 ) ) );
+		mSpheres.push_back( Sphere( Rand::randVec3() * Rand::randFloat( 8 ), Rand::randFloat( 1, 4 ) ) );
 	}
 }
 

--- a/samples/shadowMap/main.cpp
+++ b/samples/shadowMap/main.cpp
@@ -105,7 +105,7 @@ void ShadowMapSample::keyDown( ci::app::KeyEvent event )
 			mPaused = ! mPaused;
 		break;
 		case 'r': { // create a random camera position
-			vec3 eyeVec = Rand::randVec3f().normalized() * 6.0f;
+			vec3 eyeVec = Rand::randVec3().normalized() * 6.0f;
 			if( eyeVec.y < 0 ) eyeVec.y = -eyeVec.y;
 			mCamera->lookAt( eyeVec, vec3(0,-2.5,0) );
 			mLight->update( *mCamera );
@@ -115,7 +115,7 @@ void ShadowMapSample::keyDown( ci::app::KeyEvent event )
 			setFullScreen( ! isFullScreen() );
 		break;
 		case 'l': { // create a random light position
-			vec3 lightPos = Rand::randVec3f().normalized() * 4.0f;
+			vec3 lightPos = Rand::randVec3().normalized() * 4.0f;
 			if( lightPos.y < 0 ) lightPos.y = -lightPos.y;			
 			mLight->lookAt( lightPos, vec3::zero() );
 			mLight->update( *mCamera );

--- a/samples/slerpBasic/src/slerpBasicApp.cpp
+++ b/samples/slerpBasic/src/slerpBasicApp.cpp
@@ -52,8 +52,8 @@ void slerpBasicApp::update()
 
 void slerpBasicApp::setupSlerp()
 {
-	mVecA = randVec3f();
-	mVecB = randVec3f();
+	mVecA = randVec3();
+	mVecB = randVec3();
 	mSlerpAmt = 0;
 }
 

--- a/test/_opengl/ConvenienceDrawingMethods/src/ConvenienceDrawingMethodsApp.cpp
+++ b/test/_opengl/ConvenienceDrawingMethods/src/ConvenienceDrawingMethodsApp.cpp
@@ -46,7 +46,7 @@ void ConvenienceDrawingMethodsApp::setup()
 
 	Rand r;
 	for( int i = 0; i < 50; ++i ) {
-		mPolyline2D.push_back( r.nextVec2f() * cCircleRadius );
+		mPolyline2D.push_back( r.nextVec2() * cCircleRadius );
 	}
 
 	// line wrapping around a sphere

--- a/test/_opengl/QueryTest/src/QueryTestApp.cpp
+++ b/test/_opengl/QueryTest/src/QueryTestApp.cpp
@@ -50,7 +50,7 @@ void QueryTestApp::draw()
 
 	// Expensive CPU operation
 	for( size_t i = 0; i < 75000; ++i ) {
-		Rand::randVec3f();
+		Rand::randVec3();
 	}
 
 	// Expensive GPU pass

--- a/tour/Section 1/Chapter 1/src/Particle.cpp
+++ b/tour/Section 1/Chapter 1/src/Particle.cpp
@@ -12,7 +12,7 @@ Particle::Particle()
 Particle::Particle( vec2 loc )
 {
 	mLoc	= loc;
-	mDir	= Rand::randVec2f();
+	mDir	= Rand::randVec2();
 	mVel	= Rand::randFloat( 5.0f );
 	mRadius	= 3.0f;
 }

--- a/tour/Section 1/Chapter 2/src/Particle.cpp
+++ b/tour/Section 1/Chapter 2/src/Particle.cpp
@@ -12,7 +12,7 @@ Particle::Particle()
 Particle::Particle( vec2 loc )
 {
 	mLoc	= loc;
-	mDir	= Rand::randVec2f();
+	mDir	= Rand::randVec2();
 	mVel	= 0.0f;
 	mRadius	= 4.0f;
 }	

--- a/tour/Section 1/Chapter 3/src/Particle.cpp
+++ b/tour/Section 1/Chapter 3/src/Particle.cpp
@@ -12,7 +12,7 @@ Particle::Particle()
 Particle::Particle( vec2 loc )
 {
 	mLoc			= loc;
-	mDir			= Rand::randVec2f();
+	mDir			= Rand::randVec2();
 	mDirToCursor	= vec2::zero();
 	mVel			= 0.0f;
 	mRadius			= 0.0f;

--- a/tour/Section 1/Chapter 4/src/ParticleController.cpp
+++ b/tour/Section 1/Chapter 4/src/ParticleController.cpp
@@ -33,8 +33,8 @@ void ParticleController::addParticles( int amt, const ivec2 &mouseLoc, const vec
 {
 	for( int i=0; i<amt; i++ )
 	{
-		vec2 loc = mouseLoc + Rand::randVec2f() * 5.0f;
-		vec2 velOffset = Rand::randVec2f() * Rand::randFloat( 1.0f, 5.0f );
+		vec2 loc = mouseLoc + Rand::randVec2() * 5.0f;
+		vec2 velOffset = Rand::randVec2() * Rand::randFloat( 1.0f, 5.0f );
 		vec2 vel = mouseVel * 0.375f + velOffset;
 		mParticles.push_back( Particle( loc, vel ) );
 	}

--- a/tour/Section 1/Chapter 5/src/ParticleController.cpp
+++ b/tour/Section 1/Chapter 5/src/ParticleController.cpp
@@ -72,8 +72,8 @@ void ParticleController::addParticles( int amt, const ivec2 &mouseLoc, const vec
 {
 	for( int i=0; i<amt; i++ )
 	{
-		vec2 loc = mouseLoc + Rand::randVec2f() * Rand::randFloat( 5.0f );
-		vec2 velOffset = Rand::randVec2f() * Rand::randFloat( 1.0f, 3.0f );
+		vec2 loc = mouseLoc + Rand::randVec2() * Rand::randFloat( 5.0f );
+		vec2 velOffset = Rand::randVec2() * Rand::randFloat( 1.0f, 3.0f );
 		vec2 vel = mouseVel * 5.0f + velOffset;
 		mParticles.push_back( Particle( loc, vel ) );
 	}

--- a/tour/Section 2/Chapter 1/src/ParticleController.cpp
+++ b/tour/Section 2/Chapter 1/src/ParticleController.cpp
@@ -34,7 +34,7 @@ void ParticleController::draw()
 void ParticleController::addParticles( int amt )
 {
 	for( int i=0; i<amt; i++ ) {
-		vec3 randVec = Rand::randVec3f();
+		vec3 randVec = Rand::randVec3();
 		vec3 pos = randVec * Rand::randFloat( 50.0f );
 		vec3 vel = randVec * Rand::randFloat( 5.0f );
 		mParticles.push_back( Particle( pos, vel ) );

--- a/tour/Section 2/Chapter 2/src/ParticleController.cpp
+++ b/tour/Section 2/Chapter 2/src/ParticleController.cpp
@@ -63,8 +63,8 @@ void ParticleController::addParticles( int amt )
 {
 	for( int i=0; i<amt; i++ )
 	{
-		vec3 pos = Rand::randVec3f() * Rand::randFloat( 50.0f, 250.0f );
-		vec3 vel = Rand::randVec3f() * 2.0f;
+		vec3 pos = Rand::randVec3() * Rand::randFloat( 50.0f, 250.0f );
+		vec3 vel = Rand::randVec3() * 2.0f;
 		mParticles.push_back( Particle( pos, vel ) );
 	}
 }

--- a/tour/Section 2/Chapter 3/src/ParticleController.cpp
+++ b/tour/Section 2/Chapter 3/src/ParticleController.cpp
@@ -84,7 +84,7 @@ void ParticleController::addParticles( int amt )
 {
 	for( int i=0; i<amt; i++ )
 	{
-		vec3 randVec = Rand::randVec3f();
+		vec3 randVec = Rand::randVec3();
 		vec3 pos = randVec * Rand::randFloat( 50.0f, 250.0f );
 		vec3 vel = randVec * 2.0f;
 		mParticles.push_back( Particle( pos, vel ) );

--- a/tour/Section 2/Chapter 4/src/ParticleController.cpp
+++ b/tour/Section 2/Chapter 4/src/ParticleController.cpp
@@ -93,7 +93,7 @@ void ParticleController::addParticles( int amt )
 {
 	for( int i=0; i<amt; i++ )
 	{
-		vec3 randVec = Rand::randVec3f();
+		vec3 randVec = Rand::randVec3();
 		vec3 pos = randVec * Rand::randFloat( 100.0f, 600.0f );
 		vec3 vel = -randVec;
 

--- a/tour/Section 2/Chapter 5/src/ParticleController.cpp
+++ b/tour/Section 2/Chapter 5/src/ParticleController.cpp
@@ -197,8 +197,8 @@ void ParticleController::addPredators( int amt )
 {
 	for( int i=0; i<amt; i++ )
 	{
-		vec3 pos = Rand::randVec3f() * Rand::randFloat( 500.0f, 750.0f );
-		vec3 vel = Rand::randVec3f();
+		vec3 pos = Rand::randVec3() * Rand::randFloat( 500.0f, 750.0f );
+		vec3 vel = Rand::randVec3();
 		mPredators.push_back( Predator( pos, vel ) );
 	}
 }
@@ -207,8 +207,8 @@ void ParticleController::addParticles( int amt )
 {
 	for( int i=0; i<amt; i++ )
 	{
-		vec3 pos = Rand::randVec3f() * Rand::randFloat( 100.0f, 200.0f );
-		vec3 vel = Rand::randVec3f();
+		vec3 pos = Rand::randVec3() * Rand::randFloat( 100.0f, 200.0f );
+		vec3 vel = Rand::randVec3();
 		
 		bool followed = false;
 		if( mParticles.size() == 0 ) followed = true;


### PR DESCRIPTION
Since moving to GLM, we've been removing the 'f' suffix for float types, as it is the default. This does the same for the Rand variants returning vec2 and vec3 types.

closes #705