### PR TITLE
Make app::loadAsset() work before App is instantiated

### DIFF
--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -349,12 +349,12 @@ class AppBase {
 #endif
 
 	//! Returns a DataSourceRef to an application asset. Throws a AssetLoadExc on failure.
-	DataSourceRef			loadAsset( const fs::path &relativePath )					{ return Platform::get()->loadAsset( relativePath ); }
+	DataSourceRef		loadAsset( const fs::path &relativePath )					{ return Platform::get()->loadAsset( relativePath ); }
 	//! Returns a fs::path to an application asset. Returns an empty path on failure.
-	fs::path				getAssetPath( const fs::path &relativePath ) const			{ return Platform::get()->getAssetPath( relativePath ); }
+	fs::path			getAssetPath( const fs::path &relativePath ) const			{ return Platform::get()->getAssetPath( relativePath ); }
 	//! Adds an absolute path 'dirPath' to the list of directories which are searched for assets.
-	void					addAssetDirectory( const fs::path &dirPath )				{ return Platform::get()->addAssetDirectory( dirPath ); }
-	
+	void				addAssetDirectory( const fs::path &dirPath )				{ return Platform::get()->addAssetDirectory( dirPath ); }
+
 	//! Returns the path to the application on disk
 	fs::path			getAppPath() const											{ return Platform::get()->getExecutablePath(); }
 

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -356,7 +356,7 @@ class AppBase {
 	void					addAssetDirectory( const fs::path &dirPath )				{ return Platform::get()->addAssetDirectory( dirPath ); }
 	
 	//! Returns the path to the application on disk
-	virtual fs::path		getAppPath() const = 0;
+	fs::path			getAppPath() const											{ return Platform::get()->getExecutablePath(); }
 
 	//! \brief Presents the user with an open-file dialog and returns the selected file path.
 	//!

--- a/include/cinder/app/AppScreenSaver.h
+++ b/include/cinder/app/AppScreenSaver.h
@@ -127,8 +127,6 @@ class AppScreenSaver : public AppBase {
 	}
 #endif
 
-	fs::path		getAppPath() const override;
-
 #if defined( CINDER_COCOA )
 	NSBundle*		getBundle() const;
 #endif

--- a/include/cinder/app/AppScreenSaver.h
+++ b/include/cinder/app/AppScreenSaver.h
@@ -160,7 +160,7 @@ class AppScreenSaver : public AppBase {
 	}
 
 #elif defined( CINDER_MSW )
-	void							launch( const char *title, int argc, char * const argv[] );
+	void							launch() override;
 	virtual bool					getsWindowsPaintEvents() { return false; }
 	LRESULT							eventHandler( HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam );
 
@@ -178,7 +178,7 @@ class AppScreenSaver : public AppBase {
 		AppScreenSaver::sMainHwnd = mainHwnd;
 		AppScreenSaver *app = new AppT;
 
-		AppBase::executeLaunch( title, 0, nullptr );
+		app->executeLaunch();
 
 		return app;
 	}

--- a/include/cinder/app/Platform.h
+++ b/include/cinder/app/Platform.h
@@ -113,9 +113,9 @@ class Platform {
 	//! Returns a canonical version of \a path. Collapses '.', ".." and "//". Converts '~' on Cocoa. Expands environment variables on MSW.
 	virtual fs::path	expandPath( const fs::path &path ) = 0;
 	//! Returns the path to the user's home directory.
-	virtual fs::path	getHomeDirectory() = 0;
+	virtual fs::path	getHomeDirectory() const = 0;
 	//! Returns the path to the user's documents directory.
-	virtual fs::path	getDocumentsDirectory()	= 0;
+	virtual fs::path	getDocumentsDirectory() const = 0;
 	//! Returns the path used for the default executable location. Users may override this with setExecutablePath() for application specific purposes.
 	virtual fs::path	getDefaultExecutablePath() const = 0;
 

--- a/include/cinder/app/Platform.h
+++ b/include/cinder/app/Platform.h
@@ -77,8 +77,10 @@ class Platform {
 	//! Returns the absolute file path to a resource located at \a rsrcRelativePath inside the bundle's resources folder. Throws ResourceLoadExc on failure. \sa CinderResources
 	virtual fs::path	getResourcePath( const fs::path &rsrcRelativePath ) const = 0;
 
+	//! Returns the path to the associated executable
+	fs::path			getExecutablePath() const;
+	//! Sets the path to the associated executable, overriding the default
 	void				setExecutablePath( const fs::path &execPath )	{ mExecutablePath = execPath; }
-	fs::path			getExecutablePath() const						{ return mExecutablePath; }
 
 #if defined( CINDER_WINRT )
 	//! Presents the user with an open-file dialog and returns the selected file path. \a callback is called with the file selected asynchronously.
@@ -114,6 +116,8 @@ class Platform {
 	virtual fs::path	getHomeDirectory() = 0;
 	//! Returns the path to the user's documents directory.
 	virtual fs::path	getDocumentsDirectory()	= 0;
+	//! Returns the path used for the default executable location. Users may override this with setExecutablePath() for application specific purposes.
+	virtual fs::path	getDefaultExecutablePath() const = 0;
 
 	//! Suspends the execution of the current thread until \a milliseconds have passed. Supports sub-millisecond precision only on OS X.
 	virtual void sleep( float milliseconds ) = 0;
@@ -140,7 +144,7 @@ class Platform {
 
 	std::vector<fs::path>		mAssetDirectories;
 	bool						mAssetDirsInitialized;
-	fs::path					mExecutablePath;
+	mutable fs::path			mExecutablePath; // lazily defaulted if none exists
 };
 
 

--- a/include/cinder/app/cocoa/AppCocoaTouch.h
+++ b/include/cinder/app/cocoa/AppCocoaTouch.h
@@ -202,9 +202,6 @@ class AppCocoaTouch : public AppBase {
 	//! Overidden to disable, mobile is always full screen.
 	void	setFullScreen( bool fullScreen, const FullScreenOptions &options = FullScreenOptions() ) override;
 
-	//! Returns the path to the application on disk
-	fs::path	getAppPath() const override;
-
 	//! Returns an invalid position since the device doesn't have a mouse.
 	ivec2 getMousePos() const override	{ return ivec2( -1 ); }
 

--- a/include/cinder/app/cocoa/AppCocoaView.h
+++ b/include/cinder/app/cocoa/AppCocoaView.h
@@ -57,7 +57,6 @@ class AppCocoaView : public AppBase {
 	//! Returns whether frameRate limiting is enabled.
 	bool				isFrameRateEnabled() const;
 
-	fs::path	getAppPath() const override;
 	size_t		getNumWindows() const override;
 	WindowRef	getWindow() const override;
 	WindowRef	getWindowIndex( size_t index ) const override;

--- a/include/cinder/app/cocoa/AppMac.h
+++ b/include/cinder/app/cocoa/AppMac.h
@@ -50,7 +50,6 @@ class AppMac : public AppBase {
 	void		setFrameRate( float frameRate ) override;
 	void		disableFrameRate() override;
 	bool		isFrameRateEnabled() const override;
-	fs::path	getAppPath() const override;
 
 	WindowRef	getWindow() const override;
 	WindowRef	getWindowIndex( size_t index ) const override;

--- a/include/cinder/app/cocoa/PlatformCocoa.h
+++ b/include/cinder/app/cocoa/PlatformCocoa.h
@@ -88,6 +88,7 @@ class PlatformCocoa : public Platform {
 	fs::path	expandPath( const fs::path &path ) override;
 	fs::path	getHomeDirectory() override;
 	fs::path	getDocumentsDirectory()	override;
+	fs::path	getDefaultExecutablePath() const override;
 
 	void sleep( float milliseconds ) override;
 

--- a/include/cinder/app/cocoa/PlatformCocoa.h
+++ b/include/cinder/app/cocoa/PlatformCocoa.h
@@ -86,8 +86,8 @@ class PlatformCocoa : public Platform {
 	std::map<std::string,std::string>	getEnvironmentVariables() override;
 
 	fs::path	expandPath( const fs::path &path ) override;
-	fs::path	getHomeDirectory() override;
-	fs::path	getDocumentsDirectory()	override;
+	fs::path	getHomeDirectory() const override;
+	fs::path	getDocumentsDirectory() const override;
 	fs::path	getDefaultExecutablePath() const override;
 
 	void sleep( float milliseconds ) override;

--- a/include/cinder/app/msw/AppImplMsw.h
+++ b/include/cinder/app/msw/AppImplMsw.h
@@ -77,7 +77,6 @@ class AppImplMsw {
 	static void	hideCursor();
 	static void	showCursor();
 		
-	static fs::path		getAppPath();	
 	static fs::path		getOpenFilePath( const fs::path &initialPath, std::vector<std::string> extensions );
 	static fs::path		getSaveFilePath( const fs::path &initialPath, std::vector<std::string> extensions );
 	static fs::path		getFolderPath( const fs::path &initialPath );

--- a/include/cinder/app/msw/AppImplMswBasic.h
+++ b/include/cinder/app/msw/AppImplMswBasic.h
@@ -53,7 +53,6 @@ class AppImplMswBasic : public AppImplMsw {
 	size_t		getNumWindows() const;
 	WindowRef	getWindowIndex( size_t index );
 	WindowRef	getForegroundWindow() const;
-	fs::path	getAppPath() const;
 	
 	void		setupBlankingWindows( DisplayRef fullScreenDisplay );
 	void		destroyBlankingWindows();

--- a/include/cinder/app/msw/AppMsw.h
+++ b/include/cinder/app/msw/AppMsw.h
@@ -62,7 +62,6 @@ class AppMsw : public AppBase {
 	void		setFrameRate( float frameRate ) override;
 	void		disableFrameRate() override;
 	bool		isFrameRateEnabled() const override;
-	fs::path	getAppPath() const override;
 
 	WindowRef	getWindow() const override;
 	WindowRef	getWindowIndex( size_t index ) const override;

--- a/include/cinder/app/msw/PlatformMsw.h
+++ b/include/cinder/app/msw/PlatformMsw.h
@@ -48,6 +48,7 @@ class PlatformMsw : public Platform {
 	fs::path	expandPath( const fs::path &path ) override;
 	fs::path	getHomeDirectory() override;
 	fs::path	getDocumentsDirectory()	override;
+	fs::path	getDefaultExecutablePath() const override;
 
 	// Overridden to use OutputDebugString
 	std::ostream&	console() override;

--- a/include/cinder/app/msw/PlatformMsw.h
+++ b/include/cinder/app/msw/PlatformMsw.h
@@ -46,8 +46,8 @@ class PlatformMsw : public Platform {
 	std::map<std::string,std::string>	getEnvironmentVariables() override;
 
 	fs::path	expandPath( const fs::path &path ) override;
-	fs::path	getHomeDirectory() override;
-	fs::path	getDocumentsDirectory()	override;
+	fs::path	getHomeDirectory() const override;
+	fs::path	getDocumentsDirectory() const override;
 	fs::path	getDefaultExecutablePath() const override;
 
 	// Overridden to use OutputDebugString

--- a/include/cinder/app/winrt/AppWinRt.h
+++ b/include/cinder/app/winrt/AppWinRt.h
@@ -58,7 +58,6 @@ class AppWinRt : public AppBase {
 	void		setFrameRate( float frameRate ) override;
 	void		disableFrameRate() override;
 	bool		isFrameRateEnabled() const override;
-	fs::path	getAppPath() const override;
 
 	WindowRef	getWindow() const override;
 	WindowRef	getWindowIndex( size_t index ) const override;

--- a/include/cinder/app/winrt/PlatformWinRt.h
+++ b/include/cinder/app/winrt/PlatformWinRt.h
@@ -59,6 +59,7 @@ class PlatformWinRt : public Platform {
 	fs::path	expandPath( const fs::path &path ) override;
 	fs::path	getHomeDirectory() const override;
 	fs::path	getDocumentsDirectory() const override;
+	fs::path	getDefaultExecutablePath() const override;
 
 	void launchWebBrowser( const Url &url ) override;
 

--- a/include/cinder/app/winrt/PlatformWinRt.h
+++ b/include/cinder/app/winrt/PlatformWinRt.h
@@ -57,8 +57,8 @@ class PlatformWinRt : public Platform {
 	std::map<std::string,std::string>	getEnvironmentVariables() override;
 
 	fs::path	expandPath( const fs::path &path ) override;
-	fs::path	getHomeDirectory() override;
-	fs::path	getDocumentsDirectory()	override;
+	fs::path	getHomeDirectory() const override;
+	fs::path	getDocumentsDirectory() const override;
 
 	void launchWebBrowser( const Url &url ) override;
 

--- a/src/cinder/app/AppScreenSaver.cpp
+++ b/src/cinder/app/AppScreenSaver.cpp
@@ -69,7 +69,7 @@ AppScreenSaver::AppScreenSaver()
 	mImpl = new AppImplMswScreenSaver( this, sMainHwnd, *settings );
 }
 
-void AppScreenSaver::launch( const char *title, int argc, char * const argv[] )
+void AppScreenSaver::launch()
 {
 	mImpl->run();
 // NOTHING AFTER THIS LINE RUNS

--- a/src/cinder/app/AppScreenSaver.cpp
+++ b/src/cinder/app/AppScreenSaver.cpp
@@ -55,7 +55,6 @@ AppScreenSaver::AppScreenSaver()
 	CI_ASSERT_MSG( platform, "expected global Platform object to be of type PlatformCocoa" );
 
 	platform->setBundle( getBundle() );
-	platform->setExecutablePath( getAppPath() );
 	
 	ImageSourceFileQuartz::registerSelf();
 	ImageTargetFileQuartz::registerSelf();	
@@ -106,15 +105,6 @@ bool AppScreenSaver::isPreview() const
 	return [mImpl isPreview];
 #elif defined( CINDER_MSW )
 	return mImpl->isPreview();
-#endif
-}
-
-fs::path AppScreenSaver::getAppPath() const
-{
-#if defined( CINDER_MAC )
-	return [mImpl getAppPath];
-#elif defined( CINDER_MSW )
-	return mImpl->getAppPath();
 #endif
 }
 

--- a/src/cinder/app/Platform.cpp
+++ b/src/cinder/app/Platform.cpp
@@ -69,6 +69,14 @@ void Platform::set( Platform *platform )
 	sInstance = platform;
 }
 
+fs::path Platform::getExecutablePath() const
+{
+	if( mExecutablePath.empty() )
+		mExecutablePath = getDefaultExecutablePath();
+
+	return mExecutablePath;
+}
+
 DataSourceRef Platform::loadAsset( const fs::path &relativePath )
 {
 	fs::path assetPath = findAssetPath( relativePath );

--- a/src/cinder/app/cocoa/AppCocoaTouch.cpp
+++ b/src/cinder/app/cocoa/AppCocoaTouch.cpp
@@ -44,7 +44,6 @@ AppCocoaTouch::AppCocoaTouch()
 	auto settings = dynamic_cast<Settings *>( sSettingsFromMain );
 	CI_ASSERT( settings );
 
-	Platform::get()->setExecutablePath( getAppPath() );
 	mImpl = [[AppImplCocoaTouch alloc] init:this settings:*settings];
 
 	enablePowerManagement( settings->isPowerManagementEnabled() );
@@ -226,11 +225,6 @@ bool AppCocoaTouch::isFullScreen() const
 void AppCocoaTouch::setFullScreen( bool fullScreen, const FullScreenOptions &options )
 {
 	// NO-OP
-}
-
-fs::path AppCocoaTouch::getAppPath() const
-{ 
-	return fs::path( [[[NSBundle mainBundle] bundlePath] UTF8String] );
 }
 
 void AppCocoaTouch::quit()

--- a/src/cinder/app/cocoa/AppCocoaView.mm
+++ b/src/cinder/app/cocoa/AppCocoaView.mm
@@ -515,8 +515,6 @@ namespace cinder { namespace app {
 AppCocoaView::AppCocoaView()
 	: AppBase()
 {
-	Platform::get()->setExecutablePath( getAppPath() );
-
 	const Settings *settings = dynamic_cast<Settings *>( sSettingsFromMain );
 	CI_ASSERT( settings );
 
@@ -575,14 +573,6 @@ void AppCocoaView::disableFrameRate()
 bool AppCocoaView::isFrameRateEnabled() const
 {
 	return [mImpl isFrameRateEnabled];
-}
-
-fs::path AppCocoaView::getAppPath() const
-{
-	NSString *resultPath = [[NSBundle mainBundle] bundlePath];
-	std::string result;
-	result = [resultPath cStringUsingEncoding:NSUTF8StringEncoding];
-	return result;
 }
 
 size_t AppCocoaView::getNumWindows() const

--- a/src/cinder/app/cocoa/AppMac.cpp
+++ b/src/cinder/app/cocoa/AppMac.cpp
@@ -35,7 +35,6 @@ AppMac::AppMac()
 	const Settings *settings = dynamic_cast<Settings *>( sSettingsFromMain );
 	CI_ASSERT( settings );
 
-	Platform::get()->setExecutablePath( getAppPath() );
 	mImpl = [[AppImplMac alloc] init:this settings:*settings];
 
 	enablePowerManagement( settings->isPowerManagementEnabled() ); // TODO: consider moving to common method
@@ -90,11 +89,6 @@ void AppMac::disableFrameRate()
 bool AppMac::isFrameRateEnabled() const
 {
 	return [mImpl isFrameRateEnabled];
-}
-
-fs::path AppMac::getAppPath() const
-{
-	return fs::path( [[[NSBundle mainBundle] bundlePath] UTF8String] ).parent_path();
 }
 
 WindowRef AppMac::getWindow() const

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -174,6 +174,11 @@ fs::path PlatformCocoa::getHomeDirectory()
 	return fs::path( result );	
 }
 
+fs::path PlatformCocoa::getDefaultExecutablePath() const
+{
+	return fs::path( [[[::NSBundle mainBundle] bundlePath] UTF8String] ).parent_path();
+}
+
 void PlatformCocoa::launchWebBrowser( const Url &url )
 {
 	NSString *nsString = [NSString stringWithCString:url.c_str() encoding:NSUTF8StringEncoding];

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -159,14 +159,14 @@ fs::path PlatformCocoa::expandPath( const fs::path &path )
 	return fs::path( result );
 }
 
-fs::path PlatformCocoa::getDocumentsDirectory()
+fs::path PlatformCocoa::getDocumentsDirectory() const
 {
 	NSArray *arrayPaths = ::NSSearchPathForDirectoriesInDomains( NSDocumentDirectory, NSUserDomainMask, YES );
 	NSString *docDir = [arrayPaths firstObject];
 	return fs::path( cocoa::convertNsString( docDir ) + "/" );
 }
 
-fs::path PlatformCocoa::getHomeDirectory()
+fs::path PlatformCocoa::getHomeDirectory() const
 {
 	NSString *home = ::NSHomeDirectory();
 	string result = string( [home cStringUsingEncoding:NSUTF8StringEncoding] );

--- a/src/cinder/app/msw/AppImplMsw.cpp
+++ b/src/cinder/app/msw/AppImplMsw.cpp
@@ -73,42 +73,22 @@ void AppImplMsw::hideCursor()
 {
 	int counter;
 
-	while( (counter = ::ShowCursor(false)) > -1 );
+	while( ( counter = ::ShowCursor( false ) ) > -1 );
 
 	// when repeatedly calling hideCursor(), keep counter at -1
-	if(counter < -1) while( ::ShowCursor(true) < -1 );
+	if( counter < -1 )
+		while( ::ShowCursor( true ) < -1 );
 }
 
 void AppImplMsw::showCursor()
 {
 	int counter;
 
-	while( (counter = ::ShowCursor(true)) < 0 );
+	while( ( counter = ::ShowCursor( true ) ) < 0 );
 
 	// when repeatedly calling showCursor(), keep counter at 0
-	if(counter > 0) while( ::ShowCursor(false) > 0 );
-}
-
-fs::path AppImplMsw::getAppPath()
-{
-	wchar_t appPath[MAX_PATH] = L"";
-
-	// fetch the path of the executable
-	::GetModuleFileName( 0, appPath, sizeof(appPath) - 1);
-
-	// get a pointer to the last occurrence of the windows path separator
-	wchar_t *appDir = wcsrchr( appPath, L'\\' );
-	if( appDir ) {
-		++appDir;
-
-		// this shouldn't be null but one never knows
-		if( appDir ) {
-			// null terminate the string
-			*appDir = 0;
-		}
-	}
-
-	return fs::path( appPath );
+	if( counter > 0 )
+		while( ::ShowCursor( false ) > 0 );
 }
 
 fs::path AppImplMsw::getOpenFilePath( const fs::path &initialPath, vector<string> extensions )

--- a/src/cinder/app/msw/AppMsw.cpp
+++ b/src/cinder/app/msw/AppMsw.cpp
@@ -47,7 +47,6 @@ AppMsw::AppMsw()
 	mConsoleWindowEnabled = settings->isConsoleWindowEnabled();
 	enablePowerManagement( settings->isPowerManagementEnabled() ); // TODO: consider moving to common method
 
-	Platform::get()->setExecutablePath( getAppPath() );
 	mImpl.reset( new AppImplMswBasic( this, *settings ) );
 }
 
@@ -121,11 +120,6 @@ void AppMsw::disableFrameRate()
 bool AppMsw::isFrameRateEnabled() const
 {
 	return mImpl->isFrameRateEnabled();
-}
-
-fs::path AppMsw::getAppPath() const
-{
-	return AppImplMsw::getAppPath();
 }
 
 WindowRef AppMsw::getWindow() const

--- a/src/cinder/app/msw/PlatformMsw.cpp
+++ b/src/cinder/app/msw/PlatformMsw.cpp
@@ -141,14 +141,14 @@ fs::path PlatformMsw::expandPath( const fs::path &path )
 	return fs::path( buffer ); 
 }
 
-fs::path PlatformMsw::getDocumentsDirectory()
+fs::path PlatformMsw::getDocumentsDirectory() const
 {
 	wchar_t buffer[MAX_PATH];
 	::SHGetFolderPath( 0, CSIDL_MYDOCUMENTS, NULL, SHGFP_TYPE_CURRENT, buffer );
 	return fs::path( wstring(buffer) + L"\\" );
 }
 
-fs::path PlatformMsw::getHomeDirectory()
+fs::path PlatformMsw::getHomeDirectory() const
 {
 	wchar_t buffer[MAX_PATH];
 	::SHGetFolderPath( 0, CSIDL_PROFILE, NULL, SHGFP_TYPE_CURRENT, buffer );

--- a/src/cinder/app/msw/PlatformMsw.cpp
+++ b/src/cinder/app/msw/PlatformMsw.cpp
@@ -156,6 +156,28 @@ fs::path PlatformMsw::getHomeDirectory()
 	return fs::path( result );
 }
 
+fs::path PlatformMsw::getDefaultExecutablePath() const
+{
+	wchar_t appPath[MAX_PATH] = L"";
+
+	// fetch the path of the executable
+	::GetModuleFileName( 0, appPath, sizeof( appPath ) - 1 );
+
+	// get a pointer to the last occurrence of the windows path separator
+	wchar_t *appDir = wcsrchr( appPath, L'\\' );
+	if( appDir ) {
+		++appDir;
+
+		// this shouldn't be null but one never knows
+		if( appDir ) {
+			// null terminate the string
+			*appDir = 0;
+		}
+	}
+
+	return fs::path( appPath );
+}
+
 void PlatformMsw::launchWebBrowser( const Url &url )
 {
 	std::u16string urlStr = toUtf16( url.str() );

--- a/src/cinder/app/winrt/AppWinRt.cpp
+++ b/src/cinder/app/winrt/AppWinRt.cpp
@@ -137,15 +137,6 @@ bool AppWinRt::isFrameRateEnabled() const
 	return false;
 }
 
-fs::path AppWinRt::getAppPath() const
-{
-	Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
-	Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
-	::Platform::String^ output = installedLocation->Path;
-	std::wstring t = std::wstring( output->Data() );
-	return fs::path( winrt::PlatformStringToString( output ) );
-}
-
 WindowRef AppWinRt::getWindow() const
 {
 	return mActiveWindow;

--- a/src/cinder/app/winrt/PlatformWinRt.cpp
+++ b/src/cinder/app/winrt/PlatformWinRt.cpp
@@ -238,6 +238,15 @@ fs::path PlatformWinRt::getDocumentsDirectory() const
 	return PlatformStringToString(folder->Path);
 }
 
+fs::path PlatformWinRt::getDefaultExecutablePath() const
+{
+	Windows::ApplicationModel::Package^ package = Windows::ApplicationModel::Package::Current;
+	Windows::Storage::StorageFolder^ installedLocation = package->InstalledLocation;
+	::Platform::String^ output = installedLocation->Path;
+	std::wstring t = std::wstring( output->Data() );
+	return fs::path( winrt::PlatformStringToString( output ) );
+}
+
 void PlatformWinRt::launchWebBrowser( const Url &url )
 {
 	std::u16string urlStr = toUtf16( url.str() );

--- a/src/cinder/app/winrt/PlatformWinRt.cpp
+++ b/src/cinder/app/winrt/PlatformWinRt.cpp
@@ -223,7 +223,7 @@ fs::path PlatformWinRt::expandPath( const fs::path &path )
 #endif
 }
 
-fs::path PlatformWinRt::getHomeDirectory()
+fs::path PlatformWinRt::getHomeDirectory() const
 {
 	// WinRT will throw an exception if access to DocumentsLibrary has not been requested in the App Manifest
 	auto folder = Windows::Storage::KnownFolders::DocumentsLibrary;
@@ -231,7 +231,7 @@ fs::path PlatformWinRt::getHomeDirectory()
 	return fs::path( result );
 }
 
-fs::path PlatformWinRt::getDocumentsDirectory()
+fs::path PlatformWinRt::getDocumentsDirectory() const
 {
 	// WinRT will throw an exception if access to DocumentsLibrary has not been requested in the App Manifest
 	auto folder = Windows::Storage::KnownFolders::DocumentsLibrary;

--- a/test/AppCocoaViewTest/AppCocoaViewTest.xcodeproj/project.pbxproj
+++ b/test/AppCocoaViewTest/AppCocoaViewTest.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		00ED0B7C15B07FEE0034FE7C /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00ED0B7915B07FBC0034FE7C /* CoreLocation.framework */; };
 		115FAF431A8169A2009DDD59 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 115FAF421A8169A2009DDD59 /* AVFoundation.framework */; };
 		115FAF451A8169A8009DDD59 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 115FAF441A8169A8009DDD59 /* CoreMedia.framework */; };
+		11B571B61B25593900BF76CE /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11B571B51B25593900BF76CE /* IOKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -52,6 +53,7 @@
 		00ED0B7915B07FBC0034FE7C /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		115FAF421A8169A2009DDD59 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		115FAF441A8169A8009DDD59 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		11B571B51B25593900BF76CE /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				11B571B61B25593900BF76CE /* IOKit.framework in Frameworks */,
 				115FAF451A8169A8009DDD59 /* CoreMedia.framework in Frameworks */,
 				115FAF431A8169A2009DDD59 /* AVFoundation.framework in Frameworks */,
 				00ED0B7C15B07FEE0034FE7C /* CoreLocation.framework in Frameworks */,
@@ -98,6 +101,7 @@
 		003C0CA415A1F07200FF29F5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				11B571B51B25593900BF76CE /* IOKit.framework */,
 				115FAF441A8169A8009DDD59 /* CoreMedia.framework */,
 				115FAF421A8169A2009DDD59 /* AVFoundation.framework */,
 				00ED0B7915B07FBC0034FE7C /* CoreLocation.framework */,
@@ -268,7 +272,7 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "$(CINDER_PATH)/boost";
+				HEADER_SEARCH_PATHS = "$(CINDER_PATH)/include";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -292,7 +296,7 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "$(CINDER_PATH)/boost";
+				HEADER_SEARCH_PATHS = "$(CINDER_PATH)/include";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
 				USER_HEADER_SEARCH_PATHS = "../TestApp $(CINDER_PATH)/include";

--- a/test/AppTest/src/AppTestApp.cpp
+++ b/test/AppTest/src/AppTestApp.cpp
@@ -52,6 +52,10 @@ void prepareSettings( App::Settings *settings )
 #if defined( CINDER_MSW )
 	settings->setConsoleWindowEnabled();
 #endif
+
+	// test loading an asset before application has been instanciated:
+	auto asset = loadAsset( "mustache-green.png" );
+	CI_ASSERT( asset );
 }
 
 struct SomeMemberObj {

--- a/test/AppTest/xcode/AppTest.xcodeproj/project.pbxproj
+++ b/test/AppTest/xcode/AppTest.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
 		11967F5D1A65E6100080E7F6 /* mustache-blue.png in Resources */ = {isa = PBXBuildFile; fileRef = 11967F5C1A65E6100080E7F6 /* mustache-blue.png */; };
+		11B571B41B2556BC00BF76CE /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11B571B31B2556BC00BF76CE /* IOKit.framework */; };
 		2B020FA8713C445A8FE6E2B0 /* AppTestApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B2712BBC6F234EAA8A904867 /* AppTestApp.cpp */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
@@ -31,6 +32,7 @@
 		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		11967F5C1A65E6100080E7F6 /* mustache-blue.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "mustache-blue.png"; path = "../resources/mustache-blue.png"; sourceTree = "<group>"; };
+		11B571B31B2556BC00BF76CE /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		19AB1D4CDCD14A66B647258D /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
@@ -47,6 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				11B571B41B2556BC00BF76CE /* IOKit.framework in Frameworks */,
 				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
 				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
@@ -146,6 +149,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				11B571B31B2556BC00BF76CE /* IOKit.framework */,
 				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
 				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
 			);

--- a/test/ScreenSaverTest/xcode/ScreenSaverTest.xcodeproj/project.pbxproj
+++ b/test/ScreenSaverTest/xcode/ScreenSaverTest.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		112CBD821A958BC20049BE2C /* RendererImplGlMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 112CBD7E1A958BC20049BE2C /* RendererImplGlMac.mm */; };
 		1181F7C01A7E4898001BBFA2 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1181F7BF1A7E4898001BBFA2 /* AVFoundation.framework */; };
 		1181F7C21A7E48BC001BBFA2 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1181F7C11A7E48BC001BBFA2 /* CoreMedia.framework */; };
+		11B571B81B255A0400BF76CE /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11B571B71B255A0400BF76CE /* IOKit.framework */; };
+		11B571BA1B255A1200BF76CE /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11B571B91B255A1200BF76CE /* IOSurface.framework */; };
 		8D255AC70486D3F9007BF209 /* ScreenSaverTest_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 32DBCFA80370C50100C91783 /* ScreenSaverTest_Prefix.pch */; };
 		8D255ACA0486D3F9007BF209 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C167DFE841241C02AAC07 /* InfoPlist.strings */; };
 		8D255ACE0486D3F9007BF209 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7ADFEA557BF11CA2CBB /* Cocoa.framework */; };
@@ -73,6 +75,8 @@
 		112CBD871A958C070049BE2C /* RendererImplGlMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RendererImplGlMac.h; path = ../../../include/cinder/app/cocoa/RendererImplGlMac.h; sourceTree = "<group>"; };
 		1181F7BF1A7E4898001BBFA2 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		1181F7C11A7E48BC001BBFA2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		11B571B71B255A0400BF76CE /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		11B571B91B255A1200BF76CE /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		32DBCFA80370C50100C91783 /* ScreenSaverTest_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScreenSaverTest_Prefix.pch; sourceTree = "<group>"; };
 		8D255AD20486D3F9007BF209 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8D255AD30486D3F9007BF209 /* ScreenSaverTest.saver */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScreenSaverTest.saver; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,6 +87,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				11B571BA1B255A1200BF76CE /* IOSurface.framework in Frameworks */,
+				11B571B81B255A0400BF76CE /* IOKit.framework in Frameworks */,
 				1181F7C21A7E48BC001BBFA2 /* CoreMedia.framework in Frameworks */,
 				1181F7C01A7E4898001BBFA2 /* AVFoundation.framework in Frameworks */,
 				8D255ACE0486D3F9007BF209 /* Cocoa.framework in Frameworks */,
@@ -192,6 +198,8 @@
 		1058C7ACFEA557BF11CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				11B571B91B255A1200BF76CE /* IOSurface.framework */,
+				11B571B71B255A0400BF76CE /* IOKit.framework */,
 				00880A5411630D7900F731D1 /* Accelerate.framework */,
 				00880A5911630D7900F731D1 /* ApplicationServices.framework */,
 				00880A5511630D7900F731D1 /* AudioToolbox.framework */,

--- a/test/iosAppTest/src/iosAppTestApp.cpp
+++ b/test/iosAppTest/src/iosAppTestApp.cpp
@@ -427,7 +427,7 @@ void iosAppTestApp::draw()
 		}
 		if( messageTex ) {
 			gl::color( Color::white() );
-			gl::draw( messageTex, ivec2( ( getWindowWidth() - messageTex->getCleanWidth() ) / 2, getWindowCenter().y ) );
+			gl::draw( messageTex, ivec2( ( getWindowWidth() - messageTex->getWidth() ) / 2, getWindowCenter().y ) );
 		}
 	}
 


### PR DESCRIPTION
This is done by adding an abstract virtual `Platform::getDefaultExecutablePath()`, which returns the best it can for the executable path on each platform. If a specific app needs to override this, they can by calling `Platform::setExecutablePath()`.  This makes it possible to, say, load a config file in your assets directory from the prepare settings function.

The previous abstract virtual `AppBase::getAppPath()` is no longer virtual, instead it routes to `Platform::getExecutablePath()`.

Also made `Platform::getHomeDirectory()` and `getDocumentsDirectory()` const. Tested on Mac, iOS, Win Desktop, Win32, and screensaver variants.