### PR TITLE
disabling LoggerSystem on winrt.

### DIFF
--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -135,7 +135,7 @@ class LoggerBreakpoint : public Logger {
 	Level	mTriggerLevel;
 };
 
-//! Provides 'system' logging support. Uses syslog on platforms that have it, on MSW uses Windoes Event Logging
+//! Provides 'system' logging support. Uses syslog on platforms that have it, on MSW uses Windows Event Logging. \note Does nothing on WinRT.
 class LoggerSystem : public Logger {
 public:
 	LoggerSystem();

--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -593,9 +593,11 @@ LoggerSystem::~LoggerSystem()
 
 void LoggerSystem::write( const Metadata &meta, const std::string &text )
 {
+#if ! defined( CINDER_WINRT ) // Currently no system logging support on WinRT
 	if( meta.mLevel >= mMinLevel ) {
 		mImpl->write( meta, text );
 	}
+#endif
 }
 	
 // ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
as EventLog API doesn't appear to be available there. This just gets the project building again, while LoggerSystem::write() will do nothing for now. @lucasvickers Can you think of a solution we can use on that platform?  I haven't spent too much time looking, but I did see a [suggestion here](https://social.msdn.microsoft.com/Forums/windowsapps/en-US/73c7fb3a-2183-4d60-b2b1-ff4aa9286700/systemdiagnosticseventlog-replacement) to use COM and EventWrite(), not sure what the difference is between that method and the one we're using.