### PR TITLE
Expose display name

### DIFF
--- a/include/cinder/Display.h
+++ b/include/cinder/Display.h
@@ -39,7 +39,7 @@ typedef std::shared_ptr<class Display> 	DisplayRef;
 
 class Display {
   public:
-	Display() : mArea( Area::zero() ), mBitsPerPixel( 0 ), mContentScale( 1.0f ), mName( "" ) {}
+	Display() : mArea( Area::zero() ), mBitsPerPixel( 0 ), mContentScale( 1.0f ), mName( "" ), mNameDirty ( true ) {}
 	virtual ~Display() {}
 
 	//! Returns the width of the screen measured in points
@@ -65,7 +65,7 @@ class Display {
 	bool	contains( const ivec2 &pt ) const { return mArea.contains( pt ); }
 
 	//! Returns the display's name or an empty string if unavailable.
-	std::string		getName() const { return mName; }
+	virtual std::string		getName() const { return mName; }
 
 	//! Returns the system's primary display
 	static DisplayRef						getMainDisplay();
@@ -82,10 +82,11 @@ class Display {
 	}	
 
   protected:
-	Area			mArea;
-	int				mBitsPerPixel;
-	float			mContentScale;
-	std::string		mName;
+	Area				mArea;
+	int					mBitsPerPixel;
+	float				mContentScale;
+	mutable std::string	mName;
+	mutable bool		mNameDirty;
 };
 
 } // namespace cinder

--- a/include/cinder/Display.h
+++ b/include/cinder/Display.h
@@ -39,6 +39,7 @@ typedef std::shared_ptr<class Display> 	DisplayRef;
 
 class Display {
   public:
+	Display() : mArea( Area::zero() ), mBitsPerPixel( 0 ), mContentScale( 1.0f ), mName( "" ) {}
 	virtual ~Display() {}
 
 	//! Returns the width of the screen measured in points
@@ -63,6 +64,9 @@ class Display {
 	//! Returns whether the Display's coordinates contain \a pt.
 	bool	contains( const ivec2 &pt ) const { return mArea.contains( pt ); }
 
+	//! Returns the display's name or an empty string if unavailable.
+	std::string		getName() const { return mName; }
+
 	//! Returns the system's primary display
 	static DisplayRef						getMainDisplay();
 	//! Returns a vector of all displays connected to the system
@@ -78,9 +82,10 @@ class Display {
 	}	
 
   protected:
-	Area		mArea;
-	int			mBitsPerPixel;
-	float		mContentScale;
+	Area			mArea;
+	int				mBitsPerPixel;
+	float			mContentScale;
+	std::string		mName;
 };
 
 } // namespace cinder

--- a/include/cinder/app/cocoa/PlatformCocoa.h
+++ b/include/cinder/app/cocoa/PlatformCocoa.h
@@ -149,6 +149,8 @@ class DisplayMac : public Display {
 	NSScreen*			getNsScreen() const;
 	CGDirectDisplayID	getCgDirectDisplayId() const { return mDirectDisplayId; }
 
+	std::string			getName() const override;
+
   protected:	
 	static void	displayReconfiguredCallback( CGDirectDisplayID displayId, CGDisplayChangeSummaryFlags flags, void *userInfo );
 

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -419,11 +419,11 @@ DisplayRef app::PlatformCocoa::findFromCgDirectDisplayId( CGDirectDisplayID disp
 
 std::string DisplayMac::getName() const
 {
-    if( mNameDirty ) {
+	if( mNameDirty ) {
 		mName = getDisplayName( mDirectDisplayId );
 		mNameDirty = false;
-    }
-    return mName;
+	}
+	return mName;
 }
 
 DisplayRef app::PlatformCocoa::findFromNsScreen( NSScreen *nsScreen )

--- a/src/cinder/app/msw/PlatformMsw.cpp
+++ b/src/cinder/app/msw/PlatformMsw.cpp
@@ -275,6 +275,14 @@ int getMonitorBitsPerPixel( HMONITOR hMonitor )
 
 	return result;
 }
+std::string getMonitorName( HMONITOR hMonitor )
+{
+	MONITORINFOEX mix;
+	memset( &mix, 0, sizeof( MONITORINFOEX ) );
+	mix.cbSize = sizeof( MONITORINFOEX );
+	GetMonitorInfo( hMonitor, &mix );
+	return msw::toUtf8String( std::wstring( mix.szDevice ) );
+}
 } // anonymous namespace
 
 BOOL CALLBACK DisplayMsw::enumMonitorProc( HMONITOR hMonitor, HDC hdc, LPRECT rect, LPARAM lParam )
@@ -286,7 +294,8 @@ BOOL CALLBACK DisplayMsw::enumMonitorProc( HMONITOR hMonitor, HDC hdc, LPRECT re
 	newDisplay->mMonitor = hMonitor;
 	newDisplay->mContentScale = 1.0f;
 	newDisplay->mBitsPerPixel = getMonitorBitsPerPixel( hMonitor );
-		
+	newDisplay->mName = getMonitorName( hMonitor );
+
 	displaysVector->push_back( DisplayRef( newDisplay ) );
 	return TRUE;
 }

--- a/test/windowTest/src/windowTestApp.cpp
+++ b/test/windowTest/src/windowTestApp.cpp
@@ -69,7 +69,7 @@ void WindowTestApp::prepareSettings( Settings *settings )
 void WindowTestApp::setup()
 {
 	for( auto display : Display::getDisplays() )
-		CI_LOG_V( "display bounds: " << display->getBounds() );
+		CI_LOG_V( "display name: '" << display->getName() << "', bounds: " << display->getBounds() );
 
 	getWindow()->setUserData( new WindowData );
 


### PR DESCRIPTION
Propose adding a method to fetch the display name:
```C++
//! Returns the display's name or an empty string if unavailable.
std::string		getName() const { return mName; }
```

### OS X
Now that Cinder links to the IOKit framework on the OS X side, we can fetch and expose the display name without any additional dependencies. Implementation tested on:
:heavy_check_mark: OS X 10.10.4 / Xcode 6.4 / `x86_64`
:heavy_check_mark: OS X 10.8.5 / Xcode 5.1.1 / `x86_64` & `i386` (both in a VM)
and verified by adding the following to `setup()` and checking the output:
```C++
for( auto &display : Display::getDisplays() ) {
    console() << display->getName() << std::endl;
}
```

It is worth noting that an "AirPlay Display", the additional display made available by an extended desktop to an Apple TV, does not provide a display name.

### iOS
Probably not relevant as I don't think iOS has named displays.

### MSW
:question: Windows 8.1 / VS 2013 Express

An MSW implementation is provided but hasn't been tested. Though I did get Cinder building in a VM, VMWare Fusion unfortunately only supports OpenGL 2.1 (as does Parallels), so while Cinder and my sample app compile, it dies on launch failing to create a renderer. Could someone with a more reasonable setup give it a look; I'm also not 100% sure if my `TCHAR` to `std::string` conversion is legit either.

### WinRT
Probably relevant though I'm not providing an implementation here (yet).