### PR TITLE
Use 'test' terminology instead of 'read' for gl::enableDepthTest + Scoped (and enableStencilTest)

### DIFF
--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -238,20 +238,44 @@ private:
 
 #endif
 
-//! Scopes state of depth testing and writing
+//! Scopes state to control both depth testing and writing together. See information on `GL_DEPTH_TEST` and `glDepthMask()`.
 struct ScopedDepth : private Noncopyable {
-	//! Enables or disables both depth comparisons and writing to the depth buffer
-	ScopedDepth( bool enableReadAndWrite );
-	//! Enables or disables depth comparisons and/or writing to the depth buffer
-	ScopedDepth( bool enableRead, bool enableWrite );
-	//! Enables or disables depth comparisons, writing to the depth buffer and specifies a depth comparison function, either \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS.
-	ScopedDepth( bool enableRead, bool enableWrite, GLenum depthFunc );
+	//! Enables or disables both testing and writing to the depth buffer.
+	ScopedDepth( bool enableTestAndWrite );
+	//! Enables or disables both testing and writing to the depth buffer, and specifies a depth comparison function, either \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS.
+	ScopedDepth( bool enableTestAndWrite, GLenum depthFunc );
+	//! Destructor returns state to how it was before this object was constructed.
 	~ScopedDepth();
 	
   private:
 	Context		*mCtx;
 	bool		mSaveMask;
 	bool		mSaveFunc;
+};
+
+//! Scopes state to control the Depth Testing operation. See information on `GL_DEPTH_TEST`.
+struct ScopedDepthTest : private Noncopyable {
+	//! Enables or disables the Depth Test operation, which controls reading and writing to the depth buffer, for the scope of this object.
+	ScopedDepthTest( bool enableTest );
+	//! Enables or disables the DepthTest operation, which controls reading and writing to the depth buffer, for the scope of this object. Also specifies a depth comparison function, either \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS (see info on `glDepthFunc`).
+	ScopedDepthTest( bool enableTest, GLenum depthFunc );
+	//! Destructor returns state to how it was before this object was constructed.
+	~ScopedDepthTest();
+
+private:
+	Context		*mCtx;
+	bool		mSaveFunc;
+};
+
+//! Scopes state to control whether successful depth tests write to the depth buffer. See information on `glDepthMask()`. \note You must enable depth testing (`GL_DEPTH_TEST`) for this to take place.
+struct ScopedDepthWrite : private Noncopyable {
+	//! Enables or disables writing to the depth buffer for the scope of this object.
+	ScopedDepthWrite( bool enableWrite );
+	//! Destructor returns state to how it was before this object was constructed.
+	~ScopedDepthWrite();
+
+private:
+	Context		*mCtx;
 };
 
 //! Scopes state of Renderbuffer binding

--- a/include/cinder/gl/wrapper.h
+++ b/include/cinder/gl/wrapper.h
@@ -133,13 +133,13 @@ void enableLogicOp( bool enable = true );
 void logicOp( GLenum mode );
 #endif
 
-void disableDepthRead();
+void disableDepthTest();
 void disableDepthWrite();
-void enableDepthRead( bool enable = true );
+void enableDepthTest( bool enable = true );
 void enableDepthWrite( bool enable = true );
 
-void enableStencilRead( bool enable = true );
-void disableStencilRead();
+void enableStencilTest( bool enable = true );
+void disableStencilTest();
 void enableStencilWrite( bool enable = true );
 void disableStencilWrite();
 

--- a/include/cinder/gl/wrapper.h
+++ b/include/cinder/gl/wrapper.h
@@ -133,14 +133,22 @@ void enableLogicOp( bool enable = true );
 void logicOp( GLenum mode );
 #endif
 
-void disableDepthTest();
-void disableDepthWrite();
+//! Enables or disables the Depth Test operation, which controls reading and writing to the depth buffer. Analagous to `glEnable( GL_DEPTH_TEST, enable );`
 void enableDepthTest( bool enable = true );
+//! Disables the Depth Test operation. Analagous to `glEnable( GL_DEPTH_TEST, false );`
+void disableDepthTest();
+//! Enables or disables writing into the Depth Buffer. Analagous to `glDepthMask( enable );`. \note `GL_DEPTH_TEST` must be be enabled (with `gl::enableDepthTest()`) for writing to take place.
 void enableDepthWrite( bool enable = true );
+//! Disables writing into the Depth Buffer. Analagous to `glDepthMask( false );`.
+void disableDepthWrite();
 
+//! Enables or disables the Stencil Test operation, which controls reading and writing to the stencil buffer. Analagous to `glEnable( GL_STENCIL_TEST, enable );`
 void enableStencilTest( bool enable = true );
+//! Disables the Stencil Test operation. Analagous to `glEnable( GL_STENCIL_TEST, false );`
 void disableStencilTest();
+//! TODO: remove or implement (#792)
 void enableStencilWrite( bool enable = true );
+//! TODO: remove or implement (#792)
 void disableStencilWrite();
 
 //! Sets the View and Projection matrices based on a Camera

