### PR TITLE
Debug drawing cubemaps

### DIFF
--- a/include/cinder/gl/Fbo.h
+++ b/include/cinder/gl/Fbo.h
@@ -331,6 +331,9 @@ class FboCubeMap : public Fbo {
 	void 	bindFramebufferFace( GLenum faceTarget, GLint level = 0, GLenum target = GL_FRAMEBUFFER, GLenum attachment = GL_COLOR_ATTACHMENT0 );
 	//! Returns the view matrix appropriate for a given face (in the \c GL_TEXTURE_CUBE_MAP_POSITIVE_X family) looking from the position \a eyePos
 	mat4	calcViewMatrix( GLenum face, const vec3 &eyePos );
+
+	//! Returns a TextureCubeMapRef attached at \a attachment (default \c GL_COLOR_ATTACHMENT0). Resolves multisampling and renders mipmaps if necessary. Returns NULL if a TextureCubeMap is not bound at \a attachment.
+	TextureCubeMapRef	getTextureCubeMap( GLenum attachment = GL_COLOR_ATTACHMENT0 );
 	
   protected:
 	FboCubeMap( int32_t faceWidth, int32_t faceHeight, const Format &format, const TextureCubeMapRef &textureCubeMap );

--- a/include/cinder/gl/draw.h
+++ b/include/cinder/gl/draw.h
@@ -61,11 +61,11 @@ void draw( const TriMesh &mesh );
 //! Draws a geom::Source \a source at the origin.
 void draw( const geom::Source &source );
 
-//! Draws a CubeMapTex \a texture inside \a rect with an equirectangular projection. If \a lod is non-default then a specific mip-level is drawn.
+//! Draws a CubeMapTex \a texture inside \a rect with an equirectangular projection. If \a lod is non-default then a specific mip-level is drawn. Typical aspect ratio should be 2:1.
 void drawEquirectangular( const gl::TextureCubeMapRef &texture, const Rectf &r, float lod = -1 );
-//! Draws a CubeMapTex \a texture as a horizontal cross, fit inside \a rect. If \a lod is non-default then a specific mip-level is drawn.
+//! Draws a CubeMapTex \a texture as a horizontal cross, fit inside \a rect. If \a lod is non-default then a specific mip-level is drawn. Typical aspect ratio should be 4:3.
 void drawHorizontalCross( const gl::TextureCubeMapRef &texture, const Rectf &rect, float lod = -1 );
-//! Draws a CubeMapTex \a texture as a vertical cross, fit inside \a rect. If \a lod is non-default then a specific mip-level is drawn.
+//! Draws a CubeMapTex \a texture as a vertical cross, fit inside \a rect. If \a lod is non-default then a specific mip-level is drawn. Typical aspect ratio should be 3:4.
 void drawVerticalCross( const gl::TextureCubeMapRef &texture, const Rectf &rect, float lod = -1 );
 
 //! Draws a solid (filled) Path2d \a path using approximation scale \a approximationScale. 1.0 corresponds to screenspace, 2.0 is double screen resolution, etc. Performance warning: This routine tesselates the polygon into triangles. Consider using Triangulator directly.

--- a/include/cinder/gl/draw.h
+++ b/include/cinder/gl/draw.h
@@ -63,6 +63,10 @@ void draw( const geom::Source &source );
 
 //! Draws a CubeMapTex \a texture inside \a rect with an equirectangular projection. If \a lod is non-default then a specific mip-level is drawn.
 void drawEquirectangular( const gl::TextureCubeMapRef &texture, const Rectf &r, float lod = -1 );
+//! Draws a CubeMapTex \a texture as a horizontal cross, fit inside \a rect. If \a lod is non-default then a specific mip-level is drawn.
+void drawHorizontalCross( const gl::TextureCubeMapRef &texture, const Rectf &rect, float lod = -1 );
+//! Draws a CubeMapTex \a texture as a vertical cross, fit inside \a rect. If \a lod is non-default then a specific mip-level is drawn.
+void drawVerticalCross( const gl::TextureCubeMapRef &texture, const Rectf &rect, float lod = -1 );
 
 //! Draws a solid (filled) Path2d \a path using approximation scale \a approximationScale. 1.0 corresponds to screenspace, 2.0 is double screen resolution, etc. Performance warning: This routine tesselates the polygon into triangles. Consider using Triangulator directly.
 void drawSolid( const Path2d &path2d, float approximationScale = 1.0f );

--- a/include/cinder/ip/Flip.h
+++ b/include/cinder/ip/Flip.h
@@ -27,7 +27,7 @@
 
 namespace cinder { namespace ip {
 
-//! Flips the contents of \a surface vertically
+//! Flips the contents of \a surface vertically (bottom becomes top)
 template<typename T>
 void flipVertical( SurfaceT<T> *surface );
 
@@ -38,5 +38,9 @@ void flipVertical( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface );
 //! Copies the contents of \a srcChannel into \a destChannel, flipping them vertically
 template<typename T>
 void flipVertical( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel );
+
+//! Flips the contents of \a surface horizontally (left becomes right)
+template<typename T>
+void flipHorizontal( SurfaceT<T> *surface );
 
 } } // namespace cinder::ip

--- a/samples/_opengl/DynamicCubeMapping/src/DynamicCubeMappingApp.cpp
+++ b/samples/_opengl/DynamicCubeMapping/src/DynamicCubeMappingApp.cpp
@@ -14,9 +14,10 @@ struct Satellite {
 
 class DynamicCubeMappingApp : public App {
   public:
-	void setup();
-	void resize();
-	void update();
+	void setup() override;
+	void resize() override;
+	void update() override;
+	void keyDown( KeyEvent event ) override;
 
 	void drawSatellites();
 	void drawSkyBox();
@@ -24,10 +25,11 @@ class DynamicCubeMappingApp : public App {
 
 	gl::TextureCubeMapRef	mSkyBoxCubeMap;
 	gl::BatchRef			mTeapotBatch, mSkyBoxBatch;
-	mat4				mObjectRotation;
+	mat4					mObjectRotation;
 	CameraPersp				mCam;
 	
 	gl::FboCubeMapRef		mDynamicCubeMapFbo;
+	bool					mDrawCubeMap;
 	
 	std::vector<Satellite>	mSatellites;
 	gl::BatchRef			mSatelliteBatch;
@@ -65,6 +67,8 @@ void DynamicCubeMappingApp::setup()
 	}
 	mSatelliteBatch = gl::Batch::create( geom::Sphere(), getStockShader( gl::ShaderDef().color() ) );
 
+	mDrawCubeMap = false;
+
 	gl::enableDepthRead();
 	gl::enableDepthWrite();	
 }
@@ -87,6 +91,12 @@ void DynamicCubeMappingApp::update()
 		float angle = i / 33.0f;
 		mSatellites[i].mPos = vec3( cos( angle * 2 * M_PI ) * 7, 6 * sin( getElapsedSeconds() * 2 + angle * 4 * M_PI ), sin( angle * 2 * M_PI ) * 7 );
 	}	
+}
+
+void DynamicCubeMappingApp::keyDown( KeyEvent event )
+{
+	if( event.getChar() == 'd' )
+		mDrawCubeMap = ! mDrawCubeMap;
 }
 
 void DynamicCubeMappingApp::drawSatellites()
