### PR TITLE
Support for App Transport Security on OS X and iOS

### DIFF
--- a/samples/Earthquake/xcode/Info.plist
+++ b/samples/Earthquake/xcode/Info.plist
@@ -20,6 +20,17 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>earthquake.usgs.gov</key>
+			<dict>
+				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/samples/FlickrTestMultithreaded/src/FlickrTestMultithreadedApp.cpp
+++ b/samples/FlickrTestMultithreaded/src/FlickrTestMultithreadedApp.cpp
@@ -58,7 +58,7 @@ void FlickrTestMTApp::loadImagesThreadFn( gl::ContextRef context )
 	vector<Url>	urls;
 
 	// parse the image URLS from the XML feed and push them into 'urls'
-	const Url sunFlickrGroup = Url( "http://api.flickr.com/services/feeds/groups_pool.gne?id=52242317293@N01&format=rss_200" );
+	const Url sunFlickrGroup = Url( "https://api.flickr.com/services/feeds/groups_pool.gne?id=52242317293@N01&format=rss_200" );
 	const XmlTree xml( loadUrl( sunFlickrGroup ) );
 	for( auto item = xml.begin( "rss/channel/item" ); item != xml.end(); ++item ) {
 		const XmlTree &urlXml = ( ( *item / "media:content" ) );

--- a/samples/FlickrTestMultithreaded/xcode/Info.plist
+++ b/samples/FlickrTestMultithreaded/xcode/Info.plist
@@ -20,6 +20,17 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>api.flickr.com</key>
+			<dict>
+				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/samples/Kaleidoscope/xcode/Info.plist
+++ b/samples/Kaleidoscope/xcode/Info.plist
@@ -20,6 +20,17 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>api.instagram.com</key>
+			<dict>
+				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/samples/QuickTimeAdvanced/xcode/Info.plist
+++ b/samples/QuickTimeAdvanced/xcode/Info.plist
@@ -20,6 +20,22 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>movies.apple.com</key>
+			<dict>
+				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>pdl.warnerbros.com</key>
+			<dict>
+				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/samples/flickrTest/src/flickrTest.cpp
+++ b/samples/flickrTest/src/flickrTest.cpp
@@ -26,7 +26,7 @@ class FlickrTestApp : public App {
 
 void FlickrTestApp::setup()
 {
-	const Url flickrUrl( "http://api.flickr.com/services/feeds/groups_pool.gne?id=1423039@N24&lang=en-us&format=rss_200" );
+	const Url flickrUrl( "https://api.flickr.com/services/feeds/groups_pool.gne?id=1423039@N24&lang=en-us&format=rss_200" );
 	const XmlTree xml( loadUrl( flickrUrl ) );
 	for( auto item = xml.begin( "rss/channel/item" ); item != xml.end(); ++item )
 		mUrls.push_back( Url(((*item) / "media:content")["url"]) );

--- a/samples/flickrTest/xcode/Info.plist
+++ b/samples/flickrTest/xcode/Info.plist
@@ -20,6 +20,17 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>api.flickr.com</key>
+			<dict>
+				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Introduced in OS X 10.11 and iOS 9, [App Transport Security](https://developer.apple.com/library/prerelease/ios/technotes/App-Transport-Security-Technote/) requires a secure connection from app to a web service to prevent accidental disclosure and just generally be secure by default. A few samples load content via web service and exceptions are required in some cases to be runnable on 10.11+ / iOS 9+. In each case, the most narrow exception only to the immediate web service domain.

### Samples
Samples were found via:
```sh
$ grep -r -i --include \*.cpp '"http' samples | less
```

#### FlickrTestMultithreaded / flickrTest
The API request is (now) made over HTTPS, but unfortunately it doesn't support [forward secrecy](https://en.wikipedia.org/wiki/Forward_secrecy) so an exception is still required. Apparently all is well with the server configuration for the image loads on `https://farm*. staticflickr.com`.

#### Earthquake
The API request is made over HTTP.

#### QuickTimeAdvanced
The videos are loaded over HTTP.

### Later Pass
There are a couple samples that aren't working currently that will need similar treatment in a second pass:
* _svg/GoodNightMorning
* Kaleidoscope