### PR TITLE
Addressing GlslProg uniform issue with array of struct member access

### DIFF
--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -987,12 +987,23 @@ const GlslProg::Attribute* GlslProg::findAttrib( geom::Attrib semantic ) const
 	
 const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *resultLocation ) const
 {
-	size_t nameLeftSquareBracket = name.find( '[' );
 	const Uniform* ret = nullptr;
 	for( const auto & uniform : mUniforms ) {
-		if( uniform.mName.substr( 0, uniform.mName.find( '[' ) ) == name.substr( 0, nameLeftSquareBracket ) ) {
+		if( uniform.mName == name ) {
 			ret = &uniform;
 			break;
+		}
+	}
+
+	// support array brackets
+	size_t nameLeftSquareBracket = string::npos;
+	if( ret == nullptr ) { 
+		nameLeftSquareBracket = name.find( '[' );
+		for( const auto & uniform : mUniforms ) {
+			if( uniform.mName.substr( 0, uniform.mName.find( '[' ) ) == name.substr( 0, nameLeftSquareBracket ) ) {
+				ret = &uniform;
+				break;
+			}
 		}
 	}
 


### PR DESCRIPTION
…where ```uUniformName[0].member``` is not supported because it only compares the name before the bracket.

See #948 