@@ -140,6 +150,13 @@ void DynamicCubeMappingApp::draw()
 		gl::scale( vec3( 4 ) );
 		mTeapotBatch->draw();
 	gl::popMatrices();
+
+	if( mDrawCubeMap ) {
+		gl::setMatricesWindow( getWindowSize() );
+		gl::ScopedDepth d( false );
+		//gl::drawHorizontalCross( mDynamicCubeMapFbo->getTextureCubeMap(), Rectf( 0, 0, 400, 200 ) );
+		gl::drawEquirectangular( mDynamicCubeMapFbo->getTextureCubeMap(), Rectf( 0, getWindowHeight() - 200, 400, getWindowHeight() ) ); // try this alternative
+	}
 }
 
 CINDER_APP( DynamicCubeMappingApp, RendererGl( RendererGl::Options().msaa( 16 ) ) )

--- a/samples/_opengl/DynamicCubeMapping/src/DynamicCubeMappingApp.cpp
+++ b/samples/_opengl/DynamicCubeMapping/src/DynamicCubeMappingApp.cpp
@@ -67,7 +67,7 @@ void DynamicCubeMappingApp::setup()
 	}
 	mSatelliteBatch = gl::Batch::create( geom::Sphere(), getStockShader( gl::ShaderDef().color() ) );
 
-	mDrawCubeMap = false;
+	mDrawCubeMap = true;
 
 	gl::enableDepthRead();
 	gl::enableDepthWrite();	