--- a/samples/ArcballDemo/src/ArcballDemoApp.cpp
+++ b/samples/ArcballDemo/src/ArcballDemoApp.cpp
@@ -27,7 +27,7 @@ class ArcballDemoApp : public App {
 
 void ArcballDemoApp::setup()
 {
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	mCamera.setPerspective( 45.0f, getWindowAspectRatio(), 0.1f, 1000.0f );

--- a/samples/CameraPersp/src/CameraPerspApp.cpp
+++ b/samples/CameraPersp/src/CameraPerspApp.cpp
@@ -64,7 +64,7 @@ void CameraPerspApp::setup()
 {
 	setWindowSize( 1280, 480 );
 	
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 	gl::enableAlphaBlending();
 	

--- a/samples/CaptureCube/src/CaptureCubeApp.cpp
+++ b/samples/CaptureCube/src/CaptureCubeApp.cpp
@@ -43,7 +43,7 @@ void CaptureCubeApp::setup()
 	}
 	
 	mCam.lookAt( vec3( 3, 2, -3 ), vec3( 0 ) );
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 }
 

--- a/samples/Earthquake/src/Earth.cpp
+++ b/samples/Earthquake/src/Earth.cpp
@@ -107,7 +107,8 @@ void Earth::drawQuakes()
 
 void Earth::drawQuakeLabelsOnSphere( const vec3 &eyeNormal, const float eyeDist )
 {
-	gl::ScopedDepth depth( true, false );
+	gl::ScopedDepthTest depthTest( true );
+	gl::ScopedDepthWrite depthWrite( false );
 	gl::ScopedGlslProg shader( gl::getStockShader( gl::ShaderDef().color().texture() ) );
 
 	gl::ScopedColor color( 1, 1, 1 );

--- a/samples/Earthquake/src/EarthquakeApp.cpp
+++ b/samples/Earthquake/src/EarthquakeApp.cpp
@@ -146,7 +146,7 @@ void EarthquakeApp::draw()
 {
 	gl::clear( Color( 1, 0, 0 ) );
 
-	gl::ScopedDepth       depth( true, true );
+	gl::ScopedDepth       depth( true );
 	gl::ScopedColor       color( 1, 1, 1 );
 
 	// Draw stars.

--- a/samples/Extrude/src/ExtrudeApp.cpp
+++ b/samples/Extrude/src/ExtrudeApp.cpp
@@ -40,7 +40,7 @@ class ExtrudeApp : public App {
 
 void ExtrudeApp::setup()
 {
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 	gl::enableFaceCulling();
 
@@ -148,9 +148,9 @@ void ExtrudeApp::draw()
 		if( mDrawNormals && mNormalsBatch )
 			mNormalsBatch->draw();
 		if( mUseSpline && mSplineBatch ) {
-			gl::disableDepthRead();
+			gl::disableDepthTest();
 			mSplineBatch->draw();
-			gl::enableDepthRead();
+			gl::enableDepthTest();
 		}
 	gl::popMatrices();
 	

--- a/samples/FrustumCulling/src/FrustumCullingApp.cpp
+++ b/samples/FrustumCulling/src/FrustumCullingApp.cpp
@@ -214,7 +214,7 @@ void FrustumCullingReduxApp::draw()
 		gl::setMatrices( mRenderCam );
 
 		gl::ScopedState scopeState( GL_CULL_FACE, true );
-		gl::enableDepthRead();
+		gl::enableDepthTest();
 		gl::enableDepthWrite();
 
 		// Draw all objects.
@@ -288,7 +288,7 @@ void FrustumCullingReduxApp::draw()
 		mGridBatch->draw();
 
 		// Disable depth testing.
-		gl::disableDepthRead();
+		gl::disableDepthTest();
 
 		drawCullableFov();
 	}

--- a/samples/Geometry/src/GeometryApp.cpp
+++ b/samples/Geometry/src/GeometryApp.cpp
@@ -165,7 +165,7 @@ void GeometryApp::draw()
 	gl::setMatrices( mCamera );
 
 	// Enable the depth buffer.
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	if( mPrimitive ) {
@@ -247,7 +247,7 @@ void GeometryApp::draw()
 	}
 
 	// Disable the depth buffer.
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 
 	// Render the parameter window.
 #if ! defined( CINDER_GL_ES )

--- a/samples/HodginParticlesRedux/src/HodginParticlesReduxApp.cpp
+++ b/samples/HodginParticlesRedux/src/HodginParticlesReduxApp.cpp
@@ -197,7 +197,7 @@ void HodginParticlesReduxApp::draw()
 {
 	glClearColor( 0.0025f, 0.0025f, 0.0025f, 1 );
 	gl::enableDepthWrite( true );
-	gl::enableDepthRead( true );
+	gl::enableDepthTest( true );
 	glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
 	gl::enableAlphaBlending();
 	

--- a/samples/ImageHeightField/src/ImageHeightFieldApp.cpp
+++ b/samples/ImageHeightField/src/ImageHeightFieldApp.cpp
@@ -38,7 +38,7 @@ class ImageHFApp : public App {
 void ImageHFApp::setup()
 {
 	gl::enableAlphaBlending();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();    
 
 	mCamUi = CameraUi( &mCam, getWindow() );

--- a/samples/LocationManager/src/LocationManagerApp.cpp
+++ b/samples/LocationManager/src/LocationManagerApp.cpp
@@ -77,7 +77,7 @@ void LocationApp::draw()
 {
 	// Clear the screen
 	gl::clear( Color::gray( 0.3f ) );
-	gl::enableDepthRead( true );
+	gl::enableDepthTest( true );
 	gl::enableDepthWrite( true );
 
 	gl::setMatrices( mCamera );
@@ -103,7 +103,7 @@ void LocationApp::draw()
 	////////////////////////////////////////////////////
 #if defined( CINDER_COCOA_TOUCH )
 	gl::setMatricesWindow( getWindowSize() );
-	gl::enableDepthRead( false );
+	gl::enableDepthTest( false );
 	gl::enableDepthWrite( false );
 	
 	// Plot arrow position

--- a/samples/MotionBasic/src/MotionBasicApp.cpp
+++ b/samples/MotionBasic/src/MotionBasicApp.cpp
@@ -46,7 +46,7 @@ void MotionBasicApp::update()
 void MotionBasicApp::draw()
 {
 	gl::clear( mBackgroundColor() );
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 
 	gl::setMatrices( mCam );
 	gl::multModelMatrix( mModelMatrix );

--- a/samples/ParamsBasic/src/ParamsBasicApp.cpp
+++ b/samples/ParamsBasic/src/ParamsBasicApp.cpp
@@ -112,7 +112,7 @@ void TweakBarApp::update()
 void TweakBarApp::draw()
 {
 	// this pair of lines is the standard way to clear the screen in OpenGL
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 	gl::clear( Color::gray( 0.1f ) );
 

--- a/samples/Picking3D/src/Picking3DApp.cpp
+++ b/samples/Picking3D/src/Picking3DApp.cpp
@@ -91,8 +91,8 @@ void Picking3DApp::draw()
 	gl::ScopedMatrices push;
 	gl::setMatrices( mCamera );
 
-	// Enable depth buffer.
-	gl::ScopedDepth depth( true, true );
+	// Enable depth testing and write.
+	gl::ScopedDepth depth( true );
 
 	// Draw the grid on the floor.
 	{

--- a/samples/QuaternionAccum/src/QuaternionAccumApp.cpp
+++ b/samples/QuaternionAccum/src/QuaternionAccumApp.cpp
@@ -159,8 +159,8 @@ void QuaternionAccumApp::draw()
 	gl::clear();
 	gl::setMatrices( mCam );
 
-	// Enable depth buffer reading and writing.
-	gl::ScopedDepth depth( true, true );
+	// Enable depth buffer testing and writing.
+	gl::ScopedDepth depth( true );
 
 	// Draw our scene.
 	drawPlane();

--- a/samples/QuickTimeAvfWriter/src/MovieWriterApp.cpp
+++ b/samples/QuickTimeAvfWriter/src/MovieWriterApp.cpp
@@ -56,7 +56,7 @@ void MovieWriterApp::update()
 void MovieWriterApp::draw()
 {
 	gl::clear();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::color( Color( CM_HSV, fmod( getElapsedFrames() / 30.0f, 1.0f ), 1, 1 ) );
 	gl::draw( geom::Circle().center( getWindowCenter() ).radius( getElapsedFrames() ).subdivisions( 100 ) );
 }

--- a/samples/StereoscopicRendering/src/StereoscopicRenderingApp.cpp
+++ b/samples/StereoscopicRendering/src/StereoscopicRenderingApp.cpp
@@ -519,7 +519,7 @@ void StereoscopicRenderingApp::render()
 	float seconds = (float) getElapsedSeconds();
 
 	// enable 3D rendering
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	// set 3D camera matrices
@@ -565,7 +565,7 @@ void StereoscopicRenderingApp::render()
 	// restore 2D rendering
 	gl::popMatrices();
 	gl::disableDepthWrite();
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 
 	// render UI
 	if( mDrawUI ) renderUI();

--- a/samples/_opengl/Cube/src/CubeApp.cpp
+++ b/samples/_opengl/Cube/src/CubeApp.cpp
@@ -35,7 +35,7 @@ void RotatingCubeApp::setup()
 	mBatch = gl::Batch::create( geom::Cube(), mGlsl );
 
 	gl::enableDepthWrite();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 }
 
 void RotatingCubeApp::resize()

--- a/samples/_opengl/CubeMapping/src/CubeMappingApp.cpp
+++ b/samples/_opengl/CubeMapping/src/CubeMappingApp.cpp
@@ -40,7 +40,7 @@ void CubeMappingApp::setup()
 	mSkyBoxBatch = gl::Batch::create( geom::Cube(), skyBoxGlsl );
 	mSkyBoxBatch->getGlslProg()->uniform( "uCubeMapTex", 0 );
 	
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();	
 }
 

--- a/samples/_opengl/DeferredShading/src/DeferredShadingApp.cpp
+++ b/samples/_opengl/DeferredShading/src/DeferredShadingApp.cpp
@@ -194,7 +194,7 @@ void DeferredShadingApp::draw()
 		}
 		const gl::ScopedViewport scopedViewport( ivec2( 0 ), mFboGBuffer->getSize() );
 		const gl::ScopedMatrices scopedMatrices;
-		gl::enableDepthRead();
+		gl::enableDepthTest();
 		gl::enableDepthWrite();
 		gl::clear();
 		gl::setMatrices( mCamera );
@@ -231,7 +231,7 @@ void DeferredShadingApp::draw()
 		const gl::ScopedFramebuffer scopedFrameBuffer( mFboShadowMap );
 		const gl::ScopedViewport scopedViewport( ivec2( 0 ), mFboShadowMap->getSize() );
 		const gl::ScopedMatrices scopedMatrices;
-		gl::enableDepthRead( true );
+		gl::enableDepthTest( true );
 		gl::enableDepthWrite( true );
 		gl::clear();
 		gl::setMatrices( mShadowCamera );
@@ -253,7 +253,7 @@ void DeferredShadingApp::draw()
 		const gl::ScopedBlendAdditive scopedAdditiveBlend;
 		const gl::ScopedFaceCulling scopedFaceCulling( true, GL_FRONT );
 		gl::setMatrices( mCamera );
-		gl::enableDepthRead();
+		gl::enableDepthTest();
 		gl::disableDepthWrite();
 		
 		// Bind G-buffer textures and shadow map
@@ -291,7 +291,7 @@ void DeferredShadingApp::draw()
 	// Set up window for screen render
 	const gl::ScopedViewport scopedViewport( ivec2( 0 ), toPixels( getWindowSize() ) );
 	const gl::ScopedMatrices scopedMatrices;
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 	gl::disableDepthWrite();
 	gl::clear();
 	

--- a/samples/_opengl/DeferredShadingAdvanced/src/DeferredShadingAdvancedApp.cpp
+++ b/samples/_opengl/DeferredShadingAdvanced/src/DeferredShadingAdvancedApp.cpp
@@ -535,7 +535,7 @@ void DeferredShadingAdvancedApp::draw()
 		gl::clear();
 		const gl::ScopedMatrices scopedMatrices;
 		gl::setMatrices( mCamera );
-		gl::enableDepthRead();
+		gl::enableDepthTest();
 		gl::enableDepthWrite();
 		
 		////// BEGIN DRAW STUFF ////////////////////////////////////////////////
@@ -577,7 +577,7 @@ void DeferredShadingAdvancedApp::draw()
 		const gl::ScopedFramebuffer scopedFrameBuffer( mFboShadowMap );
 		const gl::ScopedViewport scopedViewport( ivec2( 0 ), mFboShadowMap->getSize() );
 		const gl::ScopedMatrices scopedMatrices;
-		gl::enableDepthRead();
+		gl::enableDepthTest();
 		gl::enableDepthWrite();
 		gl::clear();
 		gl::setMatrices( mShadowCamera );
@@ -615,7 +615,7 @@ void DeferredShadingAdvancedApp::draw()
 		}
 		
 		gl::drawBuffer( GL_COLOR_ATTACHMENT0 + (GLenum)ping );
-		gl::enableDepthRead();
+		gl::enableDepthTest();
 		
 		// Draw light volumes into L-buffer, reading G-buffer to perform shading
 		{
@@ -684,7 +684,7 @@ void DeferredShadingAdvancedApp::draw()
 		const gl::ScopedViewport scopedViewport( ivec2( 0 ), mFboAccum->getSize() );
 		const gl::ScopedMatrices scopedMatrices;
 		gl::setMatricesWindow( mFboAccum->getSize() );
-		gl::disableDepthRead();
+		gl::disableDepthTest();
 		gl::disableDepthWrite();
 		gl::translate( mFboAccum->getSize() / 2 );
 		gl::scale( mFboAccum->getSize() );
@@ -766,7 +766,7 @@ void DeferredShadingAdvancedApp::draw()
 			const gl::ScopedFramebuffer scopedFrameBuffer( mFboRayDepth );
 			const gl::ScopedViewport scopedViewport( ivec2( 0 ), mFboRayDepth->getSize() );
 			gl::clear();
-			gl::enableDepthRead();
+			gl::enableDepthTest();
 			gl::enableDepthWrite();
 			const gl::ScopedMatrices scopedMatrices;
 			gl::setMatrices( mCamera );
@@ -779,7 +779,7 @@ void DeferredShadingAdvancedApp::draw()
 			const gl::ScopedFramebuffer scopedFrameBuffer( mFboRayColor );
 			const gl::ScopedViewport scopedViewport( ivec2( 0 ), mFboRayColor->getSize() );
 			gl::clear();
-			gl::enableDepthRead();
+			gl::enableDepthTest();
 			gl::disableDepthWrite();
 
 			// Draw light source into color buffer
@@ -847,13 +847,13 @@ void DeferredShadingAdvancedApp::draw()
 		gl::setMatricesWindow( mFboCsz->getSize() );
 		gl::translate( mFboCsz->getSize() / 2 );
 		gl::scale( mFboCsz->getSize() );
-		gl::enableDepthRead();
+		gl::enableDepthTest();
 		
 		const gl::ScopedTextureBind scopedTextureBind( mFboGBuffer->getDepthTexture(), 0 );
 		mBatchSaoCszRect->getGlslProg()->uniform( "uNear", n );
 		mBatchSaoCszRect->draw();
 		
-		gl::disableDepthRead();
+		gl::disableDepthTest();
 	}
 	
 	{
@@ -867,7 +867,7 @@ void DeferredShadingAdvancedApp::draw()
 			// Draw next pass into AO buffer's first attachment
 			const gl::ScopedMatrices scopedMatrices;
 			gl::setMatricesWindow( mFboAo->getSize() );
-			gl::enableDepthRead();
+			gl::enableDepthTest();
 			gl::disableDepthWrite();
 			gl::translate( mFboAo->getSize() / 2 );
 			gl::scale( mFboAo->getSize() );
@@ -952,7 +952,7 @@ void DeferredShadingAdvancedApp::draw()
 		const gl::ScopedViewport scopedViewport( ivec2( 0 ), mFboPingPong->getSize() );
 		const gl::ScopedMatrices scopedMatrices;
 		gl::setMatricesWindow( mFboPingPong->getSize() );
-		gl::disableDepthRead();
+		gl::disableDepthTest();
 		gl::disableDepthWrite();
 		
 		const size_t columns = 4;
@@ -1003,7 +1003,7 @@ void DeferredShadingAdvancedApp::draw()
 			gl::setMatricesWindow( mFboPingPong->getSize() );
 			gl::translate( mFboPingPong->getSize() / 2 );
 			gl::scale( mFboPingPong->getSize() );
-			gl::disableDepthRead();
+			gl::disableDepthTest();
 			gl::disableDepthWrite();
 			
 			{
@@ -1097,7 +1097,7 @@ void DeferredShadingAdvancedApp::draw()
 		gl::setMatricesWindow( mFboPingPong->getSize() );
 		gl::translate( mFboPingPong->getSize() / 2 );
 		gl::scale( mFboPingPong->getSize() );
-		gl::disableDepthRead();
+		gl::disableDepthTest();
 		gl::disableDepthWrite();
 		
 		// Fill screen with AO in AO view mode
@@ -1155,7 +1155,7 @@ void DeferredShadingAdvancedApp::draw()
 	gl::setMatricesWindow( toPixels( getWindowSize() ) );
 	gl::translate( toPixels( getWindowSize() / 2 )  );
 	gl::scale( toPixels( getWindowSize() ) );
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 	gl::disableDepthWrite();
 	const gl::ScopedTextureBind scopedTextureBind( mTextureFboPingPong[ pong ], 0 );
 	if ( mEnabledFxaa ) {

--- a/samples/_opengl/DynamicCubeMapping/src/DynamicCubeMappingApp.cpp
+++ b/samples/_opengl/DynamicCubeMapping/src/DynamicCubeMappingApp.cpp
@@ -69,7 +69,7 @@ void DynamicCubeMappingApp::setup()
 
 	mDrawCubeMap = true;
 
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();	
 }
 

--- a/samples/_opengl/FboBasic/src/FboBasicApp.cpp
+++ b/samples/_opengl/FboBasic/src/FboBasicApp.cpp
@@ -30,7 +30,7 @@ void FboBasicApp::setup()
 	//format.setSamples( 4 ); // uncomment this to enable 4x antialiasing
 	mFbo = gl::Fbo::create( FBO_WIDTH, FBO_HEIGHT, format.depthTexture() );
 
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 }
 

--- a/samples/_opengl/FboMultipleRenderTargets/src/FboMultipleRenderTargetsApp.cpp
+++ b/samples/_opengl/FboMultipleRenderTargets/src/FboMultipleRenderTargetsApp.cpp
@@ -40,7 +40,7 @@ void FboMultipleRenderTargetsApp::setup()
 	mGlslMultipleOuts = gl::GlslProg::create( loadAsset( "multipleOut.vert" ), loadAsset( "multipleOut.frag" ) );
 #endif
 
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();	
 
 	mRotation = mat4( 1 );

--- a/samples/_opengl/InstancedTeapots/src/InstancedTeapotsApp.cpp
+++ b/samples/_opengl/InstancedTeapots/src/InstancedTeapotsApp.cpp
@@ -67,7 +67,7 @@ void InstancedTeapotsApp::setup()
 	mBatch = gl::Batch::create( mesh, mGlsl, { { geom::Attrib::CUSTOM_0, "vInstancePosition" } } );
 
 	gl::enableDepthWrite();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	
 	mTexture->bind();	
 }

--- a/samples/_opengl/MotionBlurFbo/src/MotionBlurFboApp.cpp
+++ b/samples/_opengl/MotionBlurFbo/src/MotionBlurFboApp.cpp
@@ -77,7 +77,7 @@ void MotionBlurFboApp::draw()
 		double startTime = getElapsedSeconds();
 		for( int i = 0; i < SUBFRAMES; ++i ) {
 			// draw the Cube's sub-frame into mFbo
-			gl::enableDepthRead();
+			gl::enableDepthTest();
 			gl::enableDepthWrite();
 			gl::enableAlphaBlending();
 			mFbo->bindFramebuffer();
@@ -92,12 +92,12 @@ void MotionBlurFboApp::draw()
 			gl::setMatricesWindow( mAccumFbo->getSize() );
 			gl::enableAdditiveBlending();
 			gl::disableDepthWrite();
-			gl::disableDepthRead();		
+			gl::disableDepthTest();		
 			gl::draw( mFbo->getColorTexture() );
 		}
 	}
 	
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 	gl::enableAlphaBlending();
 	// set the color to be 1/SUBFRAMES, which divides the HDR image by the number of sub-frames we rendered
 	gl::color( 1.0f / SUBFRAMES, 1.0f / SUBFRAMES, 1.0f / SUBFRAMES, 1 );

--- a/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
+++ b/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
@@ -211,7 +211,7 @@ void MotionBlurVelocityBufferApp::update()
 
 void MotionBlurVelocityBufferApp::fillGBuffer()
 {
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	gl::ScopedFramebuffer fbo( mGBuffer );
@@ -229,7 +229,7 @@ void MotionBlurVelocityBufferApp::fillGBuffer()
 		gl::draw( mesh->getMesh() );
 	}
 
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 	gl::disableDepthWrite();
 }
 

--- a/samples/_opengl/NormalMapping/src/NormalMappingApp.cpp
+++ b/samples/_opengl/NormalMapping/src/NormalMappingApp.cpp
@@ -287,7 +287,7 @@ void NormalMappingApp::draw()
 		gl::pushMatrices();
 		gl::setMatrices( mCamera );
 
-		gl::enableDepthRead();
+		gl::enableDepthTest();
 		gl::enableDepthWrite();
 
 		// bind textures
@@ -332,7 +332,7 @@ void NormalMappingApp::draw()
 
 		// get ready to render in 2D again
 		gl::disableDepthWrite();
-		gl::disableDepthRead();
+		gl::disableDepthTest();
 
 		gl::popMatrices();
 

--- a/samples/_opengl/NormalMappingBasic/src/NormalMappingBasicApp.cpp
+++ b/samples/_opengl/NormalMappingBasic/src/NormalMappingBasicApp.cpp
@@ -43,7 +43,7 @@ void NormalMappingBasicApp::setup()
 	mGlsl->uniform( "uLightLocViewSpace", vec3( 0, 0, 1 ) );
 
 	gl::enableDepthWrite();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 }
 
 void NormalMappingBasicApp::resize()

--- a/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
+++ b/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
@@ -121,7 +121,7 @@ void ObjLoaderApp::keyDown( KeyEvent event )
 void ObjLoaderApp::draw()
 {
 	gl::enableDepthWrite();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	
 	gl::clear( Color( 0.0f, 0.1f, 0.2f ) );
 

--- a/samples/_opengl/PBOReadBack/src/PBOReadBackApp.cpp
+++ b/samples/_opengl/PBOReadBack/src/PBOReadBackApp.cpp
@@ -126,7 +126,7 @@ void PBOReadBackApp::draw()
 	mTimer.stop();
 	
 	// Render to new Fbo
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 	
 	{
@@ -143,7 +143,7 @@ void PBOReadBackApp::draw()
 	}
 	
 	// Render to screen
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 	gl::disableDepthWrite();
 	
 	gl::setMatricesWindow( getWindowSize() );

--- a/samples/_opengl/ParticleSphereCPU/src/ParticleSphereCPUApp.cpp
+++ b/samples/_opengl/ParticleSphereCPU/src/ParticleSphereCPUApp.cpp
@@ -142,7 +142,7 @@ void ParticleSphereCPUApp::draw()
 {
 	gl::clear( Color( 0, 0, 0 ) );
 	gl::setMatricesWindowPersp( getWindowSize() );
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	mParticleBatch->draw();

--- a/samples/_opengl/ParticleSphereCS/src/ParticleSphereCSApp.cpp
+++ b/samples/_opengl/ParticleSphereCS/src/ParticleSphereCSApp.cpp
@@ -170,7 +170,7 @@ void ParticleSphereCSApp::draw()
 {
 	gl::clear( Color( 0, 0, 0 ) );
 	gl::setMatricesWindowPersp( getWindowSize() );
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	gl::ScopedGlslProg render( mRenderProg );

--- a/samples/_opengl/ParticleSphereGPU/src/ParticleSphereGPUApp.cpp
+++ b/samples/_opengl/ParticleSphereGPU/src/ParticleSphereGPUApp.cpp
@@ -187,7 +187,7 @@ void ParticleSphereGPUApp::draw()
 {
 	gl::clear( Color( 0, 0, 0 ) );
 	gl::setMatricesWindowPersp( getWindowSize() );
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	gl::ScopedGlslProg render( mRenderProg );

--- a/samples/_opengl/PickingFBO/src/PickingFBOApp.cpp
+++ b/samples/_opengl/PickingFBO/src/PickingFBOApp.cpp
@@ -94,7 +94,7 @@ void PickingFBOApp::setup()
 	mDebugDisplaySize = 20.0f;
 
 	gl::enableDepthWrite();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 }
 
 void PickingFBOApp::resize()
@@ -112,7 +112,7 @@ void PickingFBOApp::draw()
 		renderScene();
 
 	gl::clear();
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 	gl::setMatricesWindow( toPixels( getWindowSize() ) );
 	gl::draw( mFbo->getColorTexture(), toPixels( getWindowBounds() ) );
 	if( mDebugTexture ) {
@@ -122,7 +122,7 @@ void PickingFBOApp::draw()
 #if ! defined( CINDER_GL_ES )
 	mParams->draw();
 #endif
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 }
 
 void PickingFBOApp::renderScene()

--- a/samples/_opengl/PostProcessingAA/src/Pistons.cpp
+++ b/samples/_opengl/PostProcessingAA/src/Pistons.cpp
@@ -147,7 +147,7 @@ void Pistons::update( const ci::Camera& camera )
 
 void Pistons::draw( const ci::Camera& camera, float time )
 {
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	gl::pushMatrices();
@@ -161,5 +161,5 @@ void Pistons::draw( const ci::Camera& camera, float time )
 	gl::popMatrices();
 
 	gl::disableDepthWrite();
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 }

--- a/samples/_opengl/ShadowMapping/src/ShadowMappingApp.cpp
+++ b/samples/_opengl/ShadowMapping/src/ShadowMappingApp.cpp
@@ -217,7 +217,7 @@ void ShadowMappingApp::setup()
 		mTransforms.emplace_back( m, randVec3() );
 	}
 	
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	mCamera.setFov( 30.0f );

--- a/samples/_opengl/ShadowMappingBasic/src/ShadowMappingBasicApp.cpp
+++ b/samples/_opengl/ShadowMappingBasic/src/ShadowMappingBasicApp.cpp
@@ -104,7 +104,7 @@ void ShadowMappingBasic::setup()
 	mFloorBatch				= gl::Batch::create( floor, gl::getStockShader( gl::ShaderDef() ) );
 	mFloorShadowedBatch		= gl::Batch::create( floor, mGlsl );
 	
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 }
 

--- a/samples/_opengl/StencilReflection/src/StencilReflectionApp.cpp
+++ b/samples/_opengl/StencilReflection/src/StencilReflectionApp.cpp
@@ -44,7 +44,7 @@ void StencilReflectionApp::setup()
 								  vec2( toPixels( getWindowWidth() ) / 2, toPixels( getWindowHeight() ) ) );
 	
 	gl::enableDepthWrite();
-    gl::enableDepthRead();
+    gl::enableDepthTest();
 	gl::clearColor( Color( 1, 1, 1 ) );
 }
 

--- a/samples/_opengl/SuperformulaGPU/src/SuperformulaGPUApp.cpp
+++ b/samples/_opengl/SuperformulaGPU/src/SuperformulaGPUApp.cpp
@@ -114,7 +114,7 @@ void SuperformulaGpuApp::setup()
 	setupGeometry();
 
 	gl::enableDepthWrite();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 }
 
 void SuperformulaGpuApp::resize()

--- a/samples/iosNativeControls/src/NativeControlsApp.mm
+++ b/samples/iosNativeControls/src/NativeControlsApp.mm
@@ -81,7 +81,7 @@ void NativeControlsApp::setupVisuals()
 	}
 
 	mTex = gl::Texture::create( surface );
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 }
 

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -333,25 +333,18 @@ ScopedLogicOp::~ScopedLogicOp()
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // ScopedDepth
-ScopedDepth::ScopedDepth( bool enableReadAndWrite )
+ScopedDepth::ScopedDepth( bool enableTestAndWrite )
 	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( false )
 {
-	mCtx->pushBoolState( GL_DEPTH_TEST, enableReadAndWrite );
-	mCtx->pushDepthMask( enableReadAndWrite );
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableTestAndWrite );
+	mCtx->pushDepthMask( enableTestAndWrite );
 }
 	
