### PR TITLE
BufferObj::mapWriteOnly() changes

### DIFF
--- a/include/cinder/gl/BufferObj.h
+++ b/include/cinder/gl/BufferObj.h
@@ -59,8 +59,10 @@ class BufferObj {
 	void*				map( GLenum access ) const;
 #endif
 #if (! defined( CINDER_GL_ANGLE )) || defined( CINDER_GL_ES_3 )
-	//! Abstracts glMapBuffer() vs. glMapBufferRange() with appropriate write-only parameters for the platform. Passing \c true for \a invalidPrevious allows the GL to flush the contents of the buffer as an optimization.
-	void*				mapWriteOnly( bool invalidatePrevious );
+	//! Maps the Buffer for writing, but does not invalidate the Buffer's existing contents. Slower than mapReplace(). Abstracts glMapBuffer() vs. glMapBufferRange() with appropriate write-only parameters for the platform.
+	void*				mapWriteOnly();
+	//! Invalidates the Buffer's existing contents and maps it for writing. Preferable to mapWriteOnly() when invalidation is acceptable. Abstracts glMapBuffer() vs. glMapBufferRange() with appropriate write-only parameters for the platform.
+	void*				mapReplace();
 	//! Analogous to glMapBufferRange(). On iOS ES 2 only \c GL_WRITE_ONLY_OES is valid.
 	void*				mapBufferRange( GLintptr offset, GLsizeiptr length, GLbitfield access ) const;
 	void				unmap() const;

--- a/samples/Earthquake/src/Earth.cpp
+++ b/samples/Earthquake/src/Earth.cpp
@@ -67,7 +67,7 @@ void Earth::update()
 
 	// Update the instance data.
 	if( !mQuakes.empty() && mNumQuakes == 0 ) {
-		mat4 *data = (mat4*) mInstanceDataVbo->mapWriteOnly( true );
+		mat4 *data = (mat4*) mInstanceDataVbo->mapReplace();
 		{
 			mNumQuakes = 0;
 			for( auto &quake : mQuakes ) {

--- a/samples/_opengl/ClothSimulation/src/ClothSimulationApp.cpp
+++ b/samples/_opengl/ClothSimulation/src/ClothSimulationApp.cpp
@@ -147,7 +147,7 @@ void ClothSimulationApp::setupBuffers()
 	// create the indices to draw links between the cloth points
 	mLineIndices = gl::Vbo::create( GL_ELEMENT_ARRAY_BUFFER, lines * 2 * sizeof(int), nullptr, GL_STATIC_DRAW );
 	
-	auto e = (int *) mLineIndices->mapWriteOnly( true );
+	auto e = (int *) mLineIndices->mapReplace();
 	for (j = 0; j < POINTS_Y; j++) {
 		for (i = 0; i < POINTS_X - 1; i++) {
 			*e++ = i + j * POINTS_X;

--- a/samples/_opengl/DeferredShadingAdvanced/src/DeferredShadingAdvancedApp.cpp
+++ b/samples/_opengl/DeferredShadingAdvanced/src/DeferredShadingAdvancedApp.cpp
@@ -1559,7 +1559,7 @@ void DeferredShadingAdvancedApp::update()
 		mLights.back().setPosition( p );
 		
 		// Update light positions in UBO
-		Light* lights = (Light*)mUboLight->mapWriteOnly( false );
+		Light* lights = (Light*)mUboLight->mapWriteOnly();
 		for ( const Light& light : mLights ) {
 			lights->setPosition( light.getPosition() );
 			++lights;

--- a/samples/_opengl/InstancedTeapots/src/InstancedTeapotsApp.cpp
+++ b/samples/_opengl/InstancedTeapots/src/InstancedTeapotsApp.cpp
@@ -87,7 +87,7 @@ void InstancedTeapotsApp::update()
 	mCam.lookAt( vec3( 0, CAMERA_Y_RANGE.first + abs(sin( getElapsedSeconds() / 4)) * (CAMERA_Y_RANGE.second - CAMERA_Y_RANGE.first), 0 ), vec3( 0 ) );
 	
 	// update our instance positions; map our instance data VBO, write new positions, unmap
-	vec3 *positions = (vec3*)mInstanceDataVbo->mapWriteOnly( true );
+	vec3 *positions = (vec3*)mInstanceDataVbo->mapReplace();
 	for( size_t potX = 0; potX < NUM_INSTANCES_X; ++potX ) {
 		for( size_t potY = 0; potY < NUM_INSTANCES_Y; ++potY ) {
 			float instanceX = potX / (float)NUM_INSTANCES_X - 0.5f;

--- a/samples/_opengl/ParticleSphereCPU/src/ParticleSphereCPUApp.cpp
+++ b/samples/_opengl/ParticleSphereCPU/src/ParticleSphereCPUApp.cpp
@@ -133,11 +133,8 @@ void ParticleSphereCPUApp::update()
 
 	// Copy particle data onto the GPU.
 	// Map the GPU memory and write over it.
-	Particle *gpu = static_cast<Particle*>( mParticleVbo->mapWriteOnly( false ) );
-	for( const auto &cpu : mParticles ) {
-		*gpu = cpu;
-		++gpu;
-	}
+	void *gpuMem = mParticleVbo->mapReplace();
+	memcpy( gpuMem, mParticles.data(), mParticles.size() * sizeof(Particle) );
 	mParticleVbo->unmap();
 }
 

--- a/src/cinder/gl/BufferObj.cpp
+++ b/src/cinder/gl/BufferObj.cpp
@@ -125,19 +125,29 @@ void* BufferObj::map( GLenum access ) const
 #endif
 
 #if (! defined( CINDER_GL_ANGLE )) || defined( CINDER_GL_ES_3 )
-void* BufferObj::mapWriteOnly( bool invalidatePrevious )
+void* BufferObj::mapWriteOnly()
 {
 	ScopedBuffer bufferBind( mTarget, mId );
 	// iOS ES 2 only has glMapBufferOES()
 #if defined( CINDER_GL_ES_2 )
-	if( invalidatePrevious )
-		glBufferData( mTarget, mSize, nullptr, mUsage );
 	return reinterpret_cast<void*>( glMapBufferOES( mTarget, GL_WRITE_ONLY_OES ) );
 #else	
 	// ES 3 has only glMapBufferRange
 	GLbitfield access = GL_MAP_WRITE_BIT;
-	if( invalidatePrevious )
-		access |= GL_MAP_INVALIDATE_BUFFER_BIT;
+	return reinterpret_cast<void*>( glMapBufferRange( mTarget, 0, mSize, access ) );
+#endif
+}
+
+void* BufferObj::mapReplace()
+{
+	ScopedBuffer bufferBind( mTarget, mId );
+	// iOS ES 2 only has glMapBufferOES()
+#if defined( CINDER_GL_ES_2 )
+	glBufferData( mTarget, mSize, nullptr, mUsage );
+	return reinterpret_cast<void*>( glMapBufferOES( mTarget, GL_WRITE_ONLY_OES ) );
+#else	
+	// ES 3 has only glMapBufferRange
+	GLbitfield access = GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT;
 	return reinterpret_cast<void*>( glMapBufferRange( mTarget, 0, mSize, access ) );
 #endif
 }

--- a/src/cinder/gl/VboMesh.cpp
+++ b/src/cinder/gl/VboMesh.cpp
@@ -525,7 +525,7 @@ void VboMesh::bufferAttrib( geom::Attrib attrib, size_t dataSizeBytes, const voi
 	}
 	else { // interleaved data
 #if ! defined( CINDER_GL_ANGLE ) || defined( CINDER_GL_ES_3 )
-		uint8_t *ptr = reinterpret_cast<uint8_t*>( layoutVbo->second->mapWriteOnly( false ) );
+		uint8_t *ptr = reinterpret_cast<uint8_t*>( layoutVbo->second->mapWriteOnly() );
 		if( ! ptr ) {
 			CI_LOG_E( "Failed to map VBO" );
 			return;
@@ -557,7 +557,7 @@ void VboMesh::bufferIndices( size_t dataSizeBytes, const void *data )
 	mIndices->bufferSubData( 0, dataSizeBytes, data );
 }
 
-#if defined(CINDER_GL_ES_3) || (! defined( CINDER_GL_ANGLE ))
+#if defined( CINDER_GL_ES_3 ) || (! defined( CINDER_GL_ANGLE ))
 template<typename T>
 VboMesh::MappedAttrib<T> VboMesh::mapAttribImpl( geom::Attrib attr, int dims, bool orphanExisting )
 {
@@ -576,7 +576,10 @@ VboMesh::MappedAttrib<T> VboMesh::mapAttribImpl( geom::Attrib attr, int dims, bo
 	else {
 		MappedVboInfo mappedVboInfo;
 		mappedVboInfo.mRefCount = 1;
-		mappedVboInfo.mPtr = layoutVbo->second->mapWriteOnly( orphanExisting );
+		if( orphanExisting )
+			mappedVboInfo.mPtr = layoutVbo->second->mapReplace();
+		else
+			mappedVboInfo.mPtr = layoutVbo->second->mapWriteOnly();
 		mMappedVbos[layoutVbo->second] = mappedVboInfo;
 		dataPtr = mappedVboInfo.mPtr;
 	}


### PR DESCRIPTION
This modifies BufferObj::mapWriteOnly() to no longer take a boolean for 'invalidatePrevious'. Instead, an alternative method BufferObj::mapReplace() serves this role. This has been a common source of confusion even for experienced users.