### PR TITLE
Added missing algorithm include for std::max.

### DIFF
--- a/include/cinder/Timeline.h
+++ b/include/cinder/Timeline.h
@@ -32,6 +32,7 @@
 #include <vector>
 #include <list>
 #include <map>
+#include <algorithm>
 
 namespace cinder {
 


### PR DESCRIPTION
Because including `cinder/Timeline.h` in isolation causes a compile error on VS2013: 'max' : is not a member of 'std'.