### PR TITLE
Build iOS simulator target with simulator SDK to avoid bad archs

### DIFF
--- a/xcode/fullbuild.sh
+++ b/xcode/fullbuild.sh
@@ -3,5 +3,12 @@
 CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 CINDER_XCODEPROJ="${CURRENT_DIR}/cinder.xcodeproj"
 
-xcrun xcodebuild -project ${CINDER_XCODEPROJ} -alltargets -configuration Release $@
-xcrun xcodebuild -project ${CINDER_XCODEPROJ} -alltargets -configuration Debug $@
+# OS X
+xcrun xcodebuild -project ${CINDER_XCODEPROJ} -target cinder -configuration Release $@
+xcrun xcodebuild -project ${CINDER_XCODEPROJ} -target cinder -configuration Debug $@
+
+# iOS
+xcrun xcodebuild -project ${CINDER_XCODEPROJ} -target cinder_iphone -configuration Release -sdk iphoneos $@
+xcrun xcodebuild -project ${CINDER_XCODEPROJ} -target cinder_iphone -configuration Debug -sdk iphoneos $@
+xcrun xcodebuild -project ${CINDER_XCODEPROJ} -target cinder_iphone_sim -configuration Release -sdk iphonesimulator $@
+xcrun xcodebuild -project ${CINDER_XCODEPROJ} -target cinder_iphone_sim -configuration Debug -sdk iphonesimulator $@


### PR DESCRIPTION
Fixes #825

The `cinder_iphone_sim` target seems to build defaulting to the `iphone` SDK when built via `fullbuild.sh`, yielding bad simulator binaries. The tweak here just specifies the SDK for both the `cinder_iphone` and `cinder_iphone_sim` targets to make sure they build as expected - it is still possible to get oneself into trouble building these targets from Xcode with an unintended device vs simulator selection.