### PR TITLE
Alpha channel support at 8bpc on MSW

### DIFF
--- a/src/cinder/app/msw/RendererImplGlMsw.cpp
+++ b/src/cinder/app/msw/RendererImplGlMsw.cpp
@@ -216,7 +216,7 @@ bool testPixelFormat( HDC dc, int colorSamples, int depthDepth, int msaaSamples,
 	iAttributes.push_back( WGL_RED_BITS_ARB ); iAttributes.push_back( colorSamples );
 	iAttributes.push_back( WGL_GREEN_BITS_ARB ); iAttributes.push_back( colorSamples );
 	iAttributes.push_back( WGL_BLUE_BITS_ARB ); iAttributes.push_back( colorSamples );
-	if ( colorSamples == 8 ) {
+	if( colorSamples == 8 ) {
 		iAttributes.push_back( WGL_ALPHA_BITS_ARB ); iAttributes.push_back( colorSamples );
 	}
 	iAttributes.push_back( WGL_DEPTH_BITS_ARB ); iAttributes.push_back( depthDepth );

--- a/src/cinder/app/msw/RendererImplGlMsw.cpp
+++ b/src/cinder/app/msw/RendererImplGlMsw.cpp
@@ -216,6 +216,9 @@ bool testPixelFormat( HDC dc, int colorSamples, int depthDepth, int msaaSamples,
 	iAttributes.push_back( WGL_RED_BITS_ARB ); iAttributes.push_back( colorSamples );
 	iAttributes.push_back( WGL_GREEN_BITS_ARB ); iAttributes.push_back( colorSamples );
 	iAttributes.push_back( WGL_BLUE_BITS_ARB ); iAttributes.push_back( colorSamples );
+	if ( colorSamples == 8 ) {
+		iAttributes.push_back( WGL_ALPHA_BITS_ARB ); iAttributes.push_back( colorSamples );
+	}
 	iAttributes.push_back( WGL_DEPTH_BITS_ARB ); iAttributes.push_back( depthDepth );
 	iAttributes.push_back( WGL_STENCIL_BITS_ARB ); iAttributes.push_back( stencilDepth );
 	iAttributes.push_back( WGL_DOUBLE_BUFFER_ARB ); iAttributes.push_back( GL_TRUE );


### PR DESCRIPTION
In 0.9.0, color buffer has no alpha channel because the **WGL_ALPHA_BITS_ARB** attribute has been removed probably for 10bpc support.
I think **WGL_ALPHA_BITS_ARB** should be set to 8 at 8bpc to create an alpha buffer.
