### PR TITLE
Disable default alpha blending for smaa.

### DIFF
--- a/samples/_opengl/PostProcessingAA/src/PostProcessingAAApp.cpp
+++ b/samples/_opengl/PostProcessingAA/src/PostProcessingAAApp.cpp
@@ -119,6 +119,9 @@ void PostProcessingAAApp::setup()
 
 	mFrameTime = getElapsedSeconds();
 	mFrameRate = 0.0;
+
+	// Disable alpha blending (which is now enabled by default) for SMAA to work correctly.
+	gl::disableAlphaBlending();
 }
 
 void PostProcessingAAApp::update()


### PR DESCRIPTION
I had completely missed this: https://github.com/cinder/Cinder/pull/1030 and lost way to much time trying to use SMAA in my app.

In the sample, SMAA only worked correctly because disableAlphaBlending() was called at the end of draw(), after the text information is drawn.