### PR TITLE
rename objWrite() -> writeObj()

### DIFF
--- a/include/cinder/ObjLoader.h
+++ b/include/cinder/ObjLoader.h
@@ -155,9 +155,9 @@ class ObjLoader : public geom::Source {
 };
 
 //! Writes \a source to a new OBJ file to \a dataTarget.
-void		writeObj( DataTargetRef dataTarget, const geom::Source &source, bool includeNormals = true, bool includeTexCoords = true );
+void		writeObj( const DataTargetRef &dataTarget, const geom::Source &source, bool includeNormals = true, bool includeTexCoords = true );
 //! Writes \a source to a new OBJ file to \a dataTarget.
-inline void	writeObj( DataTargetRef dataTarget, const geom::SourceRef &source, bool includeNormals = true, bool includeTexCoords = true )
+inline void	writeObj( const DataTargetRef &dataTarget, const geom::SourceRef &source, bool includeNormals = true, bool includeTexCoords = true )
 {
 	writeObj( dataTarget, *source, includeNormals, includeTexCoords );
 }

--- a/include/cinder/ObjLoader.h
+++ b/include/cinder/ObjLoader.h
@@ -154,11 +154,12 @@ class ObjLoader : public geom::Source {
 
 };
 
-//! Writes a new OBJ file to \a dataTarget.
-void		objWrite( DataTargetRef dataTarget, const geom::Source &source, bool includeNormals = true, bool includeTexCoords = true );
-inline void	objWrite( DataTargetRef dataTarget, const geom::SourceRef &source, bool includeNormals = true, bool includeTexCoords = true )
+//! Writes \a source to a new OBJ file to \a dataTarget.
+void		writeObj( DataTargetRef dataTarget, const geom::Source &source, bool includeNormals = true, bool includeTexCoords = true );
+//! Writes \a source to a new OBJ file to \a dataTarget.
+inline void	writeObj( DataTargetRef dataTarget, const geom::SourceRef &source, bool includeNormals = true, bool includeTexCoords = true )
 {
-	objWrite( dataTarget, *source, includeNormals, includeTexCoords );
+	writeObj( dataTarget, *source, includeNormals, includeTexCoords );
 }
 
 } // namespace cinder

--- a/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
+++ b/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
@@ -93,7 +93,7 @@ void ObjLoaderApp::writeObj()
 	fs::path filePath = getSaveFilePath();
 	if( ! filePath.empty() ) {
 		console() << "writing mesh to file path: " << filePath << std::endl;
-		objWrite( writeFile( filePath ), mMesh );
+		writeObj( writeFile( filePath ), mMesh );
 	}
 }
 

--- a/src/cinder/ObjLoader.cpp
+++ b/src/cinder/ObjLoader.cpp
@@ -743,7 +743,7 @@ void ObjWriteTarget::copyIndices( geom::Primitive primitive, const uint32_t *sou
 }
 } // anonymous namespace
 
-void objWrite( DataTargetRef dataTarget, const geom::Source &source, bool includeNormals, bool includeTexCoords )
+void writeObj( DataTargetRef dataTarget, const geom::Source &source, bool includeNormals, bool includeTexCoords )
 {
 	OStreamRef stream = dataTarget->getStream();
 	

--- a/src/cinder/ObjLoader.cpp
+++ b/src/cinder/ObjLoader.cpp
@@ -743,7 +743,7 @@ void ObjWriteTarget::copyIndices( geom::Primitive primitive, const uint32_t *sou
 }
 } // anonymous namespace
 
-void writeObj( DataTargetRef dataTarget, const geom::Source &source, bool includeNormals, bool includeTexCoords )
+void writeObj( const DataTargetRef &dataTarget, const geom::Source &source, bool includeNormals, bool includeTexCoords )
 {
 	OStreamRef stream = dataTarget->getStream();
 	


### PR DESCRIPTION
To be more consistent with other `write*` calls.