### PR TITLE
Plug a couple of OS X / iOS leaks

### DIFF
--- a/src/cinder/audio/cocoa/FileCoreAudio.cpp
+++ b/src/cinder/audio/cocoa/FileCoreAudio.cpp
@@ -66,9 +66,12 @@ void SourceFileCoreAudio::initImpl()
 	::CFURLRef fileUrl = ci::cocoa::createCfUrl( Url( mDataSource->getFilePath().string() ) );
 	::ExtAudioFileRef audioFile;
 	OSStatus status = ::ExtAudioFileOpenURL( fileUrl, &audioFile );
+	if( fileUrl ) {
+		CFRelease(fileUrl);
+		fileUrl = NULL;
+	}
 	if( status != noErr ) {
-		string urlString = ci::cocoa::convertCfString( CFURLGetString( fileUrl ) );
-		throw AudioFileExc( string( "could not open audio source file: " ) + urlString, (int32_t)status );
+		throw AudioFileExc( string( "could not open audio source file: " ) + mDataSource->getFilePath().string(), (int32_t)status );
 	}
 
 	mExtAudioFile = ExtAudioFilePtr( audioFile );

--- a/src/cinder/qtime/AvfUtils.mm
+++ b/src/cinder/qtime/AvfUtils.mm
@@ -381,9 +381,13 @@ ImageTargetCvPixelBuffer::ImageTargetCvPixelBuffer( ImageSourceRef imageSource, 
 	}
 	
 	// TODO: Can we create the buffer from the pool????? Seems like no at first attempt --maybe a pixel buffer attributes mismatch?
-	CFMutableDictionaryRef attributes = CFDictionaryCreateMutable( kCFAllocatorDefault, 6, nil, nil );
-	dictionarySetPixelBufferOpenGLCompatibility( attributes );
+//	CFMutableDictionaryRef attributes = CFDictionaryCreateMutable( kCFAllocatorDefault, 6, nil, nil );
+//	dictionarySetPixelBufferOpenGLCompatibility( attributes );
 //	CVReturn status = CVPixelBufferPoolCreatePixelBufferWithAuxAttributes(kCFAllocatorDefault, pbPool, attributes, &mPixelBufferRef);
+//	if( attributes ) {
+//		CFRelease( attributes );
+//		attributes = NULL;
+//	}
 	CVReturn status = CVPixelBufferPoolCreatePixelBuffer( kCFAllocatorDefault, pbPool, &mPixelBufferRef );
 	if( kCVReturnSuccess != status )
 		throw ImageIoException();

--- a/src/cinder/qtime/QuickTimeImplAvf.mm
+++ b/src/cinder/qtime/QuickTimeImplAvf.mm
@@ -865,6 +865,7 @@ MovieLoader::MovieLoader( const Url &url )
 	AVPlayerItem* playerItem = [[AVPlayerItem alloc] initWithURL:asset_url];
 	mPlayer = [[AVPlayer alloc] init];
 	[mPlayer replaceCurrentItemWithPlayerItem:playerItem];	// starts the downloading process
+	[playerItem release];
 }
 
 MovieLoader::~MovieLoader()


### PR DESCRIPTION
I was trying to check out the clang address sanitizer in Xcode 7 and instead ended up running the static analysis tool which flagged these. It doesn't appear as though these are called through the update cycle or anything so I don't think they'd represent significant leaks or fixes - regardless they'd probably benefit from some quick validation.