### PR TITLE
WIP: Remove virtual specifier from functions with override specifier

### DIFF
--- a/include/cinder/Exception.h
+++ b/include/cinder/Exception.h
@@ -34,7 +34,7 @@ class Exception : public std::exception {
 	Exception( const std::string &description );
 	virtual ~Exception() throw() {}
 
-	virtual const char* what() const throw() override	{ return mDescription.c_str(); }
+	const char* what() const throw() override	{ return mDescription.c_str(); }
 
   protected:
 	  void	setDescription( const std::string &description );

--- a/include/cinder/TriMesh.h
+++ b/include/cinder/TriMesh.h
@@ -78,7 +78,7 @@ class TriMesh : public geom::Source {
 	//! Creates a suitable TriMesh::Format for representing a geom::Source \a source
 	static Format		formatFromSource( const geom::Source &source );
 	
-	virtual void	loadInto( geom::Target *target, const geom::AttribSet &requestedAttribs ) const override;
+	void	loadInto( geom::Target *target, const geom::AttribSet &requestedAttribs ) const override;
 	
 	void		clear();
 	
@@ -200,7 +200,7 @@ class TriMesh : public geom::Source {
 	//! Returns the total number of triangles contained by the TriMesh.
 	size_t		getNumTriangles() const { return mIndices.size() / 3; }
 	//! Returns the total number of indices contained by the TriMesh.
-	virtual size_t	getNumVertices() const override { if( mPositionsDims ) return mPositions.size() / mPositionsDims; else return 0; }
+	size_t	getNumVertices() const override { if( mPositionsDims ) return mPositions.size() / mPositionsDims; else return 0; }
 
 	//! Copies the 3 vertices of triangle number \a idx into \a a, \a b and \a c. Assumes vertices are 3D
 	void		getTriangleVertices( size_t idx, vec3 *a, vec3 *b, vec3 *c ) const;

--- a/include/cinder/app/AppScreenSaver.h
+++ b/include/cinder/app/AppScreenSaver.h
@@ -131,9 +131,9 @@ class AppScreenSaver : public AppBase {
 	NSBundle*		getBundle() const;
 #endif
 
-	virtual size_t		getNumWindows() const override;
-	virtual WindowRef	getWindow() const override;
-	virtual WindowRef	getWindowIndex( size_t index ) const override;
+	size_t		getNumWindows() const override;
+	WindowRef	getWindow() const override;
+	WindowRef	getWindowIndex( size_t index ) const override;
 
 #if defined( CINDER_MAC )
 	void			privateSetImpl__( void *impl ) { mImpl = reinterpret_cast<AppImplMacScreenSaver*>( impl ); }

--- a/include/cinder/app/Renderer.h
+++ b/include/cinder/app/Renderer.h
@@ -121,16 +121,16 @@ class Renderer2d : public Renderer {
   	Renderer2d();
 	
 	static Renderer2dRef	create() { return Renderer2dRef( new Renderer2d() ); }
-	virtual RendererRef		clone() const override { return Renderer2dRef( new Renderer2d( *this ) ); }
+	RendererRef		clone() const override { return Renderer2dRef( new Renderer2d( *this ) ); }
 
 	#if defined( CINDER_COCOA_TOUCH )
-		virtual void setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer ) override;
+		void setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer ) override;
 	#else
 		~Renderer2d();
-		virtual void setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled ) override;
+		void setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled ) override;
 	#endif
 
-	virtual CGContextRef			getCgContext() override;
+	CGContextRef			getCgContext() override;
 
 	void			startDraw() override;
 	void			finishDraw() override;

--- a/include/cinder/app/RendererGl.h
+++ b/include/cinder/app/RendererGl.h
@@ -156,20 +156,20 @@ class RendererGl : public Renderer {
 	~RendererGl();
 
 	static RendererGlRef	create( const Options &options = Options() ) { return RendererGlRef( new RendererGl( options ) ); }
-	virtual RendererRef		clone() const override { return RendererGlRef( new RendererGl( *this ) ); }
+	RendererRef		clone() const override { return RendererGlRef( new RendererGl( *this ) ); }
  
 #if defined( CINDER_COCOA )
 	#if defined( CINDER_MAC )
-		virtual void setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled ) override;
-		virtual CGLContextObj			getCglContext() override;
-		virtual CGLPixelFormatObj		getCglPixelFormat() override;
+		void setup( CGRect frame, NSView *cinderView, RendererRef sharedRenderer, bool retinaEnabled ) override;
+		CGLContextObj			getCglContext() override;
+		CGLPixelFormatObj		getCglPixelFormat() override;
 		virtual NSOpenGLContext*		getNsOpenGlContext();		
 	#elif defined( CINDER_COCOA_TOUCH )
-		virtual void 	setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer ) override;
-		virtual bool 	isEaglLayer() const override { return true; }
+		void 	setup( const Area &frame, UIView *cinderView, RendererRef sharedRenderer ) override;
+		bool 	isEaglLayer() const override { return true; }
 		EAGLContext*	getEaglContext() const;
 	#endif
