### PR TITLE
Add PolyLine reverse() and reversed()

### DIFF
--- a/include/cinder/PolyLine.h
+++ b/include/cinder/PolyLine.h
@@ -56,6 +56,9 @@ class PolyLineT {
 
 	void		scale( const T &scaleFactor, T scaleCenter = T() );
 	void		offset( const T &offsetBy );
+	void		reverse();
+	
+	PolyLineT<T>	reversed() const;
 
 	//! Returns whether the point \a pt is contained within the boundaries of the PolyLine
 	bool	contains( const vec2 &pt ) const;

--- a/src/cinder/PolyLine.cpp
+++ b/src/cinder/PolyLine.cpp
@@ -71,6 +71,20 @@ void PolyLineT<T>::offset( const T &offsetBy )
 }
 
 template<typename T>
+void PolyLineT<T>::reverse()
+{
+	std::reverse( mPoints.begin(), mPoints.end() );
+}
+
+template<typename T>
+PolyLineT<T> PolyLineT<T>::reversed() const
+{
+	PolyLineT result( *this );
+	std::reverse( result.mPoints.begin(), result.mPoints.end() );
+	return result;
+}
+
+template<typename T>
 T linearYatX( const glm::tvec2<T, glm::defaultp> p[2], T x )
 {
 	if( p[0].x == p[1].x ) 	return p[0].y;


### PR DESCRIPTION
Makes it easier switch between from clockwise to counter-clockwise winding order.

Returning a copy makes for a nicer API:
```c++
intersection = PolyLine2f::calcIntersection( shapeA, shapeB );
if (intersection.size()) {
    // Reverse the winding order:
    PolyLine2f outline = intersection.front().reverse();
    // Use the outline
}
```
