### PR TITLE
Add a signed distance function to RectT

### DIFF
--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -86,6 +86,8 @@ class RectT {
 	T		distance( const Vec2T &pt ) const;
 	//! Returns the squared distance between the point \a pt and the rectangle. Points inside the rectangle return \c 0.
 	T		distanceSquared( const Vec2T &pt ) const;
+	//! Returns the signed distance from the rectangle to the point \a pt. Distances inside the rectangle are negative.
+	T		distanceSigned( const Vec2T &pt ) const;
 
 	//! Returns the nearest point on the Rect \a rect. Points inside the rectangle return \a pt.
 	Vec2T		closestPoint( const Vec2T &pt ) const;

--- a/src/cinder/Rect.cpp
+++ b/src/cinder/Rect.cpp
@@ -262,8 +262,17 @@ T RectT<T>::distanceSquared( const Vec2T &pt ) const
 	else if( pt.x > x2 ) squaredDistance += ( pt.x - x2 ) * ( pt.x - x2 );
 	if( pt.y < y1 ) squaredDistance += ( y1 - pt.y ) * ( y1 - pt.y );
 	else if( pt.y > y2 ) squaredDistance += ( pt.y - y2 ) * ( pt.y - y2 );
-	
+
 	return squaredDistance;
+}
+
+template<typename T>
+T RectT<T>::distanceSigned( const Vec2T &pt ) const
+{
+	Vec2T halfSize = getSize() * static_cast<T>(0.5);
+	Vec2T center = getUpperLeft() + halfSize;
+	Vec2T d = glm::abs(pt - center) - halfSize;
+	return glm::min<T>(glm::max(d.x, d.y), 0) + length(glm::max<T>(d, 0));
 }
 
 template<typename T>


### PR DESCRIPTION
Sometimes it's useful to know how far a point lies inside a rectangle. Alternatively, I'd like to replace the plain `distance` function. It currently returns 0 for points inside which could be achieved just by min(x,0)'ing the signed version. Although, I can understand this might be unexpected for people used to the current behavior.

A 3d version should probably be added to AxisAlignedBox. Happy to do that as well.

Demo Sketch:
```cpp
#include "cinder/app/App.h"
#include "cinder/app/RendererGl.h"
#include "cinder/gl/gl.h"
#include "cinder/Vector.h"

using namespace ci;
using namespace ci::app;
using namespace std;

class TestRectSignedDistApp : public App {
public:
  void draw() override;
};

void TestRectSignedDistApp::draw() {
  gl::clear(Color(0, 0, 0));

  float t = getElapsedSeconds();
  float s = glm::length(vec2(getWindowSize())) / 4.0f;
  Rectf rect = { glm::rotate(vec2(s, 0), t * 0.8234f),
                 glm::rotate(vec2(0, s * 0.75f), t * 0.3345f) };
  rect.offset(getWindowCenter());
  rect.canonicalize();

  vec2 p = getMousePos() - getWindowPos();
  auto d = rect.distance(p);
  auto sd = rect.distanceSigned(p);

  gl::color(1, 1, 1);
  gl::drawStrokedRect(rect);

  gl::color(0, 1, 1);
  gl::drawStrokedCircle(p, glm::abs(sd), 64);
  gl::drawString("sd: " + std::to_string(sd), p + vec2(0, 40));

  gl::color(1, 0, 0);
  gl::drawStrokedCircle(p, d, 64);
  gl::drawString("d: " + std::to_string(d), p + vec2(0, 20));
}

CINDER_APP(TestRectSignedDistApp, RendererGl)
```