### PR TITLE
ManagedComPtr, improvements for using ci::msw::makeComUnique()

### DIFF
--- a/include/cinder/audio/msw/FileMediaFoundation.h
+++ b/include/cinder/audio/msw/FileMediaFoundation.h
@@ -57,10 +57,10 @@ class SourceFileMediaFoundation : public SourceFile {
 	void		initReader();
 	size_t		processNextReadSample();
 
-	std::unique_ptr<::IMFSourceReader, ci::msw::ComDeleter>		mSourceReader;
-	std::unique_ptr<ci::msw::ComIStream, ci::msw::ComDeleter>	mComIStream;
-	std::unique_ptr<::IMFByteStream, ci::msw::ComDeleter>		mByteStream;
-	DataSourceRef												mDataSource; // stored so that clone() can tell if original data source is a file or windows resource
+	ci::msw::ManagedComPtr<::IMFSourceReader>		mSourceReader;
+	ci::msw::ManagedComPtr<ci::msw::ComIStream>		mComIStream;
+	ci::msw::ManagedComPtr<::IMFByteStream>			mByteStream;
+	DataSourceRef									mDataSource; // stored so that clone() can tell if original data source is a file or windows resource
 	
 	size_t				mSampleRate;
 	size_t				mNumChannels;

--- a/include/cinder/msw/CinderMsw.h
+++ b/include/cinder/msw/CinderMsw.h
@@ -56,16 +56,22 @@ void ComDelete( void *p );
 //! Functor version that calls Release() on a com-managed object
 struct ComDeleter {
 	template <typename T>
-	void operator()( T* ptr )	{ if( ptr ) ptr->Release(); }
+	void operator()( T *p )	{ if( p ) p->Release(); }
 };
+
+template<typename T>
+using ManagedComRef = std::shared_ptr<T>;
 
 //! Creates a shared_ptr whose deleter will properly decrement the reference count of a COM object
 template<typename T>
-inline std::shared_ptr<T> makeComShared( T *p )		{ return std::shared_ptr<T>( p, &ComDelete ); }
+ManagedComRef<T> makeComShared( T *p )		{ return ManagedComRef<T>( p, &ComDelete ); }
+
+template<typename T>
+using ManagedComPtr = std::unique_ptr<T, ComDeleter>;
 
 //! Creates a unique_ptr whose deleter will properly decrement the reference count of a COM object
 template<typename T>
-inline std::unique_ptr<T, ComDeleter> makeComUnique( T *p )	{ return std::unique_ptr<T, ComDeleter>( p ); }
+ManagedComPtr<T> makeComUnique( T *p )		{ return ManagedComPtr<T>( p ); }
 
 //! Wraps a cinder::OStream with a COM ::IStream
 class ComOStream : public ::IStream


### PR DESCRIPTION
With this you can declare your COM member variables like:

```cpp
ci::msw::ManagedComPtr<::IMFSourceReader>  mSourceReader;
```