### PR TITLE
Fixed the default radius, was too big

### DIFF
--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -574,7 +574,7 @@ void Rect::setDefaultTexCoords()
 ///////////////////////////////////////////////////////////////////////////////////////
 // RoundedRect
 RoundedRect::RoundedRect()
-	: mSubdivisions( -1 ), mCornerRadius( 1.0f ), mHasColors( false ), mNumVertices( 0 )
+	: mSubdivisions( -1 ), mCornerRadius( 0.1f ), mHasColors( false ), mNumVertices( 0 )
 {
 	rect( Rectf( -0.5f, -0.5f, 0.5f, 0.5f ) );
 	updateVertexCount();
@@ -3384,7 +3384,7 @@ void WireCircle::loadInto( Target *target, const AttribSet &requestedAttribs ) c
 ///////////////////////////////////////////////////////////////////////////////////////
 // WireRoundedRect
 WireRoundedRect::WireRoundedRect()
-	: mCornerSubdivisions( -1 ), mCornerRadius( 1.0f ), mNumVertices( 0 )
+	: mCornerSubdivisions( -1 ), mCornerRadius( 0.1f ), mNumVertices( 0 )
 {
 	rect( Rectf( -0.5f, -0.5f, 0.5f, 0.5f ) );
 	updateVertexCount();


### PR DESCRIPTION
Looks like my default radius was a bit insane, larger than the shape itself. This should fix #958.