### PR TITLE
Fix appTouchEvent operator<<

### DIFF
--- a/include/cinder/app/TouchEvent.h
+++ b/include/cinder/app/TouchEvent.h
@@ -85,19 +85,19 @@ class TouchEvent : public Event {
 	bool					mHandled;
 };
 
-} } // namespace cinder::app
-
-inline std::ostream& operator<<( std::ostream &out, const cinder::app::TouchEvent::Touch &touch )
+inline std::ostream& operator<<( std::ostream &out, const TouchEvent::Touch &touch )
 {
 	out << touch.getId() << ": " << touch.getPos() << " @ " << touch.getTime() << "s";
 	return out;
 }
 
-inline std::ostream& operator<<( std::ostream &out, const cinder::app::TouchEvent &event )
+inline std::ostream& operator<<( std::ostream &out, const TouchEvent &event )
 {
 	out << "{" << std::endl;
-	for( std::vector<cinder::app::TouchEvent::Touch>::const_iterator tIt = event.getTouches().begin(); tIt != event.getTouches().end(); ++tIt )
+	for( std::vector<TouchEvent::Touch>::const_iterator tIt = event.getTouches().begin(); tIt != event.getTouches().end(); ++tIt )
 		out << "  " << *tIt << std::endl;
 	out << "}";
 	return out;
 }
+
+} } // namespace cinder::app

--- a/include/cinder/app/TouchEvent.h
+++ b/include/cinder/app/TouchEvent.h
@@ -94,8 +94,9 @@ inline std::ostream& operator<<( std::ostream &out, const TouchEvent::Touch &tou
 inline std::ostream& operator<<( std::ostream &out, const TouchEvent &event )
 {
 	out << "{" << std::endl;
-	for( std::vector<TouchEvent::Touch>::const_iterator tIt = event.getTouches().begin(); tIt != event.getTouches().end(); ++tIt )
-		out << "  " << *tIt << std::endl;
+	for( const auto &touch : event.getTouches() ) {
+		out << "  " << touch << std::endl;
+	}
 	out << "}";
 	return out;
 }

--- a/samples/MultiTouchBasic/src/MultiTouchBasicApp.cpp
+++ b/samples/MultiTouchBasic/src/MultiTouchBasicApp.cpp
@@ -75,7 +75,7 @@ void MultiTouchApp::setup()
 
 void MultiTouchApp::touchesBegan( TouchEvent event )
 {
-	console() << "began: " << event << std::endl;
+	CI_LOG_I( event );
 
 	for( const auto &touch : event.getTouches() ) {
 		Color newColor( CM_HSV, Rand::randFloat(), 1, 1 );
@@ -85,7 +85,7 @@ void MultiTouchApp::touchesBegan( TouchEvent event )
 
 void MultiTouchApp::touchesMoved( TouchEvent event )
 {
-	//console() << "Moved: " << event << std::endl;
+	CI_LOG_I( event );
 	for( const auto &touch : event.getTouches() ) {
 		mActivePoints[touch.getId()].addPoint( touch.getPos() );
 	}
@@ -93,7 +93,7 @@ void MultiTouchApp::touchesMoved( TouchEvent event )
 
 void MultiTouchApp::touchesEnded( TouchEvent event )
 {
-	console() << "ended: " << event << std::endl;
+	CI_LOG_I( event );
 	for( const auto &touch : event.getTouches() ) {
 		mActivePoints[touch.getId()].startDying();
 		mDyingPoints.push_back( mActivePoints[touch.getId()] );
@@ -103,12 +103,12 @@ void MultiTouchApp::touchesEnded( TouchEvent event )
 
 void MultiTouchApp::mouseDown( MouseEvent event )
 {
-	console() << "Mouse down: " << event.isRight() << " & " << event.isControlDown() << std::endl;
+	CI_LOG_I( "right: " << boolalpha << event.isRight() << " , control down " << event.isControlDown() << dec );
 }
 
 void MultiTouchApp::mouseDrag( MouseEvent event )
 {
-	console() << "Mouse drag pos: " << event.getPos() << std::endl;
+	CI_LOG_I( "pos: " << event.getPos() );
 }
 
 void MultiTouchApp::draw()


### PR DESCRIPTION
By defining the operators within the cinder::app namespace. Fixes #915.