### PR TITLE
Getting rid of false positives on MSW leak detection.

### DIFF
--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -162,7 +162,7 @@ public:
 	// Returns a pointer to the shared instance. To enable logging during shutdown, this instance is leaked at shutdown.
 	static LogManager* instance()	{ return sInstance; }
 	//! Destroys the shared instance. Useful to remove false positives with leak detectors like valgrind.
-	static void destroyInstance()	{ delete sInstance; }
+	static void destroyInstance()	{ if( sInstance ) delete sInstance; sInstance = nullptr; }
 	//! Restores LogManager to its default state.
 	void restoreToDefault();
 

--- a/include/cinder/app/msw/PlatformMsw.h
+++ b/include/cinder/app/msw/PlatformMsw.h
@@ -50,6 +50,8 @@ class PlatformMsw : public Platform {
 	fs::path	getDocumentsDirectory() const override;
 	fs::path	getDefaultExecutablePath() const override;
 
+	void		cleanupLaunch() override;
+
 	// Overridden to use OutputDebugString
 	std::ostream&	console() override;
 

--- a/include/cinder/app/msw/RendererImplGlMsw.h
+++ b/include/cinder/app/msw/RendererImplGlMsw.h
@@ -36,6 +36,7 @@ namespace cinder { namespace app {
 class RendererImplGlMsw : public RendererImplMsw {
  public:
 	RendererImplGlMsw( class RendererGl *aRenderer );
+	virtual ~RendererImplGlMsw();
 	
 	virtual bool	initialize( HWND wnd, HDC dc, RendererRef sharedRenderer );
 	virtual void	prepareToggleFullScreen();
@@ -55,6 +56,8 @@ class RendererImplGlMsw : public RendererImplMsw {
 	bool		mWasVerticalSynced;
 	HGLRC		mRC;
 	HDC			mDC;
+
+	static std::atomic<long>	mRefCount;
 };
 
 } } // namespace cinder::app

--- a/include/cinder/gl/Environment.h
+++ b/include/cinder/gl/Environment.h
@@ -81,6 +81,8 @@ class Environment {
 #else
 	static void				setEs();
 #endif
+
+	static void				destroy();
 };
 
 

--- a/src/cinder/app/msw/PlatformMsw.cpp
+++ b/src/cinder/app/msw/PlatformMsw.cpp
@@ -23,6 +23,7 @@
 
 #include "cinder/app/msw/PlatformMsw.h"
 #include "cinder/msw/OutputDebugStringStream.h"
+#include "cinder/Log.h"
 #include "cinder/Unicode.h"
 #include "cinder/msw/StackWalker.h"
 #include "cinder/msw/CinderMsw.h"
@@ -176,6 +177,14 @@ fs::path PlatformMsw::getDefaultExecutablePath() const
 	}
 
 	return fs::path( appPath );
+}
+
+void PlatformMsw::cleanupLaunch()
+{
+	// To avoid false positives when performing leak detection, destroy our singletons.
+	log::LogManager::destroyInstance();
+
+	Platform::set( nullptr );
 }
 
 void PlatformMsw::launchWebBrowser( const Url &url )

--- a/src/cinder/app/msw/RendererImplGlMsw.cpp
+++ b/src/cinder/app/msw/RendererImplGlMsw.cpp
@@ -41,10 +41,21 @@ int sArbMultisampleFormat;
 typedef HGLRC (__stdcall * PFNWGLCREATECONTEXTATTRIBSARB) (HDC hDC, HGLRC hShareContext, const int *attribList);
 typedef BOOL (__stdcall * PFNWGLCHOOSEPIXELFORMATARBPROC)(HDC hdc, const int * piAttribIList, const FLOAT * pfAttribFList, UINT nMaxFormats, int * piFormats, UINT * nNumFormats);
 
+std::atomic<long> RendererImplGlMsw::mRefCount = 0;
+
 RendererImplGlMsw::RendererImplGlMsw( RendererGl *aRenderer )
 	: mRenderer( aRenderer )
 {
 	mRC = 0;
+
+	if( mRefCount++ == 0L )
+		gl::Environment::setCore();
+}
+
+RendererImplGlMsw::~RendererImplGlMsw()
+{
+	if( --mRefCount == 0L )
+		gl::Environment::destroy();
 }
 
 void RendererImplGlMsw::prepareToggleFullScreen()

--- a/src/cinder/gl/Environment.cpp
+++ b/src/cinder/gl/Environment.cpp
@@ -74,6 +74,14 @@ Environment* env()
 	return sEnvironment;
 }
 
+void Environment::destroy()
+{
+	if( sEnvironment )
+		delete sEnvironment;
+
+	sEnvironment = NULL;
+}
+
 namespace {
 void destroyPlatformData( Context::PlatformData *data )
 {


### PR DESCRIPTION
By properly destroying our singletons (LogManager, Platform and gl::Environment) on exit, I was able to get rid of false positives reported by Visual Leak Detector on MSW. For LogManager and Platform, I simply override cleanupLaunch(). For gl::Environment, I keep a reference counter and destroy the instance when it reaches zero.