### PR TITLE
Added static void Voice::clearBufferCache()

### DIFF
--- a/include/cinder/audio/Voice.h
+++ b/include/cinder/audio/Voice.h
@@ -83,6 +83,8 @@ class Voice {
 	static VoiceSamplePlayerNodeRef create( const SourceFileRef &sourceFile, const Options &options = Options() );
 	//! Creates a Voice that continuously calls \a callbackFn to process a Buffer of samples.
 	static VoiceRef create( const CallbackProcessorFn &callbackFn, const Options &options = Options() );
+	//! Clears all audio file buffers that that are cached in the Mixer
+	static void clearBufferCache();
 
 	//! Starts the Voice. Does nothing if currently playing. \note In the case of a VoiceSamplePlayerNode and the sample has reached EOF, start() will start from the beginning.
 	virtual void start();

--- a/src/cinder/audio/Voice.cpp
+++ b/src/cinder/audio/Voice.cpp
@@ -57,6 +57,8 @@ public:
 	void	removeVoice( size_t busId );
 
 	BufferRef loadBuffer( const SourceFileRef &sourceFile );
+	// clears the cache of all previously loaded audio file buffers stored in mBufferCache
+	void clearBufferCache();
 
 private:
 	MixerImpl();
@@ -124,6 +126,11 @@ BufferRef MixerImpl::loadBuffer( const SourceFileRef &sourceFile )
 		mBufferCache.insert( make_pair( sourceFile, result ) );
 		return result;
 	}
+}
+	
+void MixerImpl::clearBufferCache()
+{
+	mBufferCache.clear();
 }
 
 size_t MixerImpl::getFirstAvailableBusId() const
@@ -198,6 +205,11 @@ VoiceSamplePlayerNodeRef Voice::create( const SourceFileRef &sourceFile, const O
 Voice::~Voice()
 {
 	MixerImpl::get()->removeVoice( mBusId );
+}
+	
+void Voice::clearBufferCache()
+{
+	MixerImpl::get()->clearBufferCache();
 }
 
 float Voice::getVolume() const


### PR DESCRIPTION
This function adds the ability to clear the audio buffer cache that the MixerImpl retains.

I am aware of audio::Voice::Options().maxFramesForBufferPlayback to avoid buffering all together, but for my current application I load scenes with dozens of audio files that get played multiple times, so I want them to be cached, but I also want to be able to clear the cache once I unload that scene and load a new scene. This commit adds the ability to do this.