### PR TITLE
Add no optimization option to Objloader

### DIFF
--- a/include/cinder/ObjLoader.h
+++ b/include/cinder/ObjLoader.h
@@ -51,17 +51,17 @@ class ObjLoader : public geom::Source {
 	 * \param includeNormals if false texture coordinates will be skipped, which can provide a faster load time
 	 * \param includeTexCoords if false normasls will be skipped, which can provide a faster load time
 	**/
-	ObjLoader( std::shared_ptr<IStreamCinder> stream, bool includeNormals = true, bool includeTexCoords = true );
+	ObjLoader( std::shared_ptr<IStreamCinder> stream, bool includeNormals = true, bool includeTexCoords = true, bool optimize = true );
 	/**Constructs and does the parsing of the file
 	 * \param includeNormals if false texture coordinates will be skipped, which can provide a faster load time
 	 * \param includeTexCoords if false normasls will be skipped, which can provide a faster load time
 	**/
-	ObjLoader( DataSourceRef dataSource, bool includeNormals = true, bool includeTexCoords = true );
+	ObjLoader( DataSourceRef dataSource, bool includeNormals = true, bool includeTexCoords = true, bool optimize = true );
 	/**Constructs and does the parsing of the file
 	 * \param includeNormals if false texture coordinates will be skipped, which can provide a faster load time
 	 * \param includeTexCoords if false normasls will be skipped, which can provide a faster load time
 	**/
-	ObjLoader( DataSourceRef dataSource, DataSourceRef materialSource, bool includeNormals = true, bool includeTexCoords = true );
+	ObjLoader( DataSourceRef dataSource, DataSourceRef materialSource, bool includeNormals = true, bool includeTexCoords = true,  bool optimize = true );
 
 	/**Loads a specific group index from the file**/
 	ObjLoader&	groupIndex( size_t groupIndex );
@@ -141,6 +141,7 @@ class ObjLoader : public geom::Source {
 	std::vector<vec2>			    mInternalTexCoords;
 	std::vector<Colorf>				mInternalColors;
 
+    mutable bool					mOptimizeVertices;
 	mutable bool					mOutputCached;
 	mutable std::vector<vec3>		mOutputVertices, mOutputNormals;
 	mutable std::vector<vec2>		mOutputTexCoords;

--- a/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
+++ b/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
@@ -93,7 +93,7 @@ void ObjLoaderApp::writeObj()
 	fs::path filePath = getSaveFilePath();
 	if( ! filePath.empty() ) {
 		console() << "writing mesh to file path: " << filePath << std::endl;
-		writeObj( writeFile( filePath ), mMesh );
+		ci::writeObj( writeFile( filePath ), mMesh );
 	}
 }
 

--- a/src/cinder/ObjLoader.cpp
+++ b/src/cinder/ObjLoader.cpp
@@ -402,7 +402,7 @@ void ObjLoader::loadGroupNormalsTextures( const Group &group, map<VertexTriple,i
     bool hasColors = mMaterials.size() > 0;
 	for( size_t f = 0; f < group.mFaces.size(); ++f ) {
 		vec3 inferredNormal;
-		bool forceUnique = !mOptimizeVertices;
+		bool forceUnique = ! mOptimizeVertices;
 		Color rgb;
 		if( hasColors ) {
 			const Material *m = group.mFaces[f].mMaterial;
@@ -486,7 +486,7 @@ void ObjLoader::loadGroupNormals( const Group &group, map<VertexPair,int> &uniqu
 			}
         }
 		vec3 inferredNormal;
-		bool forceUnique = !mOptimizeVertices;
+		bool forceUnique = ! mOptimizeVertices;
 		if( group.mFaces[f].mNormalIndices.empty() ) { // we'll have to derive it from two edges
 			vec3 edge1 = mInternalVertices[group.mFaces[f].mVertexIndices[1]] - mInternalVertices[group.mFaces[f].mVertexIndices[0]];
 			vec3 edge2 = mInternalVertices[group.mFaces[f].mVertexIndices[2]] - mInternalVertices[group.mFaces[f].mVertexIndices[0]];
@@ -547,7 +547,7 @@ void ObjLoader::loadGroupTextures( const Group &group, map<VertexPair,int> &uniq
 				rgb.b = 1;
 			}
 		}
-		bool forceUnique = !mOptimizeVertices;
+		bool forceUnique = ! mOptimizeVertices;
 		if( group.mFaces[f].mTexCoordIndices.empty() )
 			forceUnique = true;
 		

--- a/src/cinder/ObjLoader.cpp
+++ b/src/cinder/ObjLoader.cpp
@@ -35,20 +35,20 @@ geom::SourceRef	loadGeom( const fs::path &path )
 	return geom::SourceRef();
 }
 
-ObjLoader::ObjLoader( shared_ptr<IStreamCinder> stream, bool includeNormals, bool includeTexCoords )
-	: mStream( stream ), mOutputCached( false ), mGroupIndex( numeric_limits<size_t>::max() )
+ObjLoader::ObjLoader( shared_ptr<IStreamCinder> stream, bool includeNormals, bool includeTexCoords, bool optimize )
+	: mStream( stream ), mOutputCached( false ), mOptimizeVertices( optimize ), mGroupIndex( numeric_limits<size_t>::max() )
 {
 	parse( includeNormals, includeTexCoords );
 }
 
-ObjLoader::ObjLoader( DataSourceRef dataSource, bool includeNormals, bool includeTexCoords )
-	: mStream( dataSource->createStream() ), mOutputCached( false ), mGroupIndex( numeric_limits<size_t>::max() )
+ObjLoader::ObjLoader( DataSourceRef dataSource, bool includeNormals, bool includeTexCoords, bool optimize )
+	: mStream( dataSource->createStream() ), mOutputCached( false ), mOptimizeVertices( optimize ), mGroupIndex( numeric_limits<size_t>::max() )
 {
 	parse( includeNormals, includeTexCoords );
 }
 
-ObjLoader::ObjLoader( DataSourceRef dataSource, DataSourceRef materialSource, bool includeNormals, bool includeTexCoords )
-	: mStream( dataSource->createStream() ), mOutputCached( false ), mGroupIndex( numeric_limits<size_t>::max() )
+ObjLoader::ObjLoader( DataSourceRef dataSource, DataSourceRef materialSource, bool includeNormals, bool includeTexCoords, bool optimize )
+	: mStream( dataSource->createStream() ), mOutputCached( false ), mOptimizeVertices( optimize ), mGroupIndex( numeric_limits<size_t>::max() )
 {
 	parseMaterial( materialSource->createStream() );
 	parse( includeNormals, includeTexCoords );
@@ -402,7 +402,7 @@ void ObjLoader::loadGroupNormalsTextures( const Group &group, map<VertexTriple,i
     bool hasColors = mMaterials.size() > 0;
 	for( size_t f = 0; f < group.mFaces.size(); ++f ) {
 		vec3 inferredNormal;
-		bool forceUnique = false;
+		bool forceUnique = !mOptimizeVertices;
 		Color rgb;
 		if( hasColors ) {
 			const Material *m = group.mFaces[f].mMaterial;
@@ -486,7 +486,7 @@ void ObjLoader::loadGroupNormals( const Group &group, map<VertexPair,int> &uniqu
 			}
         }
 		vec3 inferredNormal;
-		bool forceUnique = false;
+		bool forceUnique = !mOptimizeVertices;
 		if( group.mFaces[f].mNormalIndices.empty() ) { // we'll have to derive it from two edges
 			vec3 edge1 = mInternalVertices[group.mFaces[f].mVertexIndices[1]] - mInternalVertices[group.mFaces[f].mVertexIndices[0]];
 			vec3 edge2 = mInternalVertices[group.mFaces[f].mVertexIndices[2]] - mInternalVertices[group.mFaces[f].mVertexIndices[0]];
@@ -547,7 +547,7 @@ void ObjLoader::loadGroupTextures( const Group &group, map<VertexPair,int> &uniq
 				rgb.b = 1;
 			}
 		}
-		bool forceUnique = false;
+		bool forceUnique = !mOptimizeVertices;
 		if( group.mFaces[f].mTexCoordIndices.empty() )
 			forceUnique = true;
 		


### PR DESCRIPTION
I added the option to not optimize vertices in ``ObjLoader``.
Instead of using a separate function, like it was in 0.8.6, I'm forcing the existing variable ``forceUnique`` to ``true`` for every vertex, when the user chooses to not optimize.
It's a pretty minimal change, although it might not be the fastest way, not sure.

I also fixed a namespace bug in the ObjLoader sample.