### PR TITLE
Added ci::app::launch as a way to launch a Cinder app without macros

### DIFF
--- a/include/cinder/app/App.h
+++ b/include/cinder/app/App.h
@@ -25,6 +25,11 @@
 
 #include "cinder/Cinder.h"
 
+namespace cinder { namespace app {
+template< typename AppType, typename RendererType, typename ...Args >
+void launch( const char* title, Args... args );
+} } // namespace cinder::app
+
 #if defined( CINDER_MAC )
 	#include "cinder/app/cocoa/AppMac.h"
 	namespace cinder { namespace app {

--- a/include/cinder/app/cocoa/AppCocoaTouch.h
+++ b/include/cinder/app/cocoa/AppCocoaTouch.h
@@ -264,11 +264,16 @@ void AppCocoaTouch::main( const RendererRef &defaultRenderer, const char *title,
 	AppBase::cleanupLaunch();
 }
 
+template< typename AppType, typename RendererType, typename ...Args >
+void launch( const char* title, Args... args ) {
+	cinder::app::RendererRef renderer( new RendererType );
+	cinder::app::AppCocoaTouch::main<AppType>( renderer, title, args... );
+}
+
 #define CINDER_APP_COCOA_TOUCH( APP, RENDERER, ... )									\
 int main( int argc, char * const argv[] )												\
 {																						\
-	cinder::app::RendererRef renderer( new RENDERER );									\
-	cinder::app::AppCocoaTouch::main<APP>( renderer, #APP, argc, argv, ##__VA_ARGS__ );	\
+	cinder::app::launch< APP, RENDERER >( #APP, argc, argv, ##__VA_ARGS__ );			\
 	return 0;																			\
 }
 

--- a/include/cinder/app/cocoa/AppMac.h
+++ b/include/cinder/app/cocoa/AppMac.h
@@ -95,11 +95,16 @@ void AppMac::main( const RendererRef &defaultRenderer, const char *title, int ar
 	AppBase::cleanupLaunch();
 }
 
+template< typename AppType, typename RendererType, typename ...Args >
+void launch( const char* title, Args... args ) {
+	cinder::app::RendererRef renderer( new RendererType );
+	cinder::app::AppMac::main<AppType>( renderer, title, args... );
+}
+
 #define CINDER_APP_MAC( APP, RENDERER, ... )										\
-int main( int argc, char* argv[] )											\
+int main( int argc, char* argv[] )													\
 {																					\
-	cinder::app::RendererRef renderer( new RENDERER );								\
-	cinder::app::AppMac::main<APP>( renderer, #APP, argc, argv, ##__VA_ARGS__ );	\
+	cinder::app::launch< APP, RENDERER >( #APP, argc, argv, ##__VA_ARGS__ );		\
 	return 0;																		\
 }
 

--- a/include/cinder/app/msw/AppMsw.h
+++ b/include/cinder/app/msw/AppMsw.h
@@ -109,11 +109,16 @@ void AppMsw::main( const RendererRef &defaultRenderer, const char *title, const 
 	AppBase::cleanupLaunch();
 }
 
-#define CINDER_APP_MSW( APP, RENDERER, ... )													\
+template< typename AppType, typename RendererType, typename ...Args >
+void launch( const char* title, Args... args ) {
+	cinder::app::RendererRef renderer( new RendererType );
+	cinder::app::AppMsw::main<AppType>( renderer, title, args... );
+}
+
+#define CINDER_APP_MSW( APP, RENDERER, ... )														\
 int __stdcall WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow )\
 {																									\
-	cinder::app::RendererRef renderer( new RENDERER );												\
-	cinder::app::AppMsw::main<APP>( renderer, #APP, ##__VA_ARGS__ );							\
+	cinder::app::launch< APP, RENDERER >( #APP, ##__VA_ARGS__ );									\
 	return 0;																						\
 }
 

--- a/include/cinder/app/winrt/AppWinRt.h
+++ b/include/cinder/app/winrt/AppWinRt.h
@@ -72,7 +72,7 @@ class AppWinRt : public AppBase {
 	//! \cond
 	// Called from WinMain (in CINDER_APP_WINRT macro)
 	template<typename AppT>
-	static void main( ::Platform::Array<::Platform::String^>^ args, const RendererRef &defaultRenderer, const SettingsFn &settingsFn = SettingsFn() );
+	static void main(const RendererRef &defaultRenderer, ::Platform::Array<::Platform::String^>^ args, const SettingsFn &settingsFn = SettingsFn());
 
 	static void	executeLaunch( const std::function<AppWinRt*()> &appFactoryFn );
 	//! \endcond
@@ -112,7 +112,7 @@ class AppWinRt : public AppBase {
 };
 
 template<typename AppT>
-void AppWinRt::main( ::Platform::Array<::Platform::String^>^ args, const RendererRef &defaultRenderer, const SettingsFn &settingsFn )
+void AppWinRt::main( const RendererRef &defaultRenderer, ::Platform::Array<::Platform::String^>^ args, const SettingsFn &settingsFn )
 {
 	AppBase::prepareLaunch();
 
@@ -128,11 +128,15 @@ void AppWinRt::main( ::Platform::Array<::Platform::String^>^ args, const Rendere
 
 } } // namespace cinder::app
 
+template< typename AppType, typename RendererType, typename ...Args >
+void launch( const char*, Args... args ) {
+	cinder::app::RendererRef renderer( new RendererType );
+	cinder::app::AppWinRt::main<AppType>( renderer, args... );
+}
 
 #define CINDER_APP_WINRT( APP, RENDERER, ... )													\
 [::Platform::MTAThread]																			\
 int main( ::Platform::Array<::Platform::String^>^ args ) {										\
-	cinder::app::RendererRef renderer( new RENDERER );											\
-	cinder::app::AppWinRt::main<APP>( args, renderer, ##__VA_ARGS__ );							\
+	cinder::app::launch< APP, RENDERER >( "", args, ##__VA_ARGS__ );							\
 	return 0;																					\
 }


### PR DESCRIPTION
The standard way of running an app in Cinder has been traditionally calling a macro to define the entry point. I specifically want to delay the launch of the application in my `mian()`. With the existence of the `ci::app::launch()` A user will have the freedom to choose between calling a macro or launching manually and making sure that both calls will result in the same behavior.
