### PR TITLE
Adds deleter to Texture*::Format; changes clean bounds semantics

### DIFF
--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -690,19 +690,28 @@ void TextureBase::Format::setBorderColor( const ColorA &color )
 #if ! defined( CINDER_GL_ES )
 /////////////////////////////////////////////////////////////////////////////////
 // Texture1d
-Texture1dRef Texture1d::create( GLint width, Format format )
+Texture1dRef Texture1d::create( GLint width, const Format &format )
 {
-	return Texture1dRef( new Texture1d( width, format ) );
+	if( format.mDeleter )
+		return Texture1dRef( new Texture1d( width, format ), format.mDeleter );
+	else
+		return Texture1dRef( new Texture1d( width, format ) );
 }
 
-Texture1dRef Texture1d::create( const Surface8u &surface, Format format )
+Texture1dRef Texture1d::create( const Surface8u &surface, const Format &format )
 {
-	return Texture1dRef( new Texture1d( surface, format ) );
+	if( format.mDeleter )
+		return Texture1dRef( new Texture1d( surface, format ), format.mDeleter );
+	else
+		return Texture1dRef( new Texture1d( surface, format ) );
 }
 
-Texture1dRef Texture1d::create( const void *data, GLenum dataFormat, int width, Format format )
+Texture1dRef Texture1d::create( const void *data, GLenum dataFormat, int width, const Format &format )
 {
-	return Texture1dRef( new Texture1d( data, dataFormat, width, format ) );
+	if( format.mDeleter )
+		return Texture1dRef( new Texture1d( data, dataFormat, width, format ), format.mDeleter );
+	else
+		return Texture1dRef( new Texture1d( data, dataFormat, width, format ) );
 }
 
 Texture1d::Texture1d( GLint width, Format format )
@@ -774,59 +783,92 @@ void Texture1d::printDims( std::ostream &os ) const
 
 /////////////////////////////////////////////////////////////////////////////////
 // Texture2d