@@ -154,8 +154,8 @@ void DynamicCubeMappingApp::draw()
 	if( mDrawCubeMap ) {
 		gl::setMatricesWindow( getWindowSize() );
 		gl::ScopedDepth d( false );
-		//gl::drawHorizontalCross( mDynamicCubeMapFbo->getTextureCubeMap(), Rectf( 0, 0, 400, 200 ) );
-		gl::drawEquirectangular( mDynamicCubeMapFbo->getTextureCubeMap(), Rectf( 0, getWindowHeight() - 200, 400, getWindowHeight() ) ); // try this alternative
+		gl::drawHorizontalCross( mDynamicCubeMapFbo->getTextureCubeMap(), Rectf( 0, 0, 300, 150 ) );
+		//gl::drawEquirectangular( mDynamicCubeMapFbo->getTextureCubeMap(), Rectf( 0, getWindowHeight() - 200, 400, getWindowHeight() ) ); // try this alternative
 	}
 }
 

--- a/samples/_opengl/TransformFeedbackSmokeParticles/assets/renderSmoke.vert
+++ b/samples/_opengl/TransformFeedbackSmokeParticles/assets/renderSmoke.vert
@@ -1,9 +1,7 @@
 #version 150 core
 
 in vec3 VertexPosition;
-in vec3 VertexVelocity;
 in float VertexStartTime;
-in vec3 VertexInitialVelocity;
 in vec4 VertexColor;
 
 out float Transp; // To Fragment Shader

--- a/samples/_opengl/TransformFeedbackSmokeParticles/src/TransformFeedbackSmokeParticlesApp.cpp
+++ b/samples/_opengl/TransformFeedbackSmokeParticles/src/TransformFeedbackSmokeParticlesApp.cpp
@@ -117,9 +117,7 @@ void TransformFeedbackSmokeParticlesApp::loadShaders()
 		mRenderParticleGlslFormat.vertex( loadAsset( "renderSmoke.vert" ) )
 			.fragment( loadAsset( "renderSmoke.frag" ) )
 			.attribLocation("VertexPosition",			PositionIndex )
-			.attribLocation( "VertexVelocity",			VelocityIndex )
-			.attribLocation( "VertexStartTime",			StartTimeIndex )
-			.attribLocation( "VertexInitialVelocity",	InitialVelocityIndex );
+			.attribLocation( "VertexStartTime",			StartTimeIndex );
 		
 		mPRenderGlsl = ci::gl::GlslProg::create( mRenderParticleGlslFormat );
 	}

--- a/src/cinder/gl/Fbo.cpp
+++ b/src/cinder/gl/Fbo.cpp
@@ -825,6 +825,11 @@ void FboCubeMap::bindFramebufferFace( GLenum faceTarget, GLint level, GLenum tar
 	glFramebufferTexture2D( target, attachment, faceTarget, mTextureCubeMap->getId(), level );
 }
 
