### PR TITLE
iOS sample fixes for latest glNext, post app_refactor

### DIFF
--- a/include/cinder/app/Window.h
+++ b/include/cinder/app/Window.h
@@ -254,7 +254,7 @@ class Window : public std::enable_shared_from_this<Window> {
 		bool					mTitleSpecified;
 
 #if defined( CINDER_COCOA_TOUCH )
-		UIViewController *mRootViewController;
+		__unsafe_unretained UIViewController *mRootViewController;
 #endif
 	};
 

--- a/samples/iosKeyboard/src/iosKeyboardApp.cpp
+++ b/samples/iosKeyboard/src/iosKeyboardApp.cpp
@@ -1,4 +1,5 @@
 #include "cinder/app/App.h"
+#include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
 #include "cinder/gl/Texture.h"
 #include "cinder/Text.h"
@@ -59,7 +60,7 @@ void iosKeyboardApp::setup()
 
 	// You can further customize the way the iOS virtual keyboard looks by directly manipulating the managed UITextField:
 	// (note: requires that you build this source file as Obj-C++).
-	getkeyboardTextView().keyboardAppearance = UIKeyboardAppearanceAlert;
+	getKeyboardTextView().keyboardAppearance = UIKeyboardAppearanceAlert;
 }
 
 void iosKeyboardApp::touchesBegan( TouchEvent event )
@@ -162,7 +163,9 @@ void iosKeyboardApp::drawTextView( const TextView &textView )
 		tbox.color( Color( "FireBrick" ) ).text( textView.mText );
 	}
 	gl::color( Color::white() );
-	gl::draw( tbox.render(), fitRect.getUpperLeft() );
+
+	auto tex = gl::Texture::create( tbox.render() );
+	gl::draw( tex, fitRect.getUpperLeft() );
 }
 
 void iosKeyboardApp::layoutTextViews()

--- a/samples/iosNativeControls/src/NativeControlsApp.mm
+++ b/samples/iosNativeControls/src/NativeControlsApp.mm
@@ -23,24 +23,27 @@ using namespace ci;
 using namespace ci::app;
 using namespace std;
 
+// Allocate the custom view controller up front, this will be passed to the Window::Format from within the prepareSettings function
+NativeViewController *sNativeController = [[NativeViewController alloc] init];
+
 class NativeControlsApp : public App {
   public:
-	void prepareSettings( Settings *settings );
-	void setup();
-	void draw();
+	static void prepareSettings( Settings *settings );
+	void setup() override;
+	void cleanup() override;
+	void draw() override;
 
   private:
 	void setupVisuals();
 	void infoTapped();
 
-	NativeViewController*	mNativeController;
 	gl::TextureRef			mTex;
 };
 
+// static
 void NativeControlsApp::prepareSettings( Settings *settings )
 {
-	mNativeController = [NativeViewController new];
-	settings->prepareWindow( Window::Format().rootViewController( mNativeController ) );
+	settings->prepareWindow( Window::Format().rootViewController( sNativeController ) );
 }
 
 void NativeControlsApp::setup()
@@ -48,13 +51,18 @@ void NativeControlsApp::setup()
 	setupVisuals();
 
 	// Example of how to add Cinder's UIViewController to your native root UIViewViewController
-	[mNativeController addCinderViewToFront];
+	[sNativeController addCinderViewToFront];
 
 	// Example of how to add Cinder's UIView to your view heirarchy (comment above out first)
-//	[mNativeController addCinderViewAsBarButton];
+//	[sNativeController addCinderViewAsBarButton];
 
 	// Example of how to add a std::function callback from a UIControl (NativeViewController's info button in the upper right)
-	[mNativeController setInfoButtonCallback: bind( &NativeControlsApp::infoTapped, this ) ];
+	[sNativeController setInfoButtonCallback: bind( &NativeControlsApp::infoTapped, this ) ];
+}
+
+void NativeControlsApp::cleanup()
+{
+	sNativeController = nil; // nil out our strong reference to the native view controller
 }
 
 void NativeControlsApp::setupVisuals()
@@ -102,4 +110,4 @@ void NativeControlsApp::draw()
 	gl::drawCube( vec3( 0 ), vec3( 2 ) );
 }
 
-CINDER_APP( NativeControlsApp, RendererGl )
+CINDER_APP( NativeControlsApp, RendererGl, NativeControlsApp::prepareSettings )

--- a/samples/iosNativeControls/src/NativeControlsApp.mm
+++ b/samples/iosNativeControls/src/NativeControlsApp.mm
@@ -50,11 +50,13 @@ void NativeControlsApp::setup()
 {
 	setupVisuals();
 
+#if 1
 	// Example of how to add Cinder's UIViewController to your native root UIViewViewController
 	[sNativeController addCinderViewToFront];
-
-	// Example of how to add Cinder's UIView to your view heirarchy (comment above out first)
-//	[sNativeController addCinderViewAsBarButton];
+#else
+	// Example of how to add Cinder's UIView to your view heirarchy
+	[sNativeController addCinderViewAsBarButton];
+#endif
 
 	// Example of how to add a std::function callback from a UIControl (NativeViewController's info button in the upper right)
 	[sNativeController setInfoButtonCallback: bind( &NativeControlsApp::infoTapped, this ) ];

--- a/samples/iosNativeControls/xcode_ios/NativeControls.xcodeproj/project.pbxproj
+++ b/samples/iosNativeControls/xcode_ios/NativeControls.xcodeproj/project.pbxproj
@@ -214,7 +214,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -250,7 +250,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_UNIVERSAL_IPHONE_OS)";
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;


### PR DESCRIPTION
For iosKeyboard and iosNativeControls. The latter solution is not so elegant, the NativeViewController point had to be made global but I don't yet see any problem with that in a real world scenario.

There's something I'd like to verify with other obj-c gurus (pinging @pizthewiz), in that I had to declare the Window's UIViewController as `__unsafe_unretained` because it was causing the sample's NativeViewController object to be deallocated when the Window::Format went out of scope (the sample is using ARC, while cinder is still retain / release).  I believe this is kosher, that you can use `__unsafe_unretained` from within a non-ARC project, but it would be nice if someone else could verify as it is a bit hard to find docs related to this.