### PR TITLE
rename PlaneT -> Plane, allows for typedef'ed Plane

### DIFF
--- a/include/cinder/Frustum.h
+++ b/include/cinder/Frustum.h
@@ -88,10 +88,10 @@ class FrustumT {
 	bool intersects( const AxisAlignedBox &box ) const;
 
 	//! Returns a const reference to the Plane associated with /a section of the Frustum.
-	const Plane<T>& getPlane( FrustumSection section ) const { return mFrustumPlanes[section]; }
+	const PlaneT<T>& getPlane( FrustumSection section ) const { return mFrustumPlanes[section]; }
 	
   protected:
-	Plane<T>	mFrustumPlanes[6];
+	PlaneT<T>	mFrustumPlanes[6];
 };
 
 typedef FrustumT<float>		Frustum;

--- a/include/cinder/Plane.h
+++ b/include/cinder/Plane.h
@@ -32,6 +32,7 @@
 
 namespace cinder {
 
+//! Represents a Plane, as a geometric primitive, useful in conducting tests in 3D space.
 template<typename T>
 class PlaneT {
   public:
@@ -77,6 +78,7 @@ std::ostream& operator<<( std::ostream &o, const PlaneT<T> &p )
 	return o << "(" << p.mNormal << ", " << p.mDistance << ")";
 }
 
+//! Exception type thrown when bad values are encountered.
 class PlaneExc : public Exception {
   public:
 	PlaneExc()

--- a/include/cinder/Plane.h
+++ b/include/cinder/Plane.h
@@ -33,14 +33,14 @@
 namespace cinder {
 
 template<typename T>
-class Plane {
+class PlaneT {
   public:
 	typedef glm::tvec3<T, glm::defaultp> Vec3T;
 
-	Plane() {}
-	Plane( const Vec3T &v1, const Vec3T &v2, const Vec3T &v3 );
-	Plane( const Vec3T &point, const Vec3T &normal );
-	Plane( T a, T b, T c, T d );
+	PlaneT() {}
+	PlaneT( const Vec3T &v1, const Vec3T &v2, const Vec3T &v3 );
+	PlaneT( const Vec3T &point, const Vec3T &normal );
+	PlaneT( T a, T b, T c, T d );
 
 	//! Defines a plane using 3 points. 
 	void	set( const Vec3T &v1, const Vec3T &v2, const Vec3T &v3 );
@@ -67,11 +67,12 @@ class Plane {
 	void	set( const Vec3Y &v1, const Vec3Y &v2, const Vec3Y &v3 )	{ set( Vec3T( v1 ), Vec3T( v2 ), Vec3T( v3 ) ); }
 };
 
-typedef Plane<float>	Planef;
-typedef Plane<double>	Planed;
+typedef PlaneT<float>	Plane;
+typedef PlaneT<float>	Planef;
+typedef PlaneT<double>	Planed;
 
 template<typename T>
-std::ostream& operator<<( std::ostream &o, const Plane<T> &p )
+std::ostream& operator<<( std::ostream &o, const PlaneT<T> &p )
 {
 	return o << "(" << p.mNormal << ", " << p.mDistance << ")";
 }

--- a/include/cinder/Plane.h
+++ b/include/cinder/Plane.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, The Cinder Project, All rights reserved.
+ Copyright (c) 2011-15, The Cinder Project, All rights reserved.
  This code is intended for use with the Cinder C++ library: http://libcinder.org
  
  Portions of this code (C) Paul Houx
@@ -77,10 +77,11 @@ std::ostream& operator<<( std::ostream &o, const PlaneT<T> &p )
 	return o << "(" << p.mNormal << ", " << p.mDistance << ")";
 }
 
-
 class PlaneExc : public Exception {
- public:
-	virtual const char* what() const throw() { return "Invalid parameters specified"; }
+  public:
+	PlaneExc()
+		: Exception( "Invalid parameters specified" )
+	{}
 };
 
 } // namespace cinder

--- a/src/cinder/Plane.cpp
+++ b/src/cinder/Plane.cpp
@@ -28,38 +28,39 @@
 namespace cinder {
 
 template<typename T>
-Plane<T>::Plane( const Vec3T &v1, const Vec3T &v2, const Vec3T &v3 )
+PlaneT<T>::PlaneT( const Vec3T &v1, const Vec3T &v2, const Vec3T &v3 )
 {
 	set( v1, v2, v3 );
 }
 
 template<typename T>
-Plane<T>::Plane( const Vec3T &point, const Vec3T &normal )
+PlaneT<T>::PlaneT( const Vec3T &point, const Vec3T &normal )
 {
 	set( point, normal );
 }
 
 template<typename T>
-Plane<T>::Plane( T a, T b, T c, T d )
+PlaneT<T>::PlaneT( T a, T b, T c, T d )
 {
 	set( a, b, c, d );
 }
 
 template<typename T>
-void Plane<T>::set( const Vec3T &v1, const Vec3T &v2, const Vec3T &v3 )
+void PlaneT<T>::set( const Vec3T &v1, const Vec3T &v2, const Vec3T &v3 )
 {
 	Vec3T normal = cross( v2 - v1, v3 - v1 );
 	
-	if( length2( normal ) == 0 )
-		 // error! invalid parameters
+	if( length2( normal ) == 0 ) {
+		// error! invalid parameters
 		throw PlaneExc();
+	}
 
 	mNormal = normalize( normal );
 	mDistance = dot( mNormal, v1 );
 }
 
 template<typename T>
-void Plane<T>::set( const Vec3T &point, const Vec3T &normal )
+void PlaneT<T>::set( const Vec3T &point, const Vec3T &normal )
 {
 	if( length2( normal ) == 0 )
 		 // error! invalid parameters
@@ -70,20 +71,21 @@ void Plane<T>::set( const Vec3T &point, const Vec3T &normal )
 }
 
 template<typename T>
-void Plane<T>::set( T a, T b, T c, T d )
+void PlaneT<T>::set( T a, T b, T c, T d )
 {
 	Vec3T normal( a, b, c );
 
 	T length = glm::length( normal );
-	if( length == 0 )
-		 // error! invalid parameters
+	if( length == 0 ) {
+		// error! invalid parameters
 		throw PlaneExc();
+	}
 
 	mNormal = normalize( normal );
 	mDistance = d / length;
 }
 
-template class Plane<float>;
-template class Plane<double>;
+template class PlaneT<float>;
+template class PlaneT<double>;
 
 } // namespace cinder


### PR DESCRIPTION
Similar to what we've done for Frustum, Polyline, and others. I also added a couple lines of docs and modernized the exception subclass.