### PR TITLE
write positions to obj file

### DIFF
--- a/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
+++ b/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
@@ -24,6 +24,7 @@ class ObjLoaderApp : public App {
 	void	keyDown( KeyEvent event ) override;
 
 	void	loadObj( const DataSourceRef &dataSource );
+	void	writeObj();
 	void	frameCurrentObject();
 	void	draw() override;
 	
@@ -87,6 +88,15 @@ void ObjLoaderApp::loadObj( const DataSourceRef &dataSource )
 	mArcball.setSphere( mBoundingSphere );
 }
 
+void ObjLoaderApp::writeObj()
+{
+	fs::path filePath = getSaveFilePath();
+	if( ! filePath.empty() ) {
+		console() << "writing mesh to file path: " << filePath << std::endl;
+		objWrite( writeFile( filePath ), mMesh );
+	}
+}
+
 void ObjLoaderApp::frameCurrentObject()
 {
 	mCam = mCam.calcFraming( mBoundingSphere );
@@ -102,6 +112,9 @@ void ObjLoaderApp::keyDown( KeyEvent event )
 	}
 	else if( event.getChar() == 'f' ) {
 		frameCurrentObject();
+	}
+	else if( event.getChar() == 'w' ) {
+		writeObj();
 	}
 }
 

--- a/src/cinder/ObjLoader.cpp
+++ b/src/cinder/ObjLoader.cpp
@@ -748,13 +748,16 @@ void objWrite( DataTargetRef dataTarget, const geom::Source &source, bool includ
 	OStreamRef stream = dataTarget->getStream();
 	
 	unique_ptr<ObjWriteTarget> target( new ObjWriteTarget( stream, includeNormals, includeTexCoords ) );
+
 	geom::AttribSet requestedAttribs;
+	requestedAttribs.insert( geom::POSITION );
 	if( includeNormals )
 		requestedAttribs.insert( geom::NORMAL );
 	if( includeTexCoords )
 		requestedAttribs.insert( geom::TEX_COORD_0 );
+
 	source.loadInto( target.get(), requestedAttribs );
-	
+
 	if( source.getNumIndices() == 0 )
 		target->generateIndices( geom::Primitive::TRIANGLES, source.getNumVertices() );
 }


### PR DESCRIPTION
As reported [here](https://forum.libcinder.org/topic/missing-vertices-in-obj-output-glnext), positions weren't being written in by the `objWrite()` method, this added `geom::POSITION` to loaded requestedAttribs so that it does.

As an aside, I'd like to suggest this method be renamed to `writeObj()`, which is in alignment with methods like `writeImage()` or `writeFile()`, also it would make it an action thus more readable.