-Texture2dRef Texture2d::create( int width, int height, Format format )
+Texture2dRef Texture2d::create( int width, int height, const Format &format )
 {
-	return TextureRef( new Texture( width, height, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( width, height, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( width, height, format ) );
 }
 
-Texture2dRef Texture2d::create( const void *data, GLenum dataFormat, int width, int height, Format format )
+Texture2dRef Texture2d::create( const void *data, GLenum dataFormat, int width, int height, const Format &format )
 {
-	return TextureRef( new Texture( data, dataFormat, width, height, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( data, dataFormat, width, height, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( data, dataFormat, width, height, format ) );
 }
 
-Texture2dRef Texture2d::create( const Surface8u &surface, Format format )
+Texture2dRef Texture2d::create( const Surface8u &surface, const Format &format )
 {
-	return TextureRef( new Texture( surface, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( surface, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( surface, format ) );
 }
 
-Texture2dRef Texture2d::create( const Surface16u &surface, Format format )
+Texture2dRef Texture2d::create( const Surface16u &surface, const Format &format )
 {
-	return TextureRef( new Texture( surface, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( surface, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( surface, format ) );
 }
 
-Texture2dRef Texture2d::create( const Surface32f &surface, Format format )
+Texture2dRef Texture2d::create( const Surface32f &surface, const Format &format )
 {
-	return TextureRef( new Texture( surface, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( surface, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( surface, format ) );
 }
 
-Texture2dRef Texture2d::create( const Channel8u &channel, Format format )
+Texture2dRef Texture2d::create( const Channel8u &channel, const Format &format )
 {
-	return TextureRef( new Texture( channel, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( channel, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( channel, format ) );
 }
 
-Texture2dRef Texture2d::create( const Channel16u &channel, Format format )
+Texture2dRef Texture2d::create( const Channel16u &channel, const Format &format )
 {
-	return TextureRef( new Texture( channel, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( channel, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( channel, format ) );
 }
 	
-Texture2dRef Texture2d::create( const Channel32f &channel, Format format )
+Texture2dRef Texture2d::create( const Channel32f &channel, const Format &format )
 {
-	return TextureRef( new Texture( channel, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( channel, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( channel, format ) );
 }
 	
-Texture2dRef Texture2d::create( ImageSourceRef imageSource, Format format )
+Texture2dRef Texture2d::create( ImageSourceRef imageSource, const Format &format )
 {
-	return TextureRef( new Texture( imageSource, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( imageSource, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( imageSource, format ) );
 }
 	
-Texture2dRef Texture2d::create( GLenum target, GLuint textureID, int width, int height, bool doNotDispose )
+Texture2dRef Texture2d::create( GLenum target, GLuint textureID, int width, int height, bool doNotDispose, const std::function<void(Texture2d*)> &deleter )
 {
-	return TextureRef( new Texture( target, textureID, width, height, doNotDispose ) );
+	if( deleter )
+		return TextureRef( new Texture( target, textureID, width, height, doNotDispose ), deleter );
+	else
+		return TextureRef( new Texture( target, textureID, width, height, doNotDispose ) );
 }
 
 Texture2dRef Texture2d::create( const TextureData &data, const Format &format )
 {
-	return TextureRef( new Texture( data, format ) );
+	if( format.mDeleter )
+		return TextureRef( new Texture( data, format ), format.mDeleter );
+	else
+		return TextureRef( new Texture( data, format ) );
 }
 
 void Texture2d::initMaxMipmapLevel()
@@ -1519,14 +1561,20 @@ ImageSourceRef Texture2d::createSource()
 #if ! defined( CINDER_GL_ES_2 )
 /////////////////////////////////////////////////////////////////////////////////
 // Texture3d
-Texture3dRef Texture3d::create( GLint width, GLint height, GLint depth, Format format )
+Texture3dRef Texture3d::create( GLint width, GLint height, GLint depth, const Format &format )
 {
-	return Texture3dRef( new Texture3d( width, height, depth, format ) );
+	if( format.mDeleter )
+		return Texture3dRef( new Texture3d( width, height, depth, format ), format.mDeleter );
+	else
+		return Texture3dRef( new Texture3d( width, height, depth, format ) );
 }
 
-Texture3dRef Texture3d::create( const void *data, GLenum dataFormat, int width, int height, int depth, Format format )
+Texture3dRef Texture3d::create( const void *data, GLenum dataFormat, int width, int height, int depth, const Format &format )
 {
-	return Texture3dRef( new Texture3d( data, dataFormat, width, height, depth, format ) );
+	if( format.mDeleter )
+		return Texture3dRef( new Texture3d( data, dataFormat, width, height, depth, format ), format.mDeleter );
+	else
+		return Texture3dRef( new Texture3d( data, dataFormat, width, height, depth, format ) );
 }
 
 Texture3d::Texture3d( GLint width, GLint height, GLint depth, Format format )
@@ -1696,7 +1744,10 @@ TextureCubeMap::Format::Format()
 
 TextureCubeMapRef TextureCubeMap::create( int32_t width, int32_t height, const Format &format )
 {
-	return TextureCubeMapRef( new TextureCubeMap( width, height, format ) );
+	if( format.mDeleter )
+		return TextureCubeMapRef( new TextureCubeMap( width, height, format ), format.mDeleter );
+	else
+		return TextureCubeMapRef( new TextureCubeMap( width, height, format ) );
 }
 
 TextureCubeMapRef TextureCubeMap::create( const ImageSourceRef &imageSource, const Format &format )
@@ -1735,7 +1786,10 @@ TextureCubeMapRef TextureCubeMap::createTextureCubeMapImpl( const ImageSourceRef
 		images[f].copyFrom( masterSurface, faceRegions[f].first, faceRegions[f].second );
 	}
 	
-	return TextureCubeMapRef( new TextureCubeMap( images, format ) );
+	if( format.mDeleter )
+		return TextureCubeMapRef( new TextureCubeMap( images, format ), format.mDeleter );
+	else
+		return TextureCubeMapRef( new TextureCubeMap( images, format ) );
 }
 
 TextureCubeMapRef TextureCubeMap::create( const ImageSourceRef images[6], const Format &format )
@@ -1745,14 +1799,20 @@ TextureCubeMapRef TextureCubeMap::create( const ImageSourceRef images[6], const 
 		for( size_t i = 0; i < 6; ++i )
 			surfaces[i] = Surface8u( images[i] );
 		
-		return TextureCubeMapRef( new TextureCubeMap( surfaces, format ) );
+		if( format.mDeleter )
+			return TextureCubeMapRef( new TextureCubeMap( surfaces, format ), format.mDeleter );
+		else
+			return TextureCubeMapRef( new TextureCubeMap( surfaces, format ) );
 	}
 	else {
 		Surface32f surfaces[6];
 		for( size_t i = 0; i < 6; ++i )
 			surfaces[i] = Surface32f( images[i] );
 		
-		return TextureCubeMapRef( new TextureCubeMap( surfaces, format ) );
+		if( format.mDeleter )
+			return TextureCubeMapRef( new TextureCubeMap( surfaces, format ), format.mDeleter );
+		else
+			return TextureCubeMapRef( new TextureCubeMap( surfaces, format ) );
 	}
 }
 

--- a/src/cinder/gl/draw.cpp
+++ b/src/cinder/gl/draw.cpp
@@ -1182,7 +1182,7 @@ void drawStringHelper( const std::string &str, const vec2 &pos, const ColorA &co
 	ivec2 actualSize;
 	Surface8u pow2Surface( renderStringPow2( str, font, color, &actualSize, &baselineOffset ) );
 	gl::TextureRef tex = gl::Texture::create( pow2Surface );
-	tex->setCleanSize( actualSize.x, actualSize.y );
+	tex->setCleanBounds( Area( 0, 0, actualSize.x, actualSize.y ) );
 	baselineOffset += pow2Surface.getHeight();
 #else
 	gl::TextureRef tex = gl::Texture::create( renderString( str, font, color, &baselineOffset ) );

--- a/src/cinder/qtime/QuickTimeGlImplAvf.cpp
+++ b/src/cinder/qtime/QuickTimeGlImplAvf.cpp
@@ -234,13 +234,22 @@ void MovieGl::newFrame( CVImageBufferRef cvImage )
 	
 	mTexture = gl::Texture2d::create( target, name, mWidth, mHeight, true, deleter );
 	
-//	vec2 t0, lowerRight, t2, upperLeft;
-//	::CVOpenGLESTextureGetCleanTexCoords( videoTextureRef, &t0.x, &lowerRight.x, &t2.x, &upperLeft.x );
+	// query and set clean bounds
+	vec2 lowerLeft, lowerRight, upperRight, upperLeft;
+	::CVOpenGLESTextureGetCleanTexCoords( videoTextureRef, &lowerLeft.x, &lowerRight.x, &upperRight.x, &upperLeft.x );
+	if( target == GL_TEXTURE_2D )
+		mTexture->setCleanBounds( Area( (int32_t)(upperLeft.x * mWidth), (int32_t)(upperLeft.y * mHeight),
+			(int32_t)(lowerRight.x * mWidth ), (int32_t)(lowerRight.y * mHeight ) ) );
+	else
+		mTexture->setCleanBounds( Area( (int32_t)upperLeft.x, (int32_t)upperLeft.y, (int32_t)lowerRight.x, (int32_t)lowerRight.y ) );
+	
 	mTexture->setWrap( GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE );
-	mTexture->setCleanSize( mWidth, mHeight );
 	mTexture->setTopDown( topDown );
+	
 #elif defined( CINDER_MAC )
+
 	mTexture = mTextureCache->add( cvImage );
+
 #endif
 }
 

--- a/test/_opengl/TextureUpload/xcode/TextureUpload.xcodeproj/project.pbxproj
+++ b/test/_opengl/TextureUpload/xcode/TextureUpload.xcodeproj/project.pbxproj
@@ -9,13 +9,13 @@
 /* Begin PBXBuildFile section */
 		006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720219952D00008149E2 /* AVFoundation.framework */; };
 		006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720319952D00008149E2 /* CoreMedia.framework */; };
+		00822ED01B210D6F00EB0E21 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00822ECF1B210D6F00EB0E21 /* IOKit.framework */; };
 		0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0091D8F80E81B9330029341E /* OpenGL.framework */; };
 		00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784AF0FF439BC000DE1D7 /* Accelerate.framework */; };
 		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
-		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		564C0DE8A07D47C8A28D121B /* TextureUploadApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01350EB98A6C4EFCA6F4E71B /* TextureUploadApp.cpp */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 /* End PBXBuildFile section */
@@ -23,6 +23,7 @@
 /* Begin PBXFileReference section */
 		006D720219952D00008149E2 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		006D720319952D00008149E2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		00822ECF1B210D6F00EB0E21 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		0091D8F80E81B9330029341E /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
 		00B784AF0FF439BC000DE1D7 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
@@ -45,12 +46,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				00822ED01B210D6F00EB0E21 /* IOKit.framework in Frameworks */,
 				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
 				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */,
 				5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */,
-				5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */,
 				00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */,
 				00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */,
 				00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */,
@@ -135,6 +136,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				00822ECF1B210D6F00EB0E21 /* IOKit.framework */,
 				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
 				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
 			);


### PR DESCRIPTION
This address 2 issues; the first is my approach for #542, adding an optional custom deleter to the Format of the various Texture types. Second, this makes "clean bounds" on Texture2d the default mode of thinking, and the 'actual' size specialized. For the average use case none of this matters, but it makes having a clean bounds distinct from the full Texture2d behave more naturally in more situations.