-ScopedDepth::ScopedDepth( bool enableRead, bool enableWrite )
-	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( false )
-{
-	mCtx->pushBoolState( GL_DEPTH_TEST, enableRead );
-	mCtx->pushDepthMask( enableWrite );
-}
-	
-ScopedDepth::ScopedDepth( bool enableRead, bool enableWrite, GLenum depthFunc )
+ScopedDepth::ScopedDepth( bool enableTestAndWrite, GLenum depthFunc )
 	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( true )
 {
-	mCtx->pushBoolState( GL_DEPTH_TEST, enableRead );
-	mCtx->pushDepthMask( enableWrite );
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableTestAndWrite );
+	mCtx->pushDepthMask( enableTestAndWrite );
 	mCtx->pushDepthFunc( depthFunc );
 }
 
@@ -362,6 +355,37 @@ ScopedDepth::~ScopedDepth()
 		mCtx->popDepthMask();
 	if( mSaveFunc )
 		mCtx->popDepthFunc();
+}
+
+ScopedDepthTest::ScopedDepthTest( bool enableTest )
+	: mCtx( gl::context() ), mSaveFunc( false )
+{
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableTest );
+}
+
+ScopedDepthTest::ScopedDepthTest( bool enableTest, GLenum depthFunc )
+	: mCtx( gl::context() ), mSaveFunc( true )
+{
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableTest );
+	mCtx->pushDepthFunc( depthFunc );
+}
+
+ScopedDepthTest::~ScopedDepthTest()
+{
+	mCtx->popBoolState( GL_DEPTH_TEST );
+	if( mSaveFunc )
+		mCtx->popDepthFunc();
+}
+
+ScopedDepthWrite::ScopedDepthWrite( bool enableWrite )
+	: mCtx( gl::context() )
+{
+	mCtx->pushDepthMask( enableWrite );
+}
+
+ScopedDepthWrite::~ScopedDepthWrite()
+{
+	mCtx->popDepthMask();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cinder/gl/wrapper.cpp
+++ b/src/cinder/gl/wrapper.cpp
@@ -338,12 +338,12 @@ void logicOp( GLenum mode )
 }
 #endif
 
