### PR TITLE
Use override specificer to quiet warnings

### DIFF
--- a/include/cinder/app/Renderer.h
+++ b/include/cinder/app/Renderer.h
@@ -78,13 +78,13 @@ class Renderer {
 #if defined( CINDER_COCOA )
 	#if defined( CINDER_MAC )
 		virtual void	setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled ) = 0;
-		virtual CGContextRef			getCgContext() { throw; } // the default behavior is failure
 		virtual CGLContextObj			getCglContext() { throw; } // the default behavior is failure
 		virtual CGLPixelFormatObj		getCglPixelFormat() { throw; } // the default behavior is failure
 	#elif defined( CINDER_COCOA_TOUCH )
 		virtual void		setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer ) = 0;
 		virtual bool		isEaglLayer() const { return false; }
 	#endif
+	virtual CGContextRef	getCgContext() { throw; } // the default behavior is failure
 
 	virtual void	setFrameSize( int width, int height ) {}		
 
@@ -121,16 +121,16 @@ class Renderer2d : public Renderer {
   	Renderer2d();
 	
 	static Renderer2dRef	create() { return Renderer2dRef( new Renderer2d() ); }
-	virtual RendererRef		clone() const { return Renderer2dRef( new Renderer2d( *this ) ); }
+	virtual RendererRef		clone() const override { return Renderer2dRef( new Renderer2d( *this ) ); }
 
 	#if defined( CINDER_COCOA_TOUCH )
-		virtual void setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer );
+		virtual void setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer ) override;
 	#else
 		~Renderer2d();
-		virtual void setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled );
+		virtual void setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled ) override;
 	#endif
 
-	virtual CGContextRef			getCgContext();
+	virtual CGContextRef			getCgContext() override;
 
 	void			startDraw() override;
 	void			finishDraw() override;

--- a/include/cinder/app/RendererGl.h
+++ b/include/cinder/app/RendererGl.h
@@ -156,20 +156,20 @@ class RendererGl : public Renderer {
 	~RendererGl();
 
 	static RendererGlRef	create( const Options &options = Options() ) { return RendererGlRef( new RendererGl( options ) ); }
-	virtual RendererRef		clone() const { return RendererGlRef( new RendererGl( *this ) ); }
+	virtual RendererRef		clone() const override { return RendererGlRef( new RendererGl( *this ) ); }
  
 #if defined( CINDER_COCOA )
 	#if defined( CINDER_MAC )
-		virtual void setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled );
-		virtual CGLContextObj			getCglContext();
-		virtual CGLPixelFormatObj		getCglPixelFormat();
+		virtual void setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled ) override;
+		virtual CGLContextObj			getCglContext() override;
+		virtual CGLPixelFormatObj		getCglPixelFormat() override;
 		virtual NSOpenGLContext*		getNsOpenGlContext();		
 	#elif defined( CINDER_COCOA_TOUCH )
-		virtual void 	setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer );
-		virtual bool 	isEaglLayer() const { return true; }
+		virtual void 	setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer ) override;
+		virtual bool 	isEaglLayer() const override { return true; }
 		EAGLContext*	getEaglContext() const;
 	#endif
-	virtual void	setFrameSize( int width, int height );
+	virtual void	setFrameSize( int width, int height ) override;
 #elif defined( CINDER_MSW )
 	void	setup( HWND wnd, HDC dc, RendererRef sharedRenderer ) override;
 	void	kill() override;

--- a/include/cinder/app/cocoa/AppCocoaTouch.h
+++ b/include/cinder/app/cocoa/AppCocoaTouch.h
@@ -105,7 +105,7 @@ class AppCocoaTouch : public AppBase {
 	WindowRef 		createWindow( const Window::Format &format = Window::Format() ) override;
 
 	WindowRef		getWindow() const override;
-	WindowRef		getForegroundWindow() const	{ return getWindow(); }
+	WindowRef		getForegroundWindow() const override { return getWindow(); }
 	size_t			getNumWindows() const override;
 	app::WindowRef	getWindowIndex( size_t index = 0 ) const override;
 

--- a/include/cinder/app/cocoa/AppCocoaView.h
+++ b/include/cinder/app/cocoa/AppCocoaView.h
@@ -53,9 +53,9 @@ class AppCocoaView : public AppBase {
 	//! Sets the maximum frame-rate the App will attempt to maintain \ a frameRate frames-per-second
 	virtual void		setFrameRate( float frameRate ) override;
 	//! Disables frameRate limiting.
-	void				disableFrameRate();
+	void				disableFrameRate() override;
 	//! Returns whether frameRate limiting is enabled.
-	bool				isFrameRateEnabled() const;
+	bool				isFrameRateEnabled() const override;
 
 	size_t		getNumWindows() const override;
 	WindowRef	getWindow() const override;

--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -562,11 +562,11 @@ class Texture2d : public TextureBase {
 	void			replace( const TextureData &textureData );
 
 	//! Returns the width of the texture in pixels.
-	GLint			getWidth() const { return mCleanBounds.getWidth(); }
+	GLint			getWidth() const override { return mCleanBounds.getWidth(); }
 	//! Returns the height of the texture in pixels.
-	GLint			getHeight() const { return mCleanBounds.getHeight(); }
+	GLint			getHeight() const override { return mCleanBounds.getHeight(); }
 	//! Returns the depth of the texture in pixels.
-	GLint			getDepth() const { return 1; }
+	GLint			getDepth() const override { return 1; }
 	//! Returns the true width of the texture in pixels, which may be larger than it's "clean" area
 	GLint			getActualWidth() const { return mActualSize.x; }
 	//! Returns the true height of the texture in pixels, which may be larger than it's "clean" area

--- a/src/cinder/gl/VaoImplEs.cpp
+++ b/src/cinder/gl/VaoImplEs.cpp
@@ -45,7 +45,7 @@ class VaoImplEs : public Vao {
 	virtual void	bindImpl( class Context *context ) override;
 	virtual void	unbindImpl( class Context *context ) override;
 	virtual void	enableVertexAttribArrayImpl( GLuint index ) override;
-	virtual void	disableVertexAttribArrayImpl( GLuint index );
+	virtual void	disableVertexAttribArrayImpl( GLuint index ) override;
 	virtual void	vertexAttribPointerImpl( GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer ) override;
 	virtual void	vertexAttribIPointerImpl( GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer ) override;
 	virtual void	vertexAttribDivisorImpl( GLuint index, GLuint divisor ) override;


### PR DESCRIPTION
Xcode 7 beta 1 warns on functions missing an explicit override specifier. Compilation tested on all 3 targets with Xcode 6.3.2 and Xcode 7 beta 1 on OS X 10.11.