### PR TITLE
CubeMaps from DDS and KTX

### DIFF
--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -318,11 +318,24 @@ std::ostream& operator<<( std::ostream &os, const TextureBase &rhs );
 
 class TextureData {
   public:
-	struct Level {
+	//! Represents a face of a texture; typically 1 Face per Level; CubeMaps have 6.
+	struct Face {
   		GLsizei						dataSize;
 		size_t						offset;
-		std::shared_ptr<uint8_t>	dataStore;
+//		std::shared_ptr<uint8_t>	dataStore;
+	};
+
+	//! Represents a single mip-level, composed of 1 or more Faces
+	struct Level {
 		GLsizei						width, height, depth;
+
+		size_t						getNumFaces() const { return mFaces.size(); }
+		const Face&					getFace( size_t index ) const { return mFaces.at( index ); }
+		const std::vector<Face>&	getFaces() const { return mFaces; }
+		Face&						back() { return mFaces.back(); }
+		void						push_back( const Face &face ) { mFaces.push_back( face ); }
+		
+		std::vector<Face>			mFaces;
 	};
 
 	TextureData();
@@ -339,8 +352,10 @@ class TextureData {
 	void				setHeight( GLint height ) { mHeight = height; }
 	GLint				getDepth() const { return mDepth; }
 	void				setDepth( GLint depth ) { mDepth = depth; }
+	GLint				getNumFaces() const { return mNumFaces; }
+	void				setNumFaces( GLint numFaces ) { mNumFaces = numFaces; }	
 	
-	bool				isCompressed() const { return mDataFormat == 0; }
+	bool				isCompressed() const { return mDataType == 0; }
 	GLint				getInternalFormat() const { return mInternalFormat; }
 	void				setInternalFormat( GLint internalFormat ) { mInternalFormat = internalFormat; }
 	GLenum				getDataFormat() const { return mDataFormat; }
@@ -354,7 +369,6 @@ class TextureData {
 	void						setSwizzleMask( const std::array<GLint,4> &swizzleMask ) { mSwizzleMask = swizzleMask; }
 
 	size_t						getNumLevels() const { return mLevels.size(); }
-	const Level&				getLevel( size_t index ) const { return mLevels.at( index ); }
 	const std::vector<Level>&	getLevels() const { return mLevels; }
 	Level&						back() { return mLevels.back(); }
 	void						push_back( const Level &level ) { mLevels.push_back( level ); }
@@ -369,14 +383,14 @@ class TextureData {
   private:
 	void		init();
 	
-	GLint				mWidth, mHeight, mDepth;
+	GLint				mWidth, mHeight, mDepth, mNumFaces;
 	GLint				mInternalFormat;
 	GLenum				mDataFormat, mDataType;
 	GLint				mUnpackAlignment;
 	std::array<GLint,4>	mSwizzleMask;
-	
-	std::vector<Level>			mLevels;
 
+	std::vector<Level>	mLevels; // mip-levels
+	
   #if ! defined( CINDER_GL_ES )
 	PboRef						mPbo;
 	void*						mPboMappedPtr;
@@ -720,6 +734,10 @@ class TextureCubeMap : public TextureBase
 	static TextureCubeMapRef	create( const ImageSourceRef &imageSource, const Format &format = Format() );
 	//! Expects images ordered { +X, -X, +Y, -Y, +Z, -Z }
 	static TextureCubeMapRef	create( const ImageSourceRef images[6], const Format &format = Format() );
+	//! Constructs a TextureCubeMap based on an instance of TextureData
+	static TextureCubeMapRef	create( const TextureData &data, const Format &format );
+	//! Constructs a TextureCubeMap from a KTX file. Enables mipmapping if KTX file contains mipmaps and Format has not specified \c false for mipmapping. Uses Format's intermediate PBO if supplied; requires it to be large enough to hold all MIP levels and throws if it is not. (http://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/)
+	static TextureCubeMapRef	createFromKtx( const DataSourceRef &dataSource, const Format &format = Format() );
 
 	//! Returns the width of the texture in pixels
 	GLint			getWidth() const override { return mWidth; }
@@ -727,11 +745,15 @@ class TextureCubeMap : public TextureBase
 	GLint			getHeight() const override { return mHeight; }
 	//! Returns the depth of the texture in pixels (
 	GLint			getDepth() const override { return 1; }
+
+	//! Replaces the pixels (and data store) of a Texture with contents of \a textureData.
+	void			replace( const TextureData &textureData );
 	
   protected:
 	TextureCubeMap( int32_t width, int32_t height, Format format );
 	template<typename T>
 	TextureCubeMap( const SurfaceT<T> images[6], Format format );
+	TextureCubeMap( const TextureData &data, Format format );
 
 	template<typename T>
 	static TextureCubeMapRef createTextureCubeMapImpl( const ImageSourceRef &imageSource, const Format &format );

--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -332,6 +332,7 @@ class TextureData {
 		size_t						getNumFaces() const { return mFaces.size(); }
 		const Face&					getFace( size_t index ) const { return mFaces.at( index ); }
 		const std::vector<Face>&	getFaces() const { return mFaces; }
+		std::vector<Face>&			getFaces() { return mFaces; }
 		Face&						back() { return mFaces.back(); }
 		void						push_back( const Face &face ) { mFaces.push_back( face ); }
 		
@@ -370,6 +371,7 @@ class TextureData {
 
 	size_t						getNumLevels() const { return mLevels.size(); }
 	const std::vector<Level>&	getLevels() const { return mLevels; }
+	std::vector<Level>&			getLevels() { return mLevels; }
 	Level&						back() { return mLevels.back(); }
 	void						push_back( const Level &level ) { mLevels.push_back( level ); }
 	void						clear() { mLevels.clear(); }
@@ -738,6 +740,10 @@ class TextureCubeMap : public TextureBase
 	static TextureCubeMapRef	create( const TextureData &data, const Format &format );
 	//! Constructs a TextureCubeMap from a KTX file. Enables mipmapping if KTX file contains mipmaps and Format has not specified \c false for mipmapping. Uses Format's intermediate PBO if supplied; requires it to be large enough to hold all MIP levels and throws if it is not. (http://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/)
 	static TextureCubeMapRef	createFromKtx( const DataSourceRef &dataSource, const Format &format = Format() );
+#if ! defined( CINDER_GL_ES ) || defined( CINDER_GL_ANGLE )
+	//! Constructs a TextureCubeMap from a DDS file. Supports DXT1, DTX3, and DTX5. Supports BC7 in the presence of \c GL_ARB_texture_compression_bptc. Enables mipmapping if DDS contains mipmaps and Format has not specified \c false for mipmapping. ANGLE version requires textures to be a multiple of 4 due to DX limitation.
+	static TextureCubeMapRef	createFromDds( const DataSourceRef &dataSource, const Format &format = Format() );
+#endif
 
 	//! Returns the width of the texture in pixels
 	GLint			getWidth() const override { return mWidth; }

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -1838,6 +1838,7 @@ TextureCubeMapRef TextureCubeMap::createFromKtx( const DataSourceRef &dataSource
 	return TextureCubeMap::create( textureData, format );
 }
 
+#if ! defined( CINDER_GL_ES )
 TextureCubeMapRef TextureCubeMap::createFromDds( const DataSourceRef &dataSource, const Format &format )
 {
 #if ! defined( CINDER_GL_ES )
@@ -1849,6 +1850,7 @@ TextureCubeMapRef TextureCubeMap::createFromDds( const DataSourceRef &dataSource
 	parseDds( dataSource, &textureData );
 	return TextureCubeMap::create( textureData, format );
 }
+#endif
 
 TextureCubeMap::TextureCubeMap( int32_t width, int32_t height, Format format )
 	: mWidth( width ), mHeight( height )

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -1759,6 +1759,14 @@ TextureCubeMapRef TextureCubeMap::create( const ImageSourceRef &imageSource, con
 	else
 		return createTextureCubeMapImpl<float>( imageSource, format );
 }
+
+TextureCubeMapRef TextureCubeMap::create( const TextureData &data, const Format &format )
+{
+	if( format.mDeleter )
+		return TextureCubeMapRef( new TextureCubeMap( data, format ), format.mDeleter );
+	else
+		return TextureCubeMapRef( new TextureCubeMap( data, format ) );
+}
 	
 template<typename T>
 TextureCubeMapRef TextureCubeMap::createTextureCubeMapImpl( const ImageSourceRef &imageSource, const Format &format )
@@ -1818,6 +1826,18 @@ TextureCubeMapRef TextureCubeMap::create( const ImageSourceRef images[6], const 
 	}
 }
 
+TextureCubeMapRef TextureCubeMap::createFromKtx( const DataSourceRef &dataSource, const Format &format )
+{
+#if ! defined( CINDER_GL_ES )
+	TextureData textureData( format.getIntermediatePbo() );
+#else
+	TextureData textureData;
+#endif
+
+	parseKtx( dataSource, &textureData );
+	return TextureCubeMap::create( textureData, format );
+}
+
 TextureCubeMap::TextureCubeMap( int32_t width, int32_t height, Format format )
 	: mWidth( width ), mHeight( height )
 {
@@ -1857,6 +1877,51 @@ TextureCubeMap::TextureCubeMap( const SurfaceT<T> images[6], Format format )
 #endif
 		glGenerateMipmap( mTarget );
 	}
+}
+
+TextureCubeMap::TextureCubeMap( const TextureData &data, Format format )
+{
+	glGenTextures( 1, &mTextureId );
+	mTarget = format.getTarget();
+	ScopedTextureBind texBindScope( mTarget, mTextureId );
+	initParams( format, 0 /* unused */, 0 /* unused */ );
+	
+	replace( data );
+
+	if( mMipmapping && data.getNumLevels() <= 1 ) {
+		glGenerateMipmap( mTarget );
+	}
+}
+
+//! Replaces the pixels (and data store) of a Texture with contents of \a textureData.
+void TextureCubeMap::replace( const TextureData &textureData )
+{
+	mInternalFormat = textureData.getInternalFormat();
+
+	mWidth = textureData.getWidth();
+	mHeight = textureData.getHeight();
+
+	ScopedTextureBind bindScope( mTarget, mTextureId );
+	if( textureData.getUnpackAlignment() != 0 )
+		glPixelStorei( GL_UNPACK_ALIGNMENT, textureData.getUnpackAlignment() );
+
+	if( textureData.getNumFaces() != 6 ) {
+		throw TextureDataExc( "TextureCubeMap requires 6 faces" );
+	}
+
+	int curFaceIdx = 0, curLevel = 0;
+	for( const auto &textureDataLevel : textureData.getLevels() ) {	
+		for( const auto &textureDataFace : textureDataLevel.getFaces() ) {
+			if( ! textureData.isCompressed() )
+				glTexImage2D( GL_TEXTURE_CUBE_MAP_POSITIVE_X + curFaceIdx, curLevel, mInternalFormat, textureDataLevel.width, textureDataLevel.height, 0, textureData.getDataFormat(), textureData.getDataType(), textureData.getDataStorePtr( textureDataFace.offset ) );
+			else
+				glCompressedTexImage2D( GL_TEXTURE_CUBE_MAP_POSITIVE_X + curFaceIdx, curLevel, textureData.getInternalFormat(), textureDataLevel.width, textureDataLevel.height, 0, textureDataFace.dataSize, textureData.getDataStorePtr( textureDataFace.offset ) );
+			++curFaceIdx;
+		}
+		++curLevel;
+	}
+	if( textureData.getUnpackAlignment() != 0 )
+		glPixelStorei( GL_UNPACK_ALIGNMENT, textureData.getUnpackAlignment() );
 }
 
 void TextureCubeMap::printDims( std::ostream &os ) const
@@ -1945,7 +2010,7 @@ TextureData::TextureData( const PboRef &pbo )
 
 void TextureData::init()
 {
-	mWidth = mHeight = mDepth = 0;
+	mWidth = mHeight = mDepth = mNumFaces = 0;
 	mInternalFormat = 0;
 	mDataFormat = mDataType = 0;
 	mUnpackAlignment = 0;
@@ -2051,11 +2116,12 @@ void Texture2d::update( const TextureData &textureData )
 			glPixelStorei( GL_UNPACK_ALIGNMENT, textureData.getUnpackAlignment() );
 
 		int curLevel = 0;
-		for( const auto &textureDataLevel : textureData.getLevels() ) {		
-			if( textureData.getDataType() != 0 )
-				glTexSubImage2D( mTarget, curLevel, 0, 0, textureDataLevel.width, textureDataLevel.height, textureData.getDataFormat(), textureData.getDataType(), textureData.getDataStorePtr( textureDataLevel.offset ) );
+		for( const auto &textureDataLevel : textureData.getLevels() ) {
+			const TextureData::Face& textureDataFace = textureDataLevel.getFaces()[0];
+			if( ! textureData.isCompressed() )
+				glTexSubImage2D( mTarget, curLevel, 0, 0, textureDataLevel.width, textureDataLevel.height, textureData.getDataFormat(), textureData.getDataType(), textureData.getDataStorePtr( textureDataFace.offset ) );
 			else
-				glCompressedTexSubImage2D( mTarget, curLevel, 0, 0, textureDataLevel.width, textureDataLevel.height, textureData.getInternalFormat(), textureDataLevel.dataSize, textureData.getDataStorePtr( textureDataLevel.offset ) );
+				glCompressedTexSubImage2D( mTarget, curLevel, 0, 0, textureDataLevel.width, textureDataLevel.height, textureData.getInternalFormat(), textureDataFace.dataSize, textureData.getDataStorePtr( textureDataFace.offset ) );
 			++curLevel;
 		}
 		if( textureData.getUnpackAlignment() != 0 )
@@ -2074,11 +2140,12 @@ void Texture2d::replace( const TextureData &textureData )
 		glPixelStorei( GL_UNPACK_ALIGNMENT, textureData.getUnpackAlignment() );
 
 	int curLevel = 0;
-	for( const auto &textureDataLevel : textureData.getLevels() ) {		
-		if( textureData.getDataType() != 0 )
-			glTexImage2D( mTarget, curLevel, textureData.getInternalFormat(), textureDataLevel.width, textureDataLevel.height, 0, textureData.getDataFormat(), textureData.getDataType(), textureData.getDataStorePtr( textureDataLevel.offset ) );
+	for( const auto &textureDataLevel : textureData.getLevels() ) {
+		const TextureData::Face& textureDataFace = textureDataLevel.getFaces()[0];
+		if( ! textureData.isCompressed() )
+			glTexImage2D( mTarget, curLevel, textureData.getInternalFormat(), textureDataLevel.width, textureDataLevel.height, 0, textureData.getDataFormat(), textureData.getDataType(), textureData.getDataStorePtr( textureDataFace.offset ) );
 		else
-			glCompressedTexImage2D( mTarget, curLevel, textureData.getInternalFormat(), textureDataLevel.width, textureDataLevel.height, 0, textureDataLevel.dataSize, textureData.getDataStorePtr( textureDataLevel.offset ) );
+			glCompressedTexImage2D( mTarget, curLevel, textureData.getInternalFormat(), textureDataLevel.width, textureDataLevel.height, 0, textureDataFace.dataSize, textureData.getDataStorePtr( textureDataFace.offset ) );
 		++curLevel;
 	}
 	if( textureData.getUnpackAlignment() != 0 )

--- a/src/cinder/gl/TextureFormatParsers.cpp
+++ b/src/cinder/gl/TextureFormatParsers.cpp
@@ -280,6 +280,12 @@ void parseDds( const DataSourceRef &dataSource, TextureData *resultData )
 			dataType = GL_UNSIGNED_BYTE;
 			blockSizeBytes = sizeof(uint8_t) * 3;
 		break;
+		case 32 /*D3DFMT_A8B8G8R8*/:
+			internalFormat = GL_RGBA8;
+			dataFormat = GL_BGRA;
+			dataType = GL_UNSIGNED_BYTE;
+			blockSizeBytes = sizeof(uint8_t) * 4;
+		break;
 		case FOURCC_DXT1: 
 			internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
 			blockSizeBytes = 8;
@@ -306,6 +312,18 @@ void parseDds( const DataSourceRef &dataSource, TextureData *resultData )
 					dataType = GL_HALF_FLOAT;
 					dataFormat = GL_RGBA;
 					blockSizeBytes = sizeof(uint16_t) * 4;
+				break;
+				case 12/*DXGI_FORMAT_R16G16B16A16_UINT*/:
+					internalFormat = GL_RGBA16;
+					dataType = GL_UNSIGNED_SHORT;
+					dataFormat = GL_RGBA;
+					blockSizeBytes = sizeof(uint16_t) * 4;
+				break;
+				case 2/*DXGI_FORMAT_R32G32B32A32_FLOAT*/:
+					internalFormat = GL_RGBA32F;
+					dataType = GL_FLOAT;
+					dataFormat = GL_RGBA;
+					blockSizeBytes = sizeof(float) * 4;
 				break;
 				case 70/*DXGI_FORMAT_BC1_TYPELESS*/:
 				case 71/*DXGI_FORMAT_BC1_UNORM*/:


### PR DESCRIPTION
This PR adds a CubeMap::createFromDds() and createFromKTx() method, along with the matching infrastructure in gl::TextureData and the relevant file parsers.

DDS in particular is much too deep for us to support completely at the current moment. However I've attempted to address the basic uncompressed cases with this PR, along with some of the compressed cases. We'll add support as users require in practice.

Relevant to #858.