### PR TITLE
Avoid direct/uninitialized display access on OS X / iOS

### DIFF
--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -422,10 +422,10 @@ NSScreen* DisplayMac::getNsScreen() const
 
 DisplayRef app::PlatformCocoa::findFromCgDirectDisplayId( CGDirectDisplayID displayId )
 {
-	for( vector<DisplayRef>::iterator dispIt = mDisplays.begin(); dispIt != mDisplays.end(); ++dispIt ) {
-		const DisplayMac& macDisplay( dynamic_cast<const DisplayMac&>( **dispIt ) );
-		if( macDisplay.getCgDirectDisplayId() == displayId )
-			return *dispIt;
+	for( auto &display : getDisplays() ) {
+		const DisplayMac* macDisplay( dynamic_cast<const DisplayMac*>( display.get() ) );
+		if( macDisplay->getCgDirectDisplayId() == displayId )
+			return display;
 	}
 
 	// couldn't find it, so return nullptr
@@ -555,7 +555,7 @@ const std::vector<DisplayRef>& app::PlatformCocoa::getDisplays()
 
 DisplayRef app::PlatformCocoa::findDisplayFromUiScreen( UIScreen *uiScreen )
 {
-	for( auto &display : mDisplays ) {
+	for( auto &display : getDisplays() ) {
 		const DisplayCocoaTouch* cocoaTouchDisplay( dynamic_cast<const DisplayCocoaTouch*>( display.get() ) );
 		if( cocoaTouchDisplay->getUiScreen() == uiScreen )
 			return display;

--- a/test/AppCocoaViewTest/src/MyCinderApp.cpp
+++ b/test/AppCocoaViewTest/src/MyCinderApp.cpp
@@ -30,7 +30,7 @@ MyCinderApp::~MyCinderApp()
 void MyCinderApp::setup()
 {
 	testCbo.setState( TestCallbackOrder::SETUP );
-	getSignalCleanup().connect( [this] { testCbo.setState( TestCallbackOrder::SHUTDOWN ); } );
+	getSignalCleanup().connect( [this] { testCbo.setState( TestCallbackOrder::CLEANUP ); } );
 
 	mRadius = 50;
 	mAnimatedRadius = 0;
@@ -76,10 +76,10 @@ void MyCinderApp::draw()
 #endif
 }
 
-void MyCinderApp::shutdown()
+void MyCinderApp::cleanup()
 {
-	console() << "Shutdown" << std::endl;
-	testCbo.setState( TestCallbackOrder::SHUTDOWN );
+	console() << "Cleanup" << std::endl;
+	testCbo.setState( TestCallbackOrder::CLEANUP );
 }
 
 void MyCinderApp::mouseDown( MouseEvent event )

--- a/test/AppCocoaViewTest/src/MyCinderApp.h
+++ b/test/AppCocoaViewTest/src/MyCinderApp.h
@@ -8,8 +8,8 @@ struct TestCallbackOrder {
 	TestCallbackOrder() : mState( TestCallbackOrder::VIRGIN ), mDoneDraw( false ) {}
 	~TestCallbackOrder()
 	{
-		if( mState != SHUTDOWN )
-			cinder::app::console() << "Failed to call shutdown()" << std::endl;
+		if( mState != CLEANUP )
+			cinder::app::console() << "Failed to call cleanup()" << std::endl;
 	}
 	
 	void	setState( int state )
@@ -24,7 +24,7 @@ struct TestCallbackOrder {
 			mDoneDraw = true;
 	}
 	
-	enum { VIRGIN, SETUP, RESIZE, UPDATE, DRAW, SHUTDOWN };
+	enum { VIRGIN, SETUP, RESIZE, UPDATE, DRAW, CLEANUP };
 	
 	bool	mDoneDraw;
 	int		mState;
@@ -36,22 +36,22 @@ class MyCinderApp : public cinder::app::AppCocoaView {
 	MyCinderApp();
 	~MyCinderApp();
 
-	void				setup();
-	void				resize();
-	void				update();
-	void				draw();
-	void				shutdown();
+	void				setup() override;
+	void				resize() override;
+	void				update() override;
+	void				draw() override;
+	void				cleanup() override;
 	
-	void				mouseUp( ci::app::MouseEvent event );
-	void				mouseDown( ci::app::MouseEvent event );
-	void				mouseDrag( ci::app::MouseEvent event );
-	void				mouseMove( ci::app::MouseEvent event );
+	void				mouseUp( ci::app::MouseEvent event ) override;
+	void				mouseDown( ci::app::MouseEvent event ) override;
+	void				mouseDrag( ci::app::MouseEvent event ) override;
+	void				mouseMove( ci::app::MouseEvent event ) override;
 
-	void		touchesMoved( ci::app::TouchEvent event ) override;
+	void				touchesMoved( ci::app::TouchEvent event ) override;
 
-	void				keyDown( ci::app::KeyEvent event );
+	void				keyDown( ci::app::KeyEvent event ) override;
 	
-	void				fileDrop( ci::app::FileDropEvent event );
+	void				fileDrop( ci::app::FileDropEvent event ) override;
 	
 	float				mRadius, mAnimatedRadius;
 	cinder::Colorf		mColor;


### PR DESCRIPTION
Fixes #1074

It seemed as though the display finding functions directly accesses the `mDisplays` member variable which hasn't been lazy loaded when using `CinderViewMac`. Worth noting that the app runs into a context error (#1035) on OS X 10.11 unless the `#define USE_RENDERER2D` is removed from `MyCinderApp.h`