-void disableDepthRead()
+void disableDepthTest()
 {
 	gl::disable( GL_DEPTH_TEST );
 }
 
-void enableDepthRead( bool enable )
+void enableDepthTest( bool enable )
 {
 	gl::enable( GL_DEPTH_TEST, enable );
 }

--- a/test/ArcballTest/src/ArcballTestApp.cpp
+++ b/test/ArcballTest/src/ArcballTestApp.cpp
@@ -35,7 +35,7 @@ class ArcballTestApp : public App {
 
 void ArcballTestApp::setup()
 {
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	mZLookAt = 0.5f;
@@ -112,7 +112,7 @@ void ArcballTestApp::draw()
 	gl::setMatrices( cam );
 
 	// draw the earth
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 	gl::translate( mEarthSphere.getCenter() );
 	gl::rotate( mArcball.getQuat() );
@@ -128,7 +128,7 @@ void ArcballTestApp::draw()
 		mConstraintAxis->draw();
 	}
 
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 
 	// draw from vector marker
 	gl::setMatrices( cam );

--- a/test/CameraLensShiftTest/src/CameraLensShiftTestApp.cpp
+++ b/test/CameraLensShiftTest/src/CameraLensShiftTestApp.cpp
@@ -71,7 +71,7 @@ void CameraLensShiftTestApp::draw()
 {
 	gl::clear(); 
 
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	// draw the overview of the scene in the left half of the window
@@ -105,7 +105,7 @@ void CameraLensShiftTestApp::draw()
 	
 	//
 	gl::disableDepthWrite();
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 
 	// draw separator
 	gl::color( Color(0.25f, 0.25f, 0.25f) );

--- a/test/GeomSourceMods/src/GeomSourceModsApp.cpp
+++ b/test/GeomSourceMods/src/GeomSourceModsApp.cpp
@@ -194,7 +194,7 @@ void GeomSourceModsApp::setup()
 	mCam.lookAt( vec3( 3, 2, 4 ), vec3( 0 ) );
 	mCam.setPerspective( 60, getWindowAspectRatio(), 1, 1000 );
 	gl::enableDepthWrite();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 
 	// triangles visual tests
 	mVisualTestSetups.push_back( visualTest10 );

--- a/test/SphereProjection/src/SphereProjectionApp.cpp
+++ b/test/SphereProjection/src/SphereProjectionApp.cpp
@@ -91,7 +91,7 @@ vec2 SphereProjectionApp::clipToScreenCoords( const vec2 &v ) const
 
 void SphereProjectionApp::draw()
 {
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 	gl::enableAlphaBlending();
 	
@@ -119,7 +119,7 @@ void SphereProjectionApp::draw()
 
 		// draw ellipse projection
 		gl::color( 1, 1, 0 );
-		gl::disableDepthRead();
+		gl::disableDepthTest();
 		gl::drawSolidCircle( clipToScreenCoords( center ), 4.0f );
 		gl::drawLine( clipToScreenCoords( center - axisA ), clipToScreenCoords( center + axisA ) );
 		gl::drawLine( clipToScreenCoords( center - axisB ), clipToScreenCoords( center + axisB ) );

--- a/test/TriMeshReadWriteTest/src/TriMeshReadWriteTestApp.cpp
+++ b/test/TriMeshReadWriteTest/src/TriMeshReadWriteTestApp.cpp
@@ -41,7 +41,7 @@ void TriMeshReadWriteTestApp::setup()
 	testObjFileWriteRead();
 
 	gl::enableDepthWrite();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 }
 
 void TriMeshReadWriteTestApp::testObjFileWriteRead()

--- a/test/_opengl/CubeMapLayout/src/CubeMapLayoutApp.cpp
+++ b/test/_opengl/CubeMapLayout/src/CubeMapLayoutApp.cpp
@@ -34,7 +34,7 @@ void CubeMapLayoutApp::prepareSettings( Settings * settings )
 
 void CubeMapLayoutApp::setup()
 {
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 					
 	mParams = params::InterfaceGl::create( "Settings", ivec2(200, 200) );

--- a/test/_opengl/GlslProgAttribTest/src/GlslProgAttribTestApp.cpp
+++ b/test/_opengl/GlslProgAttribTest/src/GlslProgAttribTestApp.cpp
@@ -62,7 +62,7 @@ void GlslProgAttribTestApp::setup()
 	mCam.lookAt( vec3( 0, 0, 10 ), vec3( 0 ) );
 	mCamUi.setCamera( &mCam );
 	
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	gl::enableDepthWrite();
 
 	mRgbNotCmy = true;

--- a/test/iPhoneTestGl/src/TestApp.cpp
+++ b/test/iPhoneTestGl/src/TestApp.cpp
@@ -81,7 +81,7 @@ void TestApp::draw()
 {
 	gl::clear( Color( 0.2f, 0.2f, 0.3f ) );
 	gl::enableAlphaBlending();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	/*mTex.bind();
 	gl::setMatrices( mCam );
 	glPushMatrix();

--- a/test/iosAppTest/src/iosAppTestApp.cpp
+++ b/test/iosAppTest/src/iosAppTestApp.cpp
@@ -375,7 +375,7 @@ void iosAppTestApp::update()
 void iosAppTestApp::draw()
 {
 	gl::enableAlphaBlending();
-	gl::enableDepthRead();
+	gl::enableDepthTest();
 	sOrderTester.setState( TestCallbackOrder::DRAW );
 	CameraPersp mCam;
 	mCam.lookAt( vec3( 3, 2, -3 ), vec3( 0 ) );
@@ -431,7 +431,7 @@ void iosAppTestApp::draw()
 		}
 	}
 
-	gl::disableDepthRead();
+	gl::disableDepthTest();
 	gl::color( Color( 0.0f, 1.0f, 0.0f ) );
 	mFont->drawString( orientationString( getWindowOrientation() ) + "@ " + toString( getWindowContentScale() ), vec2( 10.0f, 60.0f ) );
 //	gl::drawStringCentered( "Orientation: " + orientationString( getInterfaceOrientation() ), vec2( getWindowCenter().x, 30.0f ), Color( 0.0f, 1.0f, 0.0f ), Font::getDefault() ); // ???: why not centered?


### PR DESCRIPTION
Explained in #1071.  Other than making the api modifications in that issue, I also renamed `gl::enableStencilRead()` / `gl::disableStencilRead` in the header to `gl::enableStencilTest()`, etc, which was already going by that name in the .cpp (but inaccesible). We still need to fix #792 by either removing or implementing `enableStencilWrite`, I'll wait until feedback to do something about that.

Updated all samples and tests. We should be aware that existing code of the form:

```cpp
gl::ScopedDepth depth( true, false ); // or:
gl::ScopedDepth depth( true, true );
```

will be broken after this - at least on clang I'm seeing that the compiler accepts the second bool as the GLfunc for depth function. When I tested with the Earthquake sample, this lead to a `GL_INVALID_OPERATION` at least, also ScopedDepth is a new method anyway so I think it is ok for us to make breaking changes now for the better.