### PR TITLE
Lazy fetch MSW display name

### DIFF
--- a/include/cinder/app/msw/PlatformMsw.h
+++ b/include/cinder/app/msw/PlatformMsw.h
@@ -85,6 +85,9 @@ class ResourceLoadExcMsw : public ResourceLoadExc {
 namespace cinder {
 
 class DisplayMsw : public Display {
+  public:
+	std::string		getName() const override;
+
   protected:
 	static BOOL CALLBACK enumMonitorProc( HMONITOR hMonitor, HDC hdc, LPRECT rect, LPARAM lParam );
 

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -469,7 +469,6 @@ void DisplayMac::displayReconfiguredCallback( CGDirectDisplayID displayId, CGDis
 			newDisplay->mContentScale = 1.0f;
 #endif
 			newDisplay->mBitsPerPixel = 24; // hard-coded absent any examples of anything else
-			newDisplay->mNameDirty = true;
 
 			app::PlatformCocoa::get()->addDisplay( DisplayRef( newDisplay ) ); // this will signal
 		}

--- a/src/cinder/app/msw/PlatformMsw.cpp
+++ b/src/cinder/app/msw/PlatformMsw.cpp
@@ -287,6 +287,15 @@ std::string getMonitorName( HMONITOR hMonitor )
 	return msw::toUtf8String( std::wstring(  dispDev.DeviceString ) );}
 } // anonymous namespace
 
+std::string DisplayMsw::getName() const
+{
+	if( mNameDirty ) {
+		mName = getMonitorName( mMonitor );
+		mNameDirty = false;
+	}
+	return mName;
+}
+
 BOOL CALLBACK DisplayMsw::enumMonitorProc( HMONITOR hMonitor, HDC hdc, LPRECT rect, LPARAM lParam )
 {
 	vector<DisplayRef> *displaysVector = reinterpret_cast<vector<DisplayRef>*>( lParam );
@@ -296,7 +305,6 @@ BOOL CALLBACK DisplayMsw::enumMonitorProc( HMONITOR hMonitor, HDC hdc, LPRECT re
 	newDisplay->mMonitor = hMonitor;
 	newDisplay->mContentScale = 1.0f;
 	newDisplay->mBitsPerPixel = getMonitorBitsPerPixel( hMonitor );
-	newDisplay->mName = getMonitorName( hMonitor );
 
 	displaysVector->push_back( DisplayRef( newDisplay ) );
 	return TRUE;


### PR DESCRIPTION
Accidentally missed in #967, the display name should be fetched from the underlying platform on the first `Display::getName()` access, not on display creation.