### PR TITLE
Added a Frustum constructor and set() method that takes a matrix. 

### DIFF
--- a/include/cinder/Frustum.h
+++ b/include/cinder/Frustum.h
@@ -49,17 +49,20 @@ class Frustum {
 
   public:
 	Frustum() {}
+	//! Creates a world space frustum based on the camera's parameters.
 	Frustum( const Camera &cam );
+	//! Creates a frustum based on the corners of a near and far portal.
 	Frustum( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr, const Vec3T &ftl, const Vec3T &ftr, const Vec3T &fbl, const Vec3T &fbr );
+	//! Creates a frustum based on a (projection) matrix. The six planes of the frustum are derived from the matrix. To create a world space frustum, use a view-projection matrix.
 	Frustum( const Mat4T &mat );
 
-	//! Creates a frustum based on the camera's parameters.
+	//! Creates a world space frustum based on the camera's parameters.
 	void set( const Camera &cam );
-	//! Creates a frustum based on the camera's parameters and four corners of a portal.
+	//! Creates a world space frustum based on the camera's parameters and four corners of a portal.
 	void set( const Camera &cam, const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr );
 	//! Creates a frustum based on the corners of a near and far portal.
 	void set( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr, const Vec3T &ftl, const Vec3T &ftr, const Vec3T &fbl, const Vec3T &fbr );
-	//! Creates a frustum based on a matrix. To create a frustum that is compatible with the other constructors, use a view-projection matrix.
+	//! Creates a frustum based on a (projection) matrix. The six planes of the frustum are derived from the matrix. To create a world space frustum, use a view-projection matrix.
 	void set( const Mat4T &mat );
 
 	//! Returns true if point is within frustum.

--- a/include/cinder/Frustum.h
+++ b/include/cinder/Frustum.h
@@ -45,11 +45,13 @@ class Frustum {
 	enum FrustumSection { NEAR, FAR, LEFT, RIGHT, TOP, BOTTOM };
 
 	typedef glm::tvec3<T, glm::defaultp> Vec3T;
+	typedef glm::tmat4x4<T, glm::defaultp> Mat4T;
 
   public:
 	Frustum() {}
 	Frustum( const Camera &cam );
 	Frustum( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr, const Vec3T &ftl, const Vec3T &ftr, const Vec3T &fbl, const Vec3T &fbr );
+	Frustum( const Mat4T &mat );
 
 	//! Creates a frustum based on the camera's parameters.
 	void set( const Camera &cam );
@@ -57,6 +59,8 @@ class Frustum {
 	void set( const Camera &cam, const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr );
 	//! Creates a frustum based on the corners of a near and far portal.
 	void set( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const Vec3T &nbr, const Vec3T &ftl, const Vec3T &ftr, const Vec3T &fbl, const Vec3T &fbr );
+	//! Creates a frustum based on a matrix. To create a frustum that is compatible with the other constructors, use a view-projection matrix.
+	void set( const Mat4T &mat );
 
 	//! Returns true if point is within frustum.
 	bool contains( const Vec3T &loc ) const;

--- a/src/cinder/Frustum.cpp
+++ b/src/cinder/Frustum.cpp
@@ -91,13 +91,14 @@ void Frustum<T>::set( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, cons
 template<typename T>
 void Frustum<T>::set( const Mat4T &mat )
 {
-	// See: http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf
-	mFrustumPlanes[TOP].set( mat[0][3] - mat[0][1], mat[1][3] - mat[1][1], mat[2][3] - mat[2][1], -( mat[3][3] - mat[3][1] ) );
-	mFrustumPlanes[BOTTOM].set( mat[0][3] + mat[0][1], mat[1][3] + mat[1][1], mat[2][3] + mat[2][1], -( mat[3][3] + mat[3][1] ) );
-	mFrustumPlanes[LEFT].set( mat[0][3] + mat[0][0], mat[1][3] + mat[1][0], mat[2][3] + mat[2][0], -( mat[3][3] + mat[3][0] ) );
-	mFrustumPlanes[RIGHT].set( mat[0][3] - mat[0][0], mat[1][3] - mat[1][0], mat[2][3] - mat[2][0], -( mat[3][3] - mat[3][0] ) );
-	mFrustumPlanes[NEAR].set( mat[0][3] + mat[0][2], mat[1][3] + mat[1][2], mat[2][3] + mat[2][2], -( mat[3][3] + mat[3][2] ) );
-	mFrustumPlanes[FAR].set( mat[0][3] - mat[0][2], mat[1][3] - mat[1][2], mat[2][3] - mat[2][2], -( mat[3][3] - mat[3][2] ) );
+	// Based on: Fast Extraction of Viewing Frustum Planes from the WorldView-Projection Matrix
+	//       by: Gil Gribb and Klaus Hartmann
+	mFrustumPlanes[TOP].set( mat[0][3] - mat[0][1], mat[1][3] - mat[1][1], mat[2][3] - mat[2][1], -mat[3][3] + mat[3][1] );
+	mFrustumPlanes[BOTTOM].set( mat[0][3] + mat[0][1], mat[1][3] + mat[1][1], mat[2][3] + mat[2][1], -mat[3][3] - mat[3][1] );
+	mFrustumPlanes[LEFT].set( mat[0][3] + mat[0][0], mat[1][3] + mat[1][0], mat[2][3] + mat[2][0], -mat[3][3] - mat[3][0] );
+	mFrustumPlanes[RIGHT].set( mat[0][3] - mat[0][0], mat[1][3] - mat[1][0], mat[2][3] - mat[2][0], -mat[3][3] + mat[3][0] );
+	mFrustumPlanes[NEAR].set( mat[0][3] + mat[0][2], mat[1][3] + mat[1][2], mat[2][3] + mat[2][2], -mat[3][3] - mat[3][2] );
+	mFrustumPlanes[FAR].set( mat[0][3] - mat[0][2], mat[1][3] - mat[1][2], mat[2][3] - mat[2][2], -mat[3][3] + mat[3][2] );
 }
 
 template<typename T>

--- a/src/cinder/Frustum.cpp
+++ b/src/cinder/Frustum.cpp
@@ -46,6 +46,12 @@ Frustum<T>::Frustum( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, const
 }
 
 template<typename T>
+Frustum<T>::Frustum( const Mat4T &mat )
+{
+	set( mat );
+}
+
+template<typename T>
 void Frustum<T>::set( const Camera &cam )
 {
 	vec3 ntl, ntr, nbl, nbr;
@@ -80,6 +86,18 @@ void Frustum<T>::set( const Vec3T &ntl, const Vec3T &ntr, const Vec3T &nbl, cons
 	mFrustumPlanes[RIGHT].set( nbr, ntr, fbr );
 	mFrustumPlanes[NEAR].set( ntl, ntr, nbr );
 	mFrustumPlanes[FAR].set( ftr, ftl, fbl );
+}
+
+template<typename T>
+void Frustum<T>::set( const Mat4T &mat )
+{
+	// See: http://gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf
+	mFrustumPlanes[TOP].set( mat[0][3] - mat[0][1], mat[1][3] - mat[1][1], mat[2][3] - mat[2][1], -( mat[3][3] - mat[3][1] ) );
+	mFrustumPlanes[BOTTOM].set( mat[0][3] + mat[0][1], mat[1][3] + mat[1][1], mat[2][3] + mat[2][1], -( mat[3][3] + mat[3][1] ) );
+	mFrustumPlanes[LEFT].set( mat[0][3] + mat[0][0], mat[1][3] + mat[1][0], mat[2][3] + mat[2][0], -( mat[3][3] + mat[3][0] ) );
+	mFrustumPlanes[RIGHT].set( mat[0][3] - mat[0][0], mat[1][3] - mat[1][0], mat[2][3] - mat[2][0], -( mat[3][3] - mat[3][0] ) );
+	mFrustumPlanes[NEAR].set( mat[0][3] + mat[0][2], mat[1][3] + mat[1][2], mat[2][3] + mat[2][2], -( mat[3][3] + mat[3][2] ) );
+	mFrustumPlanes[FAR].set( mat[0][3] - mat[0][2], mat[1][3] - mat[1][2], mat[2][3] - mat[2][2], -( mat[3][3] - mat[3][2] ) );
 }
 
 template<typename T>


### PR DESCRIPTION
Any kind of matrix is supported, making it easier to construct a frustum in object or view space. The other constructors always create a world space frustum, so supply a view-projection matrix if you want to stay compatible.