### PR TITLE
ObjLoader sample has some alpha issues

### DIFF
--- a/samples/_opengl/ObjLoader/assets/shader.frag
+++ b/samples/_opengl/ObjLoader/assets/shader.frag
@@ -12,5 +12,6 @@ void main( void )
 {
 	vec3 normal = normalize( -Normal );
 	float diffuse = max( dot( normal, vec3( 0, 0, -1 ) ), 0 );
-	oColor = texture( uTex0, TexCoord0 ) * diffuse;
+	vec3 color = texture( uTex0, TexCoord0 ).rgb * diffuse;
+	oColor = vec4( color, 1.0 );
 }

--- a/samples/_opengl/ObjLoader/assets/shader_es2.frag
+++ b/samples/_opengl/ObjLoader/assets/shader_es2.frag
@@ -11,5 +11,6 @@ void main( void )
 {
 	vec3 normal = normalize( -Normal );
 	float diffuse = max( dot( normal, vec3( 0, 0, -1 ) ), 0.0 );
-	gl_FragColor = texture2D( uTex0, TexCoord0 ) * diffuse;
+	vec3 color = texture2D( uTex0, TexCoord0 ).rgb * diffuse;
+	gl_FragColor = vec4( color, 1.0 );
 }


### PR DESCRIPTION
There's a small issue with this sample shaders.
Right before outputing the color, the whole RGBA is multiplied by the variable ```diffuse``` making the mesh transparent in some places. This creates some transparency issues as shown here:

![screenshot 2015-09-09 10 10 48](https://cloud.githubusercontent.com/assets/241098/9756630/040e245a-56dc-11e5-866b-0aec0ddb4c93.png)
![screenshot 2015-09-09 10 10 51](https://cloud.githubusercontent.com/assets/241098/9756631/040f1c5c-56dc-11e5-860c-296ea6f46440.png)

Here's a corrected version. See how the two compares side by side:
![screenshot 2015-09-09 10 10 43](https://cloud.githubusercontent.com/assets/241098/9756716/992bc9f2-56dc-11e5-91c3-d49c3399b181.png)
