### PR TITLE
Fix for AppMac::setFrameRate() crash

### DIFF
--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -135,6 +135,7 @@ using namespace cinder::app;
 											  selector:@selector(timerFired:)
 											  userInfo:nil
 											   repeats:YES];
+	
 	[[NSRunLoop currentRunLoop] addTimer:mAnimationTimer forMode:NSDefaultRunLoopMode];
 	[[NSRunLoop currentRunLoop] addTimer:mAnimationTimer forMode:NSEventTrackingRunLoopMode];
 }
@@ -392,14 +393,12 @@ using namespace cinder::app;
 {
     mFrameRate = frameRate;
 	mFrameRateEnabled = YES;
-    [mAnimationTimer invalidate];
     [self startAnimationTimer];
 }
 
 - (void)disableFrameRate
 {
 	mFrameRateEnabled = NO;
-    [mAnimationTimer invalidate];
 	[self startAnimationTimer];
 }
 

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -103,7 +103,7 @@ using namespace cinder::app;
 	// lastly, ensure the first window is the currently active context
 	[((WindowImplBasicCocoa *)[mWindows firstObject])->mCinderView makeCurrentContext];
 
-    return self;
+	return self;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
@@ -391,9 +391,9 @@ using namespace cinder::app;
 
 - (void)setFrameRate:(float)frameRate
 {
-    mFrameRate = frameRate;
+	mFrameRate = frameRate;
 	mFrameRateEnabled = YES;
-    [self startAnimationTimer];
+	[self startAnimationTimer];
 }
 
 - (void)disableFrameRate

--- a/test/AppTest/src/AppTestApp.cpp
+++ b/test/AppTest/src/AppTestApp.cpp
@@ -158,6 +158,28 @@ void AppTestApp::keyDown( KeyEvent event )
 		auto filePath = getSaveFilePath();
 		CI_LOG_I( "result of getSaveFilePath(): " << filePath );
 	}
+	else if( event.getChar() == 'r' ) {
+		// iterate through some framerate settings
+		int targetFrameRate = (int)lround( getFrameRate() );
+		if( ! isFrameRateEnabled() ) {
+			CI_LOG_I( "setting framerate to 60" );
+			setFrameRate( 60 );
+		}
+		else if( targetFrameRate == 60 ) {
+			CI_LOG_I( "setting framerate to 30" );
+			setFrameRate( 30 );
+		}
+		else if( targetFrameRate == 30 ) {
+			CI_LOG_I( "disabling framerate" );
+			disableFrameRate();
+		}
+		else {
+			CI_ASSERT_NOT_REACHABLE();
+		}
+	}
+	else if( event.getChar() == 'v' ) {
+		gl::enableVerticalSync( ! gl::isVerticalSyncEnabled() );
+	}
 }
 
 void AppTestApp::mouseDown( MouseEvent event )


### PR DESCRIPTION
As it turns out, it was indeed repro'able from keyDown(). I've also added test code to AppTest to iterate through a few common framerate settings, and they are working as expected now on mac.

Fixes #1088.