### PR TITLE
Enabling alpha blending by default

### DIFF
--- a/samples/EaseGallery/src/EaseGalleryApp.cpp
+++ b/samples/EaseGallery/src/EaseGalleryApp.cpp
@@ -156,7 +156,6 @@ void EaseGalleryApp::sizeRectangles()
 void EaseGalleryApp::draw()
 {
 	gl::clear( Color( 0.9f, 0.9f, 0.9f ) ); 
-	gl::enableAlphaBlending();
 	gl::lineWidth( 4.0f );
 
 	// time cycles every 1 / TWEEN_SPEED seconds, with a 50% pause at the end

--- a/samples/PolygonBoolean/src/PolygonBooleanApp.cpp
+++ b/samples/PolygonBoolean/src/PolygonBooleanApp.cpp
@@ -119,7 +119,6 @@ void PolygonBooleanApp::setup()
 
 void PolygonBooleanApp::draw()
 {
-	gl::enableAlphaBlending();
 	gl::clear( Color( 0.24f, 0.24f, 0.24f ) );
 	
 	gl::color( ColorA( 0.25f, 0.5f, 1.0f, 0.15f ) );

--- a/samples/bezierPath/src/bezierPathApp.cpp
+++ b/samples/bezierPath/src/bezierPathApp.cpp
@@ -95,7 +95,6 @@ void Path2dApp::keyDown( KeyEvent event )
 void Path2dApp::draw()
 {
 	gl::clear( Color( 0.0f, 0.1f, 0.2f ) );
-	gl::enableAlphaBlending();
 	
 	// draw the control points
 	gl::color( Color( 1, 1, 0 ) );

--- a/src/cinder/gl/Context.cpp
+++ b/src/cinder/gl/Context.cpp
@@ -102,7 +102,6 @@ Context::Context( const std::shared_ptr<PlatformData> &platformData )
 	mPolygonModeStack.push_back( GL_FILL );
 #endif
 	
-
 	mImmediateMode = gl::VertBatch::create();
 	
 	GLint params[4];
@@ -130,6 +129,10 @@ Context::Context( const std::shared_ptr<PlatformData> &platformData )
 	// set default shader
 	pushGlslProg( getStockShader( ShaderDef().color() ) );
 	
+	// enable unpremultiplied alpha blending by default
+	pushBoolState( GL_BLEND, GL_TRUE );
+	pushBlendFuncSeparate( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
+
 #if defined( CINDER_GL_HAS_DEBUG_OUTPUT )
 	if( mPlatformData->mDebug ) {
 		mDebugLogSeverity = mPlatformData->mDebugLogSeverity;


### PR DESCRIPTION
This PR enables unpremultiplied alpha blending as the default in GL. This seems to be the most convenient in general, and prevents some confusion common for beginners.