### PR TITLE
GlslProg::findUniform() v3

### DIFF
--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -987,10 +987,10 @@ const GlslProg::Attribute* GlslProg::findAttrib( geom::Attrib semantic ) const
 
 const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *resultLocation ) const
 {
-	const Uniform* ret = nullptr;
+	const Uniform* resultUniform = nullptr;
 	for( const auto & uniform : mUniforms ) {
 		if( uniform.mName == name ) {
-			ret = &uniform;
+			resultUniform = &uniform;
 			break;
 		}
 	}
@@ -1001,7 +1001,7 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 
 	// if we didn't find an exact match, look for the array version in the active uniforms list
 	bool needsLocationOffset = false;
-	if( ! ret ) {
+	if( ! resultUniform ) {
 		for( const auto &uniform : mUniforms ) {
 			size_t activeUniformLeftSquareBracket = uniform.mName.find( '[' );
 			// skip match detection if this active uniform isn't an array
@@ -1012,7 +1012,7 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 			if( requestedNameLeftSquareBracket == string::npos ) {
 				// name is non-indexed, try to match the uniform base name with the entire requested uniform name
 				if( uniformBaseName == name ) {
-					ret = &uniform;
+					resultUniform = &uniform;
 					break;
 				}
 			}
@@ -1023,14 +1023,14 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 					if( name.size() - 1 > requestedNameRightSquareBracket ) {
 						// try to match the struct member portion of each name
 						if( name.substr( requestedNameRightSquareBracket, name.size() ) == uniform.mName.substr( uniform.mName.find( ']' ), name.size() ) ) {
-							ret = &uniform;
+							resultUniform = &uniform;
 							needsLocationOffset = true;
 							break;
 						}
 					}
 					else {
 						// the bases of the requested and active uniform match
-						ret = &uniform;
+						resultUniform = &uniform;
 						needsLocationOffset = true;
 						break;
 					}
@@ -1039,13 +1039,13 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 		}
 	}
 
-	if( ret ) {
+	if( resultUniform ) {
 		if( needsLocationOffset ) {
 			CI_ASSERT( requestedNameLeftSquareBracket != string::npos && requestedNameRightSquareBracket != string::npos );
 
 			try {
 				string indexStr = name.substr( requestedNameLeftSquareBracket + 1, requestedNameRightSquareBracket - requestedNameLeftSquareBracket - 1 );
-				*resultLocation = ret->mLoc + stoi( indexStr );
+				*resultLocation = resultUniform->mLoc + stoi( indexStr );
 			}
 			catch( std::exception &exc ) {
 				CI_LOG_EXCEPTION( "Failed to parse index for uniform named: " << name, exc );
@@ -1053,10 +1053,10 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 			}
 		}
 		else
-			*resultLocation = ret->mLoc;
+			*resultLocation = resultUniform->mLoc;
 	}
 	
-	return ret;
+	return resultUniform;
 }
 
 const GlslProg::Uniform* GlslProg::findUniform( int location, int *resultLocation ) const

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -988,6 +988,7 @@ const GlslProg::Attribute* GlslProg::findAttrib( geom::Attrib semantic ) const
 const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *resultLocation ) const
 {
 	const Uniform* resultUniform = nullptr;
+	// first check if there is an exact name match with mUniforms
 	for( const auto & uniform : mUniforms ) {
 		if( uniform.mName == name ) {
 			resultUniform = &uniform;

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -1043,12 +1043,13 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 		if( needsLocationOffset ) {
 			CI_ASSERT( requestedNameLeftSquareBracket != string::npos && requestedNameRightSquareBracket != string::npos );
 
+			// pull out the index and use it as an offset location for the resulting uniform
+			// the try / catch handles cases where the index is a non-number, in which case we don't have a match
 			try {
 				string indexStr = name.substr( requestedNameLeftSquareBracket + 1, requestedNameRightSquareBracket - requestedNameLeftSquareBracket - 1 );
 				*resultLocation = resultUniform->mLoc + stoi( indexStr );
 			}
 			catch( std::exception &exc ) {
-				CI_LOG_EXCEPTION( "Failed to parse index for uniform named: " << name, exc );
 				return nullptr;
 			}
 		}

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -1010,20 +1010,19 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 	}
 
 	// if this is indexed uniform (example[2]) we need to parse out the '2' and add it to ret->mLoc
-	if( resultLocation ) {
-		if( nameLeftSquareBracket != string::npos ) {
-			try {
-				string indexStr = name.substr( nameLeftSquareBracket + 1, name.find( ']' ) - nameLeftSquareBracket - 1 );
-				*resultLocation = ret->mLoc + stoi( indexStr );
-			}
-			catch( std::exception &exc ) {
-				CI_LOG_EXCEPTION( "Failed to parse index for uniform named: " << name, exc );
-				return nullptr;
-			}
+	if( nameLeftSquareBracket != string::npos ) {
+		try {
+			string indexStr = name.substr( nameLeftSquareBracket + 1, name.find( ']' ) - nameLeftSquareBracket - 1 );
+			*resultLocation = ret->mLoc + stoi( indexStr );
 		}
-		else
-			*resultLocation = ret->mLoc;
+		catch( std::exception &exc ) {
+			CI_LOG_EXCEPTION( "Failed to parse index for uniform named: " << name, exc );
+			return nullptr;
+		}
 	}
+	else
+		*resultLocation = ret->mLoc;
+
 	return ret;
 }
 
@@ -1189,7 +1188,7 @@ bool GlslProg::checkUniformValueCache( const Uniform &uniform, int location, con
 template<typename LookUp, typename T>
 inline void GlslProg::uniformImpl( const LookUp &lookUp, const T &data ) const
 {
-	int uniformLocation;
+	int uniformLocation = -1;
 	auto found = findUniform( lookUp, &uniformLocation );
 	if( ! found ) {
 		logMissingUniform( lookUp );
@@ -1202,7 +1201,7 @@ inline void GlslProg::uniformImpl( const LookUp &lookUp, const T &data ) const
 template<typename LookUp, typename T>
 inline void	GlslProg::uniformMatImpl( const LookUp &lookUp, const T &data, bool transpose ) const
 {
-	int uniformLocation;
+	int uniformLocation = -1;
 	auto found = findUniform( lookUp, &uniformLocation );
 	if( ! found ) {
 		logMissingUniform( lookUp );
@@ -1215,7 +1214,7 @@ inline void	GlslProg::uniformMatImpl( const LookUp &lookUp, const T &data, bool 
 template<typename LookUp, typename T>
 inline void	GlslProg::uniformImpl( const LookUp &lookUp, const T *data, int count ) const
 {
-	int uniformLocation;
+	int uniformLocation = -1;
 	auto found = findUniform( lookUp, &uniformLocation );
 	if( ! found ) {
 		logMissingUniform( lookUp );
@@ -1228,7 +1227,7 @@ inline void	GlslProg::uniformImpl( const LookUp &lookUp, const T *data, int coun
 template<typename LookUp, typename T>
 inline void	GlslProg::uniformMatImpl( const LookUp &lookUp, const T *data, int count, bool transpose ) const
 {
-	int uniformLocation;
+	int uniformLocation = -1;
 	auto found = findUniform( lookUp, &uniformLocation );
 	if( ! found ) {
 		logMissingUniform( lookUp );

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -1050,7 +1050,7 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 				string indexStr = name.substr( requestedNameLeftSquareBracket + 1, requestedNameRightSquareBracket - requestedNameLeftSquareBracket - 1 );
 				*resultLocation = resultUniform->mLoc + stoi( indexStr );
 			}
-			catch( std::exception &exc ) {
+			catch( std::logic_error &exc ) {
 				return nullptr;
 			}
 		}

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -984,7 +984,7 @@ const GlslProg::Attribute* GlslProg::findAttrib( geom::Attrib semantic ) const
 	}
 	return ret;
 }
-	
+
 const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *resultLocation ) const
 {
 	const Uniform* ret = nullptr;
@@ -995,15 +995,17 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 		}
 	}
 
+	// if no unforms matched, return null early indicating lookup failed
+	if( ! ret )
+		return ret;
+
 	// support array brackets
 	size_t nameLeftSquareBracket = string::npos;
-	if( ret == nullptr ) { 
-		nameLeftSquareBracket = name.find( '[' );
-		for( const auto & uniform : mUniforms ) {
-			if( uniform.mName.substr( 0, uniform.mName.find( '[' ) ) == name.substr( 0, nameLeftSquareBracket ) ) {
-				ret = &uniform;
-				break;
-			}
+	nameLeftSquareBracket = name.find( '[' );
+	for( const auto & uniform : mUniforms ) {
+		if( uniform.mName.substr( 0, uniform.mName.find( '[' ) ) == name.substr( 0, nameLeftSquareBracket ) ) {
+			ret = &uniform;
+			break;
 		}
 	}
 
@@ -1019,7 +1021,7 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 				return nullptr;
 			}
 		}
-		else if( ret )
+		else
 			*resultLocation = ret->mLoc;
 	}
 	return ret;

--- a/test/_opengl/GlslProgAttribTest/assets/UniformTest.frag
+++ b/test/_opengl/GlslProgAttribTest/assets/UniformTest.frag
@@ -1,10 +1,22 @@
 precision highp float;
 
+uniform float ciElapsedSeconds;
+
 uniform vec4 uColors[3];
+
+struct TestStruct {
+	float value;
+};
+
+uniform TestStruct uTestStruct[3];
 
 in vec2 TexCoord0;
 out vec4 oColor;
 
 void main() {
 	oColor = uColors[int(TexCoord0.s)];
+
+	oColor.r += uTestStruct[0].value * sin( ciElapsedSeconds * 1.91 + 5.5 ) * 0.5;
+	oColor.g = uTestStruct[1].value * sin( ciElapsedSeconds * 3.31 + 6.2 ) * 0.5;
+	oColor.b += uTestStruct[2].value * sin( ciElapsedSeconds * 2.34 + 9.9 ) * 0.5;
 }

--- a/test/_opengl/GlslProgAttribTest/assets/UniformTest.frag
+++ b/test/_opengl/GlslProgAttribTest/assets/UniformTest.frag
@@ -17,6 +17,6 @@ void main() {
 	oColor = uColors[int(TexCoord0.s)];
 
 	oColor.r += uTestStruct[0].value * sin( ciElapsedSeconds * 1.91 + 5.5 ) * 0.5;
-	oColor.g = uTestStruct[1].value * sin( ciElapsedSeconds * 3.31 + 6.2 ) * 0.5;
+	oColor.g += uTestStruct[1].value * sin( ciElapsedSeconds * 3.31 + 6.2 ) * 0.5;
 	oColor.b += uTestStruct[2].value * sin( ciElapsedSeconds * 2.34 + 9.9 ) * 0.5;
 }

--- a/test/_opengl/GlslProgAttribTest/assets/UniformTest.frag
+++ b/test/_opengl/GlslProgAttribTest/assets/UniformTest.frag
@@ -16,7 +16,20 @@ out vec4 oColor;
 void main() {
 	oColor = uColors[int(TexCoord0.s)];
 
+#if 1
+	// test setting a struct member uniform by const index
 	oColor.r += uTestStruct[0].value * sin( ciElapsedSeconds * 1.91 + 5.5 ) * 0.5;
 	oColor.g += uTestStruct[1].value * sin( ciElapsedSeconds * 3.31 + 6.2 ) * 0.5;
 	oColor.b += uTestStruct[2].value * sin( ciElapsedSeconds * 2.34 + 9.9 ) * 0.5;
+#else
+	// test setting a struct member uniform in a for loop
+	for( int i = 0; i < 3; i++ ) {
+		oColor[i] = uTestStruct[i].value * sin( ciElapsedSeconds * 1.91 + 5.5 ) * 0.5;
+	}
+
+	// comment out one of these, it should be the only color you see
+	oColor.r = 0;
+	oColor.g = 0;
+//	oColor.b = 0;
+#endif
 }

--- a/test/_opengl/GlslProgAttribTest/src/GlslProgAttribTestApp.cpp
+++ b/test/_opengl/GlslProgAttribTest/src/GlslProgAttribTestApp.cpp
@@ -101,6 +101,14 @@ void GlslProgAttribTestApp::setupBuffers()
 	
 	// this should issue an error
 	mUniformGlsl->uniform( "uColors[a]", vec4() );
+
+	// test setting uniforms in struct array
+	mUniformGlsl->uniform( "uTestStruct[0].value", 1.0f );
+	mUniformGlsl->uniform( "uTestStruct[1].value", 1.0f );
+	mUniformGlsl->uniform( "uTestStruct[2].value", 1.0f );
+	mUniformGlsl->uniform( "uTestStruct[2].blah", 1.0f ); // should log an error
+	mUniformGlsl->uniform( "uTestStruct[b].value", 1.0f ); // should log an error
+	mUniformGlsl->uniform( "uTestStruct[blah].value", 1.0f ); // should log an error
 }
 
 void GlslProgAttribTestApp::keyDown( KeyEvent event )

--- a/test/_opengl/GlslProgAttribTest/src/GlslProgAttribTestApp.cpp
+++ b/test/_opengl/GlslProgAttribTest/src/GlslProgAttribTestApp.cpp
@@ -98,17 +98,6 @@ void GlslProgAttribTestApp::setupBuffers()
 	mSpheres = gl::Batch::create( spheres, mUniformGlsl );
 	// without fbf9c8f2c813e562a23c561c147babc72e064c5e this line would crash
 	mSpheres2 = gl::Batch::create( spheres >> geom::Translate( 0, 1, 0 ), mUniformGlsl2 );
-	
-	// this should issue an error
-	mUniformGlsl->uniform( "uColors[a]", vec4() );
-
-	// test setting uniforms in struct array
-	mUniformGlsl->uniform( "uTestStruct[0].value", 1.0f );
-	mUniformGlsl->uniform( "uTestStruct[1].value", 1.0f );
-	mUniformGlsl->uniform( "uTestStruct[2].value", 1.0f );
-	mUniformGlsl->uniform( "uTestStruct[2].blah", 1.0f ); // should log an error
-	mUniformGlsl->uniform( "uTestStruct[b].value", 1.0f ); // should log an error
-	mUniformGlsl->uniform( "uTestStruct[blah].value", 1.0f ); // should log an error
 }
 
 void GlslProgAttribTestApp::keyDown( KeyEvent event )
@@ -139,9 +128,7 @@ void GlslProgAttribTestApp::update()
 		i++;
 	}
 	
-	mModelMatricesVbo->bufferSubData( 0,
-									 mModelMatricesCpu.size() * sizeof(mat4),
-									 mModelMatricesCpu.data() );
+	mModelMatricesVbo->bufferSubData( 0, mModelMatricesCpu.size() * sizeof( mat4 ), mModelMatricesCpu.data() );
 }
 
 void GlslProgAttribTestApp::draw()
@@ -160,6 +147,17 @@ void GlslProgAttribTestApp::draw()
 		mSpheres2->getGlslProg()->uniform( "uColors[0]", mColorsCmy[0] );
 		mSpheres2->getGlslProg()->uniform( "uColors[1]", (vec4*)&mColorsCmy[1], 2 );
 	}
+
+	mUniformGlsl->uniform( "uColors[a]", vec4() ); // should log an 'Unknown uniform' warning
+
+	// test setting uniforms in struct array
+	mUniformGlsl->uniform( "uTestStruct[0].value", 1.0f );
+	mUniformGlsl->uniform( "uTestStruct[1].value", 1.0f );
+	mUniformGlsl->uniform( "uTestStruct[2].value", 1.0f );
+
+	mUniformGlsl->uniform( "uTestStruct[2].blah", 1.0f ); // should log an 'Unknown uniform' warning
+	mUniformGlsl->uniform( "uTestStruct[b].value", 1.0f ); // should log an 'Unknown uniform' warning
+	mUniformGlsl->uniform( "uTestStruct[blah].value", 1.0f ); // should log an 'Unknown uniform' warning
 
 	gl::translate( 0, 0, 5 * sin( getElapsedSeconds() ) );	
 	mSpheres->draw();

--- a/test/_opengl/GlslProgAttribTest/xcode/GlslProgAttribTest.xcodeproj/project.pbxproj
+++ b/test/_opengl/GlslProgAttribTest/xcode/GlslProgAttribTest.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
 		00D034A01B0643E700BCA509 /* UniformTest.frag in Resources */ = {isa = PBXBuildFile; fileRef = 00D0349E1B0643E700BCA509 /* UniformTest.frag */; };
 		00D034A11B0643E700BCA509 /* UniformTest.vert in Resources */ = {isa = PBXBuildFile; fileRef = 00D0349F1B0643E700BCA509 /* UniformTest.vert */; };
+		11F7A02F1B2ABB3600D930D0 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11F7A02E1B2ABB3600D930D0 /* IOKit.framework */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		63A5220B59C1431496DE4C8A /* GlslProgAttribTestApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B546F866B17144F5B4FA81D0 /* GlslProgAttribTestApp.cpp */; };
@@ -35,6 +36,7 @@
 		00D0349E1B0643E700BCA509 /* UniformTest.frag */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; name = UniformTest.frag; path = ../assets/UniformTest.frag; sourceTree = "<group>"; };
 		00D0349F1B0643E700BCA509 /* UniformTest.vert */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; name = UniformTest.vert; path = ../assets/UniformTest.vert; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		11F7A02E1B2ABB3600D930D0 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		38144DBC25904FA18B283109 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
@@ -53,6 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				11F7A02F1B2ABB3600D930D0 /* IOKit.framework in Frameworks */,
 				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
 				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
@@ -155,6 +158,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				11F7A02E1B2ABB3600D930D0 /* IOKit.framework */,
 				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
 				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
 			);


### PR DESCRIPTION
I ran into a few issues with the existing `GlslProg::findUniform()` implementation, this is a redux that aims to fix those problems:

* Avoids exc_bad_access on the result uniform when the requested name has a left square bracket, but a match isn't found in `mUniforms` (bad access was on the `*resultLocation = ret->mLoc + stoi( ... )` line.
* Handles the case when an array uniform is requested, but a location offset isn't necessary because we found an exact match in mUniforms
* Handles bad struct member names, ex. "uTestStruct[2].blah" in the test app.
* Overall, tried to document and make the string matching logic easier to follow / more robust.

This has been tested on Mac only so far, MSW testing still needed.  Some suggestions / discussion around possible future improvements:

* Much of the logic is based on what `GL_ACTIVE_ATTRIBUTES` is returning, to me at least it feels like we are reverse engineering each hardware implementation, trying to cover each case that we run into. I was wondering if it isn't possible to have a fallback, where if findUniform() returns null, we still try to ask OpenGL if it knows about a uniform by that name, the old school way. This way we'd still get a result even if our parsing logic doesn't cover a specific case, and there would be no extra cost when we are covering the case.
* Currently the string parsing logic in findUniform() happens each time the user tries to set a uniform, yet the bulk of the logic is for array uniforms, which are much less often used.  I'm wondering if we can't add an optimization to avoid that, like flag the uniform as `UNIFORM_USER_DEFINED_ARRAY` or something, so we only do the extra string parsing on those types. Or think of a clever way to cache the results of the findUniform() lookup so it is done as few times as possible.

Please let me know if I've missed any other edge cases or mucked something up, I've got a good understanding of that portion of the code now so I can still add further work if necessary.