### PR TITLE
Fixing CGRect/NSRect 32-bit only compile error

### DIFF
--- a/src/cinder/app/cocoa/RendererImpl2dMacQuartz.mm
+++ b/src/cinder/app/cocoa/RendererImpl2dMacQuartz.mm
@@ -89,7 +89,7 @@
 	CGContextRetain( currentRef );
 
 	// set the clipping rectangle to be the parent (CinderView)'s bounds
-	CGRect boundsRect = [[view superview] bounds];
+	CGRect boundsRect = NSRectToCGRect([[view superview] bounds]);
 	CGContextClipToRect( currentRef, boundsRect );
 	
 	// undo any previously transformations, so that we start with identity CTM


### PR DESCRIPTION
Otherwise I get:

```
/cinder/app/cocoa/RendererImpl2dMacQuartz.mm:92:9: error: no viable conversion from 'NSRect' (aka '_NSRect') to 'CGRect'
        CGRect boundsRect = [[view superview] bounds];
               ^            ~~~~~~~~~~~~~~~~~~~~~~~~~
/System/Library/Frameworks/CoreGraphics.framework/Headers/CGGeometry.h:41:8: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'NSRect' (aka '_NSRect') to 'const CGRect &' for 1st argument
struct CGRect {
       ^
/System/Library/Frameworks/CoreGraphics.framework/Headers/CGGeometry.h:41:8: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'NSRect' (aka '_NSRect') to 'CGRect &&' for 1st argument
struct CGRect {
       ^
1 error generated.
```