-	virtual void	setFrameSize( int width, int height ) override;
+	void	setFrameSize( int width, int height ) override;
 #elif defined( CINDER_MSW )
 	void	setup( HWND wnd, HDC dc, RendererRef sharedRenderer ) override;
 	void	kill() override;

--- a/include/cinder/app/cocoa/AppCocoaTouch.h
+++ b/include/cinder/app/cocoa/AppCocoaTouch.h
@@ -222,7 +222,7 @@ class AppCocoaTouch : public AppBase {
 	//! \endcond
 
   protected:
-	virtual void	launch() override;
+	void	launch() override;
 
   private:
 	friend void		setupCocoaTouchWindow( AppCocoaTouch *app );

--- a/include/cinder/app/cocoa/AppCocoaView.h
+++ b/include/cinder/app/cocoa/AppCocoaView.h
@@ -46,12 +46,12 @@ class AppCocoaView : public AppBase {
 	virtual void	setupCinderView( CinderViewMac *cinderView );
 	void			launch() override;
 
-	virtual void	quit() override;
+	void	quit() override;
 
 	//! Returns the maximum frame-rate the App will attempt to maintain measured in frames-per-second
-	virtual float		getFrameRate() const override;
+	float		getFrameRate() const override;
 	//! Sets the maximum frame-rate the App will attempt to maintain \ a frameRate frames-per-second
-	virtual void		setFrameRate( float frameRate ) override;
+	void		setFrameRate( float frameRate ) override;
 	//! Disables frameRate limiting.
 	void				disableFrameRate() override;
 	//! Returns whether frameRate limiting is enabled.

--- a/include/cinder/app/msw/AppImplMswBasic.h
+++ b/include/cinder/app/msw/AppImplMswBasic.h
@@ -62,8 +62,8 @@ class AppImplMswBasic : public AppImplMsw {
 
 	WindowRef		createWindow( Window::Format format );
 	RendererRef		findSharedRenderer( const RendererRef &searchRenderer );
-	virtual void	closeWindow( class WindowImplMsw *windowImpl ) override;
-	virtual void	setForegroundWindow( WindowRef window ) override;
+	void	closeWindow( class WindowImplMsw *windowImpl ) override;
+	void	setForegroundWindow( WindowRef window ) override;
 	
 	AppMsw*	mApp;
 	HINSTANCE		mInstance;

--- a/include/cinder/app/winrt/AppImplWinRTBasic.h
+++ b/include/cinder/app/winrt/AppImplWinRTBasic.h
@@ -72,8 +72,8 @@ public:
 private:
 	void		sleep( double seconds );
 
-	virtual void	closeWindow( class WindowImplWinRT *windowImpl ) override;
-	virtual void	setForegroundWindow( WindowRef window ) override;
+	void	closeWindow( class WindowImplWinRT *windowImpl ) override;
+	void	setForegroundWindow( WindowRef window ) override;
 	
 	bool			mShouldQuit;
 	::Platform::Agile<Windows::UI::Core::CoreWindow>	mWnd;

--- a/include/cinder/audio/ChannelRouterNode.h
+++ b/include/cinder/audio/ChannelRouterNode.h
@@ -83,13 +83,13 @@ class ChannelRouterNode : public Node {
 	//! Adds \a input to the route list, routing \a numChannels starting at \a inputChannelIndex of \a input to \a outputChannelIndex.
 	void addInputRoute( const NodeRef &input, size_t inputChannelIndex, size_t outputChannelIndex, size_t numChannels );
 
-	virtual void disconnectAllInputs()									override;
+	void disconnectAllInputs()									override;
 	
   protected:
-	virtual bool supportsInputNumChannels( size_t numChannels ) const	override;
-	virtual bool supportsProcessInPlace() const							override;
-	virtual void sumInputs()											override;
-	virtual void disconnectInput( const NodeRef &input )				override;
+	bool supportsInputNumChannels( size_t numChannels ) const	override;
+	bool supportsProcessInPlace() const							override;
+	void sumInputs()											override;
+	void disconnectInput( const NodeRef &input )				override;
 
 	struct Route {
 		NodeRef	mInput;

--- a/include/cinder/audio/Node.h
+++ b/include/cinder/audio/Node.h
@@ -258,11 +258,11 @@ class NodeAutoPullable : public Node {
   public:
 	virtual ~NodeAutoPullable();
 
-	virtual void connect( const NodeRef &output )					override;
-	virtual void connectInput( const NodeRef &input )				override;
-	virtual void disconnectInput( const NodeRef &input )			override;
+	void connect( const NodeRef &output )					override;
+	void connectInput( const NodeRef &input )				override;
+	void disconnectInput( const NodeRef &input )			override;
 	//! Overridden to also remove from  Context's auto-pulled list
-	virtual void disconnectAllOutputs()								override;
+	void disconnectAllOutputs()								override;
 
   protected:
 	NodeAutoPullable( const Format &format );

--- a/include/cinder/audio/SamplePlayerNode.h
+++ b/include/cinder/audio/SamplePlayerNode.h
@@ -109,7 +109,7 @@ class BufferPlayerNode : public SamplePlayerNode {
 
 	virtual ~BufferPlayerNode() {}
 
-	virtual void seek( size_t readPositionFrames ) override;
+	void seek( size_t readPositionFrames ) override;
 
 	//! Loads and stores a reference to a Buffer created from the entire contents of \a sourceFile.
 	void loadBuffer( const SourceFileRef &sourceFile );
@@ -119,8 +119,8 @@ class BufferPlayerNode : public SamplePlayerNode {
 	const BufferRef& getBuffer() const	{ return mBuffer; }
 
   protected:
-	virtual void enableProcessing()			override;
-	virtual void process( Buffer *buffer )	override;
+	void enableProcessing()			override;
+	void process( Buffer *buffer )	override;
 
 	BufferRef mBuffer;
 };
@@ -134,8 +134,8 @@ class FilePlayerNode : public SamplePlayerNode {
 	FilePlayerNode( const SourceFileRef &sourceFile, bool isReadAsync = true, const Format &format = Node::Format() );
 	virtual ~FilePlayerNode();
 
-	virtual void stop() override;
-	virtual void seek( size_t readPositionFrames ) override;
+	void stop() override;
+	void seek( size_t readPositionFrames ) override;
 
 	//! Returns whether reading occurs asynchronously (default is false). If true, file reading is done from an internal thread, if false it is done directly on the audio thread.
 	bool isReadAsync() const	{ return mIsReadAsync; }

--- a/include/cinder/audio/SampleRecorderNode.h
+++ b/include/cinder/audio/SampleRecorderNode.h
@@ -83,8 +83,8 @@ class BufferRecorderNode : public SampleRecorderNode {
 	uint64_t getLastOverrun();
 
   protected:
-	virtual void initialize()				override;
-	virtual void process( Buffer *buffer )	override;
+	void initialize()				override;
+	void process( Buffer *buffer )	override;
 
 	void initBuffers( size_t numFrames );
 

--- a/include/cinder/audio/Voice.h
+++ b/include/cinder/audio/Voice.h
@@ -125,8 +125,8 @@ class VoiceSamplePlayerNode : public Voice {
 	//! Returns a shared_ptr of the owned SamplePlayerNode.
 	SamplePlayerNodeRef getSamplePlayerNode() const			{ return mNode; }
 
-	virtual void start() override;
-	virtual void stop() override;
+	void start() override;
+	void stop() override;
 
   protected:
 	VoiceSamplePlayerNode( const SourceFileRef &sourceFile, const Options &options );

--- a/include/cinder/audio/cocoa/CinderCoreAudio.h
+++ b/include/cinder/audio/cocoa/CinderCoreAudio.h
@@ -92,8 +92,8 @@ class ConverterImplCoreAudio : public dsp::Converter {
 	ConverterImplCoreAudio( size_t sourceSampleRate, size_t destSampleRate, size_t sourceNumChannels, size_t destNumChannels, size_t sourceMaxFramesPerBlock );
 	virtual ~ConverterImplCoreAudio();
 
-	virtual std::pair<size_t,size_t>	convert( const Buffer *sourceBuffer, Buffer *destBuffer )	override;
-	virtual void						clear()														override;
+	std::pair<size_t,size_t>	convert( const Buffer *sourceBuffer, Buffer *destBuffer )	override;
+	void						clear()														override;
 
   private:
 	std::pair<size_t,size_t> convertComplexImpl( const Buffer *sourceBuffer, Buffer *destBuffer );

--- a/include/cinder/audio/cocoa/ContextAudioUnit.h
+++ b/include/cinder/audio/cocoa/ContextAudioUnit.h
@@ -126,8 +126,8 @@ class ContextAudioUnit : public Context {
   public:
 	virtual ~ContextAudioUnit();
 
-	virtual OutputDeviceNodeRef		createOutputDeviceNode( const DeviceRef &device, const Node::Format &format = Node::Format() ) override;
-	virtual InputDeviceNodeRef		createInputDeviceNode( const DeviceRef &device, const Node::Format &format = Node::Format() ) override;
+	OutputDeviceNodeRef		createOutputDeviceNode( const DeviceRef &device, const Node::Format &format = Node::Format() ) override;
+	InputDeviceNodeRef		createInputDeviceNode( const DeviceRef &device, const Node::Format &format = Node::Format() ) override;
 
 	//! set by the OutputNode
 	void setCurrentTimeStamp( const ::AudioTimeStamp *timeStamp ) { mCurrentTimeStamp = timeStamp; }

--- a/include/cinder/audio/msw/FileMediaFoundation.h
+++ b/include/cinder/audio/msw/FileMediaFoundation.h
@@ -83,7 +83,7 @@ class TargetFileMediaFoundation : public TargetFile {
 	TargetFileMediaFoundation( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType, const std::string &extension );
 	virtual ~TargetFileMediaFoundation();
 
-	virtual void performWrite( const Buffer *buffer, size_t numFrames, size_t frameOffset ) override;
+	void performWrite( const Buffer *buffer, size_t numFrames, size_t frameOffset ) override;
 
   private:
 	  std::unique_ptr<::IMFSinkWriter, ci::msw::ComDeleter>		mSinkWriter;

--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -440,7 +440,7 @@ class Texture1d : public TextureBase {
 	Texture1d( const Surface8u &surface, Format format );
 	Texture1d( const void *data, GLenum dataFormat, int width, Format format );
 
-	virtual void	printDims( std::ostream &os ) const override;
+	void	printDims( std::ostream &os ) const override;
 
 	GLint		mWidth;
 };
@@ -584,7 +584,7 @@ class Texture2d : public TextureBase {
 	ImageSourceRef	createSource();
 	
   protected:
-	virtual void	printDims( std::ostream &os ) const override;
+	void	printDims( std::ostream &os ) const override;
 
 	Texture2d( int width, int height, Format format = Format() );
 	Texture2d( const void *data, GLenum dataFormat, int width, int height, Format format = Format() );
@@ -674,7 +674,7 @@ class Texture3d : public TextureBase {
   	Texture3d( GLint width, GLint height, GLint depth, Format format );
 	Texture3d( const void *data, GLenum dataFormat, int width, int height, int depth, Format format );
 
-	virtual void	printDims( std::ostream &os ) const override;
+	void	printDims( std::ostream &os ) const override;
 
 	GLint		mWidth, mHeight, mDepth;
 };
@@ -736,7 +736,7 @@ class TextureCubeMap : public TextureBase
 	template<typename T>
 	static TextureCubeMapRef createTextureCubeMapImpl( const ImageSourceRef &imageSource, const Format &format );
 
-	virtual void	printDims( std::ostream &os ) const override;
+	void	printDims( std::ostream &os ) const override;
 	
 	GLint		mWidth, mHeight;
 };

--- a/samples/FallingGears/src/Synths.h
+++ b/samples/FallingGears/src/Synths.h
@@ -34,7 +34,7 @@ class AltoSynth : public Synth {
 
 	void recycle() override;
 
-	virtual void trigger( float freqMidi, float decaySeconds ) override;
+	void trigger( float freqMidi, float decaySeconds ) override;
 
 	ci::audio::GenOscNodeRef		mGen;
 };
@@ -45,7 +45,7 @@ class BassSynth : public Synth {
 
 	void recycle() override;
 
-	virtual void trigger( float freqMidi, float decaySeconds ) override;
+	void trigger( float freqMidi, float decaySeconds ) override;
 
 	void setPan( float pan );
 

--- a/samples/_audio/NodeSubclassing/src/CustomTremoloNode.h
+++ b/samples/_audio/NodeSubclassing/src/CustomTremoloNode.h
@@ -25,11 +25,11 @@ class CustomTremoloNode : public ci::audio::Node {
 	// Called when it is time to use the Node, typically after a connection. This is a good place to initialize large buffers or other resources.
 	// Note that initialize() may be called more than once within the lifetime of a Node, examples include if it is connected later to inputs or outputs
 	// with a different number of channels, or if the Context's samplerate or frames per block changes.
-	virtual void initialize()							override;
+	void initialize()							override;
 
 	// Override process() to perform signal processing. The Buffer object passed in will contain processed samples from any
 	// connected inputs on the way in, and then the processed buffer is handed to any connected outputs on the way out.
-	virtual void process( ci::audio::Buffer *buffer )	override;
+	void process( ci::audio::Buffer *buffer )	override;
 
   private:
 	// in this sample, variables that are modifiable from the UI thread are atomic for thread safety.

--- a/samples/_opengl/FboBasic/src/FboBasicApp.cpp
+++ b/samples/_opengl/FboBasic/src/FboBasicApp.cpp
@@ -12,9 +12,9 @@ using namespace std;
 // into an FBO, and uses that as a Texture onto the sides of a blue cube.
 class FboBasicApp : public App {
   public:
-	virtual void	setup() override;
-	virtual void	update() override;
-	virtual void	draw() override;
+	void	setup() override;
+	void	update() override;
+	void	draw() override;
 
   private:
 	void			renderSceneToFbo();

--- a/samples/_opengl/FboMultipleRenderTargets/src/FboMultipleRenderTargetsApp.cpp
+++ b/samples/_opengl/FboMultipleRenderTargets/src/FboMultipleRenderTargetsApp.cpp
@@ -13,9 +13,9 @@ using namespace ci::app;
 
 class FboMultipleRenderTargetsApp : public App {
   public:
-	virtual void	setup() override;
-	virtual void	update() override;
-	virtual void	draw() override;
+	void	setup() override;
+	void	update() override;
+	void	draw() override;
 
   private:
 	void			renderSceneToFbo();

--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -60,7 +60,7 @@ public:
 
 	const vector<unique_ptr<Logger> >& getLoggers() const	{ return mLoggers; }
 
-	virtual void write( const Metadata &meta, const std::string &text ) override;
+	void write( const Metadata &meta, const std::string &text ) override;
 
 private:
 	vector<unique_ptr<Logger> >	mLoggers; // TODO: make set? don't want duplicates

--- a/src/cinder/ObjLoader.cpp
+++ b/src/cinder/ObjLoader.cpp
@@ -635,9 +635,9 @@ class ObjWriteTarget : public geom::Target {
 		mHasNormals = mHasTexCoords = false;
 	}
 	
-	virtual uint8_t	getAttribDims( geom::Attrib attr ) const override;
-	virtual void copyAttrib( geom::Attrib attr, uint8_t dims, size_t strideBytes, const float *srcData, size_t count ) override;
-	virtual void copyIndices( geom::Primitive primitive, const uint32_t *source, size_t numIndices, uint8_t requiredBytesPerIndex ) override;
+	uint8_t	getAttribDims( geom::Attrib attr ) const override;
+	void copyAttrib( geom::Attrib attr, uint8_t dims, size_t strideBytes, const float *srcData, size_t count ) override;
+	void copyIndices( geom::Primitive primitive, const uint32_t *source, size_t numIndices, uint8_t requiredBytesPerIndex ) override;
 	
   protected:
 	void writeData( const std::string &typeSpecifier, uint8_t dims, size_t strideBytes, const float *srcData, size_t count );

--- a/src/cinder/TriMesh.cpp
+++ b/src/cinder/TriMesh.cpp
@@ -38,9 +38,9 @@ class TriMeshGeomTarget : public geom::Target {
 		: mMesh( mesh )
 	{}
 	
-	virtual uint8_t	getAttribDims( geom::Attrib attr ) const override;
-	virtual void copyAttrib( geom::Attrib attr, uint8_t dims, size_t strideBytes, const float *srcData, size_t count ) override;
-	virtual void copyIndices( geom::Primitive primitive, const uint32_t *source, size_t numIndices, uint8_t requiredBytesPerIndex ) override;
+	uint8_t	getAttribDims( geom::Attrib attr ) const override;
+	void copyAttrib( geom::Attrib attr, uint8_t dims, size_t strideBytes, const float *srcData, size_t count ) override;
+	void copyIndices( geom::Primitive primitive, const uint32_t *source, size_t numIndices, uint8_t requiredBytesPerIndex ) override;
 	
   protected:
 	TriMesh		*mMesh;

--- a/src/cinder/gl/VaoImplCore.cpp
+++ b/src/cinder/gl/VaoImplCore.cpp
@@ -39,16 +39,16 @@ class VaoImplCore : public Vao {
 	VaoImplCore();
 
 	// Does the actual "work" of binding the VAO; called by Context
-	virtual void	bindImpl( class Context *context ) override;
-	virtual void	unbindImpl( class Context *context ) override;
-	virtual void	enableVertexAttribArrayImpl( GLuint index ) override;
-	virtual void	disableVertexAttribArrayImpl( GLuint index ) override;
-	virtual void	vertexAttribPointerImpl( GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer ) override;
-	virtual void	vertexAttribIPointerImpl( GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer ) override;
-	virtual void	vertexAttribDivisorImpl( GLuint index, GLuint divisor ) override;
-	virtual void	reflectBindBufferImpl( GLenum target, GLuint buffer ) override;	
+	void	bindImpl( class Context *context ) override;
+	void	unbindImpl( class Context *context ) override;
+	void	enableVertexAttribArrayImpl( GLuint index ) override;
+	void	disableVertexAttribArrayImpl( GLuint index ) override;
+	void	vertexAttribPointerImpl( GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer ) override;
+	void	vertexAttribIPointerImpl( GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer ) override;
+	void	vertexAttribDivisorImpl( GLuint index, GLuint divisor ) override;
+	void	reflectBindBufferImpl( GLenum target, GLuint buffer ) override;	
 
-	virtual void	reassignContext( Context *newContext ) override;
+	void	reassignContext( Context *newContext ) override;
 	void			reassignImpl( Context *newContext );
 
 	friend class Context;

--- a/src/cinder/gl/VaoImplEs.cpp
+++ b/src/cinder/gl/VaoImplEs.cpp
@@ -42,16 +42,16 @@ class VaoImplEs : public Vao {
 	VaoImplEs();
 
 	// Does the actual "work" of binding the VAO; called by Context
-	virtual void	bindImpl( class Context *context ) override;
-	virtual void	unbindImpl( class Context *context ) override;
-	virtual void	enableVertexAttribArrayImpl( GLuint index ) override;
-	virtual void	disableVertexAttribArrayImpl( GLuint index ) override;
-	virtual void	vertexAttribPointerImpl( GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer ) override;
-	virtual void	vertexAttribIPointerImpl( GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer ) override;
-	virtual void	vertexAttribDivisorImpl( GLuint index, GLuint divisor ) override;
-	virtual void	reflectBindBufferImpl( GLenum target, GLuint buffer ) override;
+	void	bindImpl( class Context *context ) override;
+	void	unbindImpl( class Context *context ) override;
+	void	enableVertexAttribArrayImpl( GLuint index ) override;
+	void	disableVertexAttribArrayImpl( GLuint index ) override;
+	void	vertexAttribPointerImpl( GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer ) override;
+	void	vertexAttribIPointerImpl( GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer ) override;
+	void	vertexAttribDivisorImpl( GLuint index, GLuint divisor ) override;
+	void	reflectBindBufferImpl( GLenum target, GLuint buffer ) override;
 	
-	virtual void	reassignContext( Context *newContext ) override;
+	void	reassignContext( Context *newContext ) override;
 	void			reassignImpl( Context *newContext );
 	
 	friend class Context;

--- a/src/cinder/gl/VaoImplSoftware.cpp
+++ b/src/cinder/gl/VaoImplSoftware.cpp
@@ -38,16 +38,16 @@ class VaoImplSoftware : public Vao {
 	VaoImplSoftware();
 
 	// Does the actual "work" of binding the VAO; called by Context
-	virtual void	bindImpl( Context *context ) override;
-	virtual void	unbindImpl( Context *context ) override;
-	virtual void	enableVertexAttribArrayImpl( GLuint index ) override;
-	virtual void	disableVertexAttribArrayImpl( GLuint index ) override;
-	virtual void	vertexAttribPointerImpl( GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer ) override;
-	virtual void	vertexAttribIPointerImpl( GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer ) override;
-	virtual void	vertexAttribDivisorImpl( GLuint index, GLuint divisor ) override;	
-	virtual void	reflectBindBufferImpl( GLenum target, GLuint buffer ) override;
+	void	bindImpl( Context *context ) override;
+	void	unbindImpl( Context *context ) override;
+	void	enableVertexAttribArrayImpl( GLuint index ) override;
+	void	disableVertexAttribArrayImpl( GLuint index ) override;
+	void	vertexAttribPointerImpl( GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer ) override;
+	void	vertexAttribIPointerImpl( GLuint index, GLint size, GLenum type, GLsizei stride, const GLvoid *pointer ) override;
+	void	vertexAttribDivisorImpl( GLuint index, GLuint divisor ) override;	
+	void	reflectBindBufferImpl( GLenum target, GLuint buffer ) override;
 
-	virtual void	reassignContext( Context *newContext ) override;
+	void	reassignContext( Context *newContext ) override;
 
   protected:
 	static size_t	sIdCounter;

--- a/src/cinder/gl/VboMesh.cpp
+++ b/src/cinder/gl/VboMesh.cpp
@@ -82,9 +82,9 @@ class VboMeshGeomTarget : public geom::Target {
 	}
 	
 	virtual geom::Primitive	getPrimitive() const;
-	virtual uint8_t	getAttribDims( geom::Attrib attr ) const override;
-	virtual void copyAttrib( geom::Attrib attr, uint8_t dims, size_t strideBytes, const float *srcData, size_t count ) override;
-	virtual void copyIndices( geom::Primitive primitive, const uint32_t *source, size_t numIndices, uint8_t requiredBytesPerIndex ) override;
+	uint8_t	getAttribDims( geom::Attrib attr ) const override;
+	void copyAttrib( geom::Attrib attr, uint8_t dims, size_t strideBytes, const float *srcData, size_t count ) override;
+	void copyIndices( geom::Primitive primitive, const uint32_t *source, size_t numIndices, uint8_t requiredBytesPerIndex ) override;
 	
 	//! Must be called in order to upload temporary 'mBufferData' to VBOs
 	void	copyBuffers();

--- a/test/AppCocoaViewTest/src/MyCinderApp.h
+++ b/test/AppCocoaViewTest/src/MyCinderApp.h
@@ -47,7 +47,7 @@ class MyCinderApp : public cinder::app::AppCocoaView {
 	void				mouseDrag( ci::app::MouseEvent event );
 	void				mouseMove( ci::app::MouseEvent event );
 
-	virtual void		touchesMoved( ci::app::TouchEvent event ) override;
+	void		touchesMoved( ci::app::TouchEvent event ) override;
 
 	void				keyDown( ci::app::KeyEvent event );
 	

--- a/test/ScreenSaverTest/src/ScreenSaverTestApp.cpp
+++ b/test/ScreenSaverTest/src/ScreenSaverTestApp.cpp
@@ -24,15 +24,15 @@ class ScreenSaverTestApp : public AppScreenSaver {
   public:
 	ScreenSaverTestApp();
 
-	virtual void setup() override;
-	virtual void resize() override;
-	virtual void update() override;
-	virtual void draw() override;
+	void setup() override;
+	void resize() override;
+	void update() override;
+	void draw() override;
 
 	void loadLogo();
 
 #if defined( CINDER_MAC )
-	virtual NSWindow* createMacConfigDialog() override
+	NSWindow* createMacConfigDialog() override
 	{
 		return getConfigDialogMac( this, &mConfig ); // defined in MacConfigDialog.cpp
 	}

--- a/test/_audio/NodeTest/src/InterleavedPassThruNode.h
+++ b/test/_audio/NodeTest/src/InterleavedPassThruNode.h
@@ -10,7 +10,7 @@ struct InterleavedPassThruNode : public ci::audio::Node {
 		setNumChannels( 2 );
 	}
 
-	virtual void initialize() override
+	void initialize() override
 	{
 		mBufferInterleaved = ci::audio::BufferInterleaved( getContext()->getFramesPerBlock(), 2 );
 	}


### PR DESCRIPTION
Based on some discussion in #980, the Cinder style now suggests that functions with the `override` specifier should also not use the `virtual` specifier as it is redundant.

To find and replace offending lines of code a regular expression was used in BBEdit and it was applied to all files in the `include`, `src`, `samples`, `test` and `blocks` subdirectories.
  Find: `virtual(\s+)(.*)(\s+)override(.*)`
  Replace: `\2\3override\4`

I quickly compiled the OS X and iOS targets and those seemed fine but Windows should be verified. Also it is worth noting that this likely messed up custom block indenting and I'm really not sure how we'd deal with that - it really seems as though it would have to be done by hand for each changed line which might be out of the scope of this particular change - maybe [ClangFormat](http://clang.llvm.org/docs/ClangFormat.html) could save the day? :sob:.

Should CONTRIBUTING.md also be updated with the new style info?