+TextureCubeMapRef FboCubeMap::getTextureCubeMap( GLenum attachment )
+{
+	return std::dynamic_pointer_cast<gl::TextureCubeMap>( getTextureBase( attachment ) );
+}
+
 mat4 FboCubeMap::calcViewMatrix( GLenum face, const vec3 &eyePos )
 {
 	static const vec3 viewDirs[6] = { vec3( 1, 0, 0 ), vec3( -1, 0, 0 ), vec3( 0, 1, 0 ), vec3( 0, -1, 0 ), vec3( 0, 0, 1 ), vec3( 0, 0, -1 ) };

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -1631,9 +1631,15 @@ void Texture3d::printDims( std::ostream &os ) const
 /////////////////////////////////////////////////////////////////////////////////
 // TextureCubeMap
 namespace {
-std::vector<std::pair<ci::Area, ci::ivec2>> calcCubeMapHorizontalCrossRegions( const ImageSourceRef &imageSource )
+struct CubeMapFaceRegion {
+	Area		mArea;
+	ivec2		mOffset;
+	bool		mFlip; // horizontal + vertical
+};
+
+std::vector<CubeMapFaceRegion> calcCubeMapHorizontalCrossRegions( const ImageSourceRef &imageSource )
 {
-	std::vector<std::pair<ci::Area, ci::ivec2>> result;
+	std::vector<CubeMapFaceRegion> result;
 
 	ivec2 faceSize( imageSource->getWidth() / 4, imageSource->getHeight() / 3 );
 	Area faceArea( 0, 0, faceSize.x, faceSize.y );
@@ -1644,34 +1650,34 @@ std::vector<std::pair<ci::Area, ci::ivec2>> calcCubeMapHorizontalCrossRegions( c
 	// GL_TEXTURE_CUBE_MAP_POSITIVE_X
 	area = faceArea + ivec2( faceSize.x * 2, faceSize.y * 1 );
 	offset = -ivec2( faceSize.x * 2, faceSize.y * 1 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_NEGATIVE_X
 	area = faceArea + ivec2( faceSize.x * 0, faceSize.y * 1 );
 	offset = -ivec2( faceSize.x * 0, faceSize.y * 1 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_POSITIVE_Y
 	area = faceArea + ivec2( faceSize.x * 1, faceSize.y * 0 );
 	offset = -ivec2( faceSize.x * 1, faceSize.y * 0 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_NEGATIVE_Y
 	area = faceArea + ivec2( faceSize.x * 1, faceSize.y * 2 );
 	offset = -ivec2( faceSize.x * 1, faceSize.y * 2 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_POSITIVE_Z
 	area = faceArea + ivec2( faceSize.x * 1, faceSize.y * 1 );
 	offset = -ivec2( faceSize.x * 1, faceSize.y * 1 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
 	area = faceArea + ivec2( faceSize.x * 3, faceSize.y * 1 );
 	offset = -ivec2( faceSize.x * 3, faceSize.y * 1 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 		
 	return result;
 };
 	
-std::vector<std::pair<ci::Area, ci::ivec2>> calcCubeMapVerticalCrossRegions( const ImageSourceRef &imageSource )
+std::vector<CubeMapFaceRegion> calcCubeMapVerticalCrossRegions( const ImageSourceRef &imageSource )
 {
-	std::vector<std::pair<ci::Area, ci::ivec2>> result;
+	std::vector<CubeMapFaceRegion> result;
 	
 	ivec2 faceSize( imageSource->getWidth() / 3, imageSource->getHeight() / 4 );
 	Area faceArea( 0, 0, faceSize.x, faceSize.y );
@@ -1682,54 +1688,54 @@ std::vector<std::pair<ci::Area, ci::ivec2>> calcCubeMapVerticalCrossRegions( con
 	// GL_TEXTURE_CUBE_MAP_POSITIVE_X
 	area = faceArea + ivec2( faceSize.x * 2, faceSize.y * 1 );
 	offset = -ivec2( faceSize.x * 2, faceSize.y * 1 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_NEGATIVE_X
 	area = faceArea + ivec2( faceSize.x * 0, faceSize.y * 1 );
 	offset = -ivec2( faceSize.x * 0, faceSize.y * 1 );
-	result.push_back( make_pair( area, offset ) );
-	//  GL_TEXTURE_CUBE_MAP_POSITIVE_Y
+	result.push_back( { area, offset, false } );
+	// GL_TEXTURE_CUBE_MAP_POSITIVE_Y
 	area = faceArea + ivec2( faceSize.x * 1, faceSize.y * 0 );
 	offset = -ivec2( faceSize.x * 1, faceSize.y * 0 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_NEGATIVE_Y
 	area = faceArea + ivec2( faceSize.x * 1, faceSize.y * 2 );
 	offset = -ivec2( faceSize.x * 1, faceSize.y * 2 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_POSITIVE_Z
 	area = faceArea + ivec2( faceSize.x * 1, faceSize.y * 1 );
 	offset = -ivec2( faceSize.x * 1, faceSize.y * 1 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, false } );
 	// GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
 	area = faceArea + ivec2( faceSize.x * 1, faceSize.y * 3 );
 	offset = -ivec2( faceSize.x * 1, faceSize.y * 3 );
-	result.push_back( make_pair( area, offset ) );
+	result.push_back( { area, offset, true } );
 	
 	return result;
 };
 	
-std::vector<std::pair<ci::Area, ci::ivec2>> calcCubeMapHorizontalRegions( const ImageSourceRef &imageSource )
+std::vector<CubeMapFaceRegion> calcCubeMapHorizontalRegions( const ImageSourceRef &imageSource )
 {
-	std::vector<std::pair<ci::Area, ci::ivec2>> result;
+	std::vector<CubeMapFaceRegion> result;
 	ivec2 faceSize( imageSource->getHeight(), imageSource->getHeight() );
 
 	for( uint8_t index = 0; index < 6; ++index ) {
 		Area area( index * faceSize.x, 0.0f, (index + 1) * faceSize.x, faceSize.y );
 		ivec2 offset( -index * faceSize.x, 0.0f );
-		result.push_back( make_pair( area, offset ) );
+		result.push_back( { area, offset, false } );
 	}
 
 	return result;
 };
 	
-std::vector<std::pair<ci::Area, ci::ivec2>> calcCubeMapVerticalRegions( const ImageSourceRef &imageSource )
+std::vector<CubeMapFaceRegion> calcCubeMapVerticalRegions( const ImageSourceRef &imageSource )
 {
-	std::vector<std::pair<ci::Area, ci::ivec2>> result;
+	std::vector<CubeMapFaceRegion> result;
 	ivec2 faceSize( imageSource->getWidth(), imageSource->getWidth() );
 	
 	for( uint8_t index = 0; index < 6; ++index ) {
-		Area area( 0.0f, index * faceSize.x, faceSize.x, (index + 1) * faceSize.y );;
+		Area area( 0.0f, index * faceSize.x, faceSize.x, (index + 1) * faceSize.y );
 		ivec2 offset( 0.0f, -index * faceSize.y );
-		result.push_back( make_pair( area, offset ) );
+		result.push_back( { area, offset, false } );
 	}
 
 	return result;
@@ -1771,7 +1777,7 @@ TextureCubeMapRef TextureCubeMap::create( const TextureData &data, const Format 
 template<typename T>
 TextureCubeMapRef TextureCubeMap::createTextureCubeMapImpl( const ImageSourceRef &imageSource, const Format &format )
 {
-	std::vector<std::pair<ci::Area, ci::ivec2>> faceRegions;
+	std::vector<CubeMapFaceRegion> faceRegions;
 
 	// Infer the layout based on image aspect ratio
 	ivec2 imageSize( imageSource->getWidth(), imageSource->getHeight() );
@@ -1785,7 +1791,7 @@ TextureCubeMapRef TextureCubeMap::createTextureCubeMapImpl( const ImageSourceRef
 		faceRegions = ( imageSize.x > imageSize.y ) ? calcCubeMapHorizontalCrossRegions( imageSource ) : calcCubeMapVerticalCrossRegions( imageSource );
 	}
 
-	Area faceArea = faceRegions.front().first;
+	Area faceArea = faceRegions.front().mArea;
 	ivec2 faceSize = faceArea.getSize();
 	
 	SurfaceT<T> masterSurface( imageSource, SurfaceConstraintsDefault() );
@@ -1793,7 +1799,11 @@ TextureCubeMapRef TextureCubeMap::createTextureCubeMapImpl( const ImageSourceRef
 	
 	for( uint8_t f = 0; f < 6; ++f ) {
 		images[f] = SurfaceT<T>( faceSize.x, faceSize.y, masterSurface.hasAlpha(), SurfaceConstraints() );
-		images[f].copyFrom( masterSurface, faceRegions[f].first, faceRegions[f].second );
+		images[f].copyFrom( masterSurface, faceRegions[f].mArea, faceRegions[f].mOffset );
+		if( faceRegions[f].mFlip ) {
+			ip::flipVertical( &images[f] );
+			ip::flipHorizontal( &images[f] );
+		}
 	}
 	
 	if( format.mDeleter )

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -1949,7 +1949,7 @@ void TextureCubeMap::replace( const TextureData &textureData )
 		glPixelStorei( GL_UNPACK_ALIGNMENT, textureData.getUnpackAlignment() );
 
 #if ! defined( CINDER_GL_ES_2 )
-	mMaxMipmapLevel = 0;//(int32_t)textureData.getLevels().size();
+	mMaxMipmapLevel = (int32_t)textureData.getNumLevels() - 1;
 	glTexParameteri( mTarget, GL_TEXTURE_MAX_LEVEL, mMaxMipmapLevel );		
 #endif
 }

--- a/src/cinder/gl/draw.cpp
+++ b/src/cinder/gl/draw.cpp
@@ -693,6 +693,182 @@ void drawEquirectangular( const gl::TextureCubeMapRef &texture, const Rectf &rec
 	drawSolidRect( rect, vec2( 0, 1 ), vec2( 1, 0 ) );
 }
 
+namespace { // drawCross helpers
+string crossVertexShader()
+{
+	string s =
+		"	uniform mat4 ciModelViewProjection;\n"
+#if defined( CINDER_GL_ES_2 )
+		"	attribute vec4 ciPosition; attribute vec3 ciTexCoord0;\n"
+		"	varying highp vec3 TexCoord0;\n"
+#else
+		"	in vec4 ciPosition; in vec3 ciTexCoord0;\n"
+		"	out vec3 TexCoord0;\n"
+#endif
+		"	void main() {\n"
+		"		gl_Position = ciModelViewProjection * ciPosition;\n"
+		"		TexCoord0 = ciTexCoord0;\n"
+		"	}\n";
+	return s;
+}
+
+string crossFragmentShader( bool withLod )
+{
+	string s;
+#if defined( CINDER_GL_ES_2 )
+	if( withLod )
+		s+="#extension GL_EXT_shader_texture_lod : require\n";
+#endif
+	if( withLod )
+		s+="uniform highp float uLod;\n";
+	s +="	uniform samplerCube uCubeMapTex;\n"
+#if defined( CINDER_GL_ES_2 )
+		"	varying highp vec3 TexCoord0;\n"
+#else
+		"	in highp vec3 TexCoord0;\n"
+		"	out highp vec4 oColor;\n"
+#endif
+		"	void main() {\n";
+#if defined( CINDER_GL_ES_2 )
+		if( withLod )
+			s+="gl_FragColor = textureCubeLodEXT( uCubeMapTex, TexCoord0, uLod );\n";
+		else
+			s+="gl_FragColor = textureCube( uCubeMapTex, TexCoord0 );\n";
+#else
+		if( withLod )
+			s+="oColor = textureLod( uCubeMapTex, TexCoord0, uLod );\n";
+		else
+			s+="oColor = texture( uCubeMapTex, TexCoord0 );\n";
+#endif
+		s+="}\n";
+	return s;
+}
+
+
+// creates 6 vertices, representing a single face of the flattened cube
+void genCrossFace( vec2 ul, vec2 lr, vec3 u, vec3 v, vec3 w, vector<vec2> *pos, vector<vec3> *texCoords )
+{
+	pos->emplace_back( lr.x, ul.y ); // upper-right
+	texCoords->emplace_back( normalize( w + u + v ) );
+	pos->emplace_back( ul.x, ul.y ); // upper-left
+	texCoords->emplace_back( normalize( w + v ) );
+	pos->emplace_back( lr.x, lr.y ); // lower-right
+	texCoords->emplace_back( normalize( w + u ) );
+
+	pos->emplace_back( ul.x, lr.y ); // lower-left
+	texCoords->emplace_back( normalize(w) );
+	pos->emplace_back( lr.x, lr.y ); // lower-right
+	texCoords->emplace_back( normalize( w + u ) );
+	pos->emplace_back( ul.x, ul.y ); // upper-left
+	texCoords->emplace_back( normalize( w + v ) );
+}
+
+void drawCrossImpl( const gl::TextureCubeMapRef &texture, const vector<vec2> &positions, const vector<vec3> &texCoords, float lod )
+{
+	static GlslProgRef glslNoLod = gl::GlslProg::create(
+		GlslProg::Format().vertex( crossVertexShader() )
+			.fragment( crossFragmentShader( false ) )
+#if defined( CINDER_GL_ES_3 )
+			.version( 300 )
+#elif ! defined( CINDER_GL_ES )
+			.version( 150 )
+#endif
+	);
+	static GlslProgRef glslWithLod = env()->supportsTextureLod() ? gl::GlslProg::create(
+		GlslProg::Format().vertex( crossVertexShader() )
+			.fragment( crossFragmentShader( true ) )
+#if defined( CINDER_GL_ES_3 )
+			.version( 300 )
+#elif ! defined( CINDER_GL_ES )
+			.version( 150 )
+#endif
+	) : glslNoLod;
+
+	bool useLod = (lod >= 0) && env()->supportsTextureLod();
+
+	const auto& glsl = ( useLod ) ? glslWithLod : glslNoLod;
+	gl::ScopedGlslProg scGlsl( glsl );
+	glsl->uniform( "uCubeMapTex", 0 );
+	if( useLod )
+		glsl->uniform( "uLod", lod );
+	
+	auto ctx = gl::context();
+	ctx->pushVao();
+	ctx->getDefaultVao()->replacementBindBegin();
+	gl::VboRef defaultVbo = ctx->getDefaultArrayVbo( sizeof(float)*(positions.size()*2+texCoords.size()*3) );
+	gl::ScopedBuffer bufferBindScp( defaultVbo );
+	gl::ScopedTextureBind texScp( texture );
+	defaultVbo->bufferSubData( 0, sizeof(float)*positions.size()*2, positions.data() );
+	defaultVbo->bufferSubData( sizeof(float)*positions.size()*2, sizeof(float)*texCoords.size()*3, texCoords.data() );
+
+	int posLoc = glsl->getAttribSemanticLocation( geom::Attrib::POSITION );
+	if( posLoc >= 0 ) {
+		gl::enableVertexAttribArray( posLoc );
+		gl::vertexAttribPointer( posLoc, 2, GL_FLOAT, GL_FALSE, 0, (void*)0 );
+	}
+	int texLoc = glsl->getAttribSemanticLocation( geom::Attrib::TEX_COORD_0 );
+	if( texLoc >= 0 ) {
+		gl::enableVertexAttribArray( texLoc );
+		gl::vertexAttribPointer( texLoc, 3, GL_FLOAT, GL_FALSE, 0, (void*)(sizeof(float)*positions.size()*2) );
+	}
+	ctx->getDefaultVao()->replacementBindEnd();
+	ctx->setDefaultShaderVars();
+	ctx->drawArrays( GL_TRIANGLES, 0, (GLsizei)positions.size() );
+	ctx->popVao();
+}
+} // anonymous namespace
+
+void drawHorizontalCross( const gl::TextureCubeMapRef &texture, const Rectf &rect, float lod )
+{
+	Rectf fullRect( 0, 0, texture->getWidth() * 4, texture->getHeight() * 3 );
+	Rectf framedRect = fullRect.getCenteredFit( rect, true );
+	vec2 faceSize( framedRect.getWidth() / 4, framedRect.getHeight() / 3 );
+
+	vector<vec2> positions;
+	vector<vec3> texCoords;
+	const vec2 ul = rect.getUpperLeft();
+	// -X
+	genCrossFace( ul + vec2( 0, faceSize.y ), ul + vec2( faceSize.x, faceSize.y * 2 ), vec3( 0, 0, 2 ), vec3( 0, 2, 0 ), vec3( -1, -1, -1 ), &positions, &texCoords );
+	// +Z
+	genCrossFace( ul + faceSize, ul + faceSize * 2.0f, vec3( 2, 0, 0 ), vec3( 0, 2, 0 ), vec3( -1, -1, 1 ), &positions, &texCoords );
+	// +X
+	genCrossFace( ul + vec2( faceSize.x * 2, faceSize.y ), ul + vec2( faceSize.x * 3, faceSize.y * 2 ), vec3( 0, 0, -2 ), vec3( 0, 2, 0 ), vec3( 1, -1, 1 ), &positions, &texCoords );
+	// -Z
+	genCrossFace( ul + vec2( faceSize.x * 3, faceSize.y ), ul + vec2( faceSize.x * 4, faceSize.y * 2 ), vec3( -2, 0, 0 ), vec3( 0, 2, 0 ), vec3( 1, -1, -1 ), &positions, &texCoords );
+	// +Y
+	genCrossFace( ul + vec2( faceSize.x, 0 ), ul + vec2( faceSize.x * 2, faceSize.y ), vec3( 2, 0, 0 ), vec3( 0, 0, -2 ), vec3( -1, 1, 1 ), &positions, &texCoords );
+	// -Y
+	genCrossFace( ul + vec2( faceSize.x, faceSize.y * 2 ), ul + vec2( faceSize.x * 2, faceSize.y * 3 ), vec3( 2, 0, 0 ), vec3( 0, 0, 2 ), vec3( -1, -1, -1 ), &positions, &texCoords );
+
+	drawCrossImpl( texture, positions, texCoords, lod );
+}
+
+void drawVerticalCross( const gl::TextureCubeMapRef &texture, const Rectf &rect, float lod )
+{
+	Rectf fullRect( 0, 0, texture->getWidth() * 3, texture->getHeight() * 4 );
+	Rectf framedRect = fullRect.getCenteredFit( rect, true );
+	vec2 faceSize( framedRect.getWidth() / 3, framedRect.getHeight() / 4 );
+
+	vector<vec2> positions;
+	vector<vec3> texCoords;
+	const vec2 ul = rect.getUpperLeft();
+
+	// -X
+	genCrossFace( ul + vec2( 0, faceSize.y ), ul + vec2( faceSize.x, faceSize.y * 2 ), vec3( 0, 0, 2 ), vec3( 0, 2, 0 ), vec3( -1, -1, -1 ), &positions, &texCoords );
+	// +Z
+	genCrossFace( ul + faceSize, ul + faceSize * 2.0f, vec3( 2, 0, 0 ), vec3( 0, 2, 0 ), vec3( -1, -1, 1 ), &positions, &texCoords );
+	// +X
+	genCrossFace( ul + vec2( faceSize.x * 2, faceSize.y ), ul + vec2( faceSize.x * 3, faceSize.y * 2 ), vec3( 0, 0, -2 ), vec3( 0, 2, 0 ), vec3( 1, -1, 1 ), &positions, &texCoords );
+	// +Y
+	genCrossFace( ul + vec2( faceSize.x, 0 ), ul + vec2( faceSize.x * 2, faceSize.y ), vec3( 2, 0, 0 ), vec3( 0, 0, -2 ), vec3( -1, 1, 1 ), &positions, &texCoords );
+	// -Y
+	genCrossFace( ul + vec2( faceSize.x, faceSize.y * 2 ), ul + vec2( faceSize.x * 2, faceSize.y * 3 ), vec3( 2, 0, 0 ), vec3( 0, 0, 2 ), vec3( -1, -1, -1 ), &positions, &texCoords );
+	// -Z
+	genCrossFace( ul + vec2( faceSize.x * 1, faceSize.y * 3 ), ul + vec2( faceSize.x * 2, faceSize.y * 4 ), vec3( 2, 0, 0 ), vec3( 0, -2, 0 ), vec3( -1, 1, -1 ), &positions, &texCoords );
+
+	drawCrossImpl( texture, positions, texCoords, lod );
+}
+
 void drawSolid( const Path2d &path, float approximationScale )
 {
 	draw( Triangulator( path ).calcMesh() );

--- a/src/cinder/ip/Flip.cpp
+++ b/src/cinder/ip/Flip.cpp
@@ -183,10 +183,44 @@ void flipVertical( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel )
 	}
 }
 
+template<typename T>
+void flipHorizontal( SurfaceT<T> *surface )
+{
+	const int32_t height = surface->getHeight();
+	const int32_t width = surface->getWidth();
+	const int32_t halfWidth = width / 2;
+	
+	if( surface->hasAlpha() ) {
+		for( int32_t y = 0; y < height; ++y ) {
+			T *rowPtr = surface->getData( ivec2( 0, y ) );
+			for( int32_t x = 0; x < halfWidth; ++x ) {
+				for( int c = 0; c < 4; ++c ) {
+					T temp = rowPtr[x*4+c];
+					rowPtr[x*4+c] = rowPtr[(width-x-1)*4+c];
+					rowPtr[(width-x-1)*4+c] = temp;
+				}
+			}
+		}
+	}
+	else {
+		for( int32_t y = 0; y < height; ++y ) {
+			T *rowPtr = surface->getData( ivec2( 0, y ) );
+			for( int32_t x = 0; x < halfWidth; ++x ) {
+				for( int c = 0; c < 3; ++c ) {
+					T temp = rowPtr[x*3+c];
+					rowPtr[x*3+c] = rowPtr[(width-x-1)*3+c];
+					rowPtr[(width-x-1)*3+c] = temp;
+				}
+			}
+		}
+	}
+}
+
 #define flip_PROTOTYPES(r,data,T)\
 	template void flipVertical<T>( SurfaceT<T> *surface );\
 	template void flipVertical<T>( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface );\
-	template void flipVertical<T>( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel );
+	template void flipVertical<T>( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel );\
+	template void flipHorizontal<T>( SurfaceT<T> *surface );
 	
 BOOST_PP_SEQ_FOR_EACH( flip_PROTOTYPES, ~, (uint8_t)(uint16_t)(float) )
 


### PR DESCRIPTION
This PR adds a few routines useful for debugging CubeMaps:
```
void drawEquirectangular( const gl::TextureCubeMapRef &texture, const Rectf &r );
void drawHorizontalCross( const gl::TextureCubeMapRef &texture, const Rectf &r );
void drawVerticalCross( const gl::TextureCubeMapRef &texture, const Rectf &r );
```

The DynamicCubeMapping sample now exercises these:
![image](https://cloud.githubusercontent.com/assets/227107/8623166/d5487fc0-26fd-11e5-8a3c-e9bf030bb4cf.png)

These all also take optional parameter to specify a level-of-detail (mip-level) to draw. Additionally, this PR adds a ip::flipHorizontal() method, fixes our vertical cross cubeMap importing to match CMFT, and addresses an issue with cubeMaps parsed from DDS / KTX not enabling mipmapping correctly.