### PR TITLE
Handle \ continuations as part of a line.

### DIFF
--- a/include/cinder/Stream.h
+++ b/include/cinder/Stream.h
@@ -120,6 +120,7 @@ class IStreamCinder : public virtual StreamBase {
 	void		readFixedString( char *t, size_t maxSize, bool nullTerminate );
 	void		readFixedString( std::string *t, size_t size );
 	std::string	readLine();
+	std::string readLineWithContinuation( char lineContinuationChar = '\\' );
 	
 	void			readData( void *dest, size_t size );
 	virtual size_t	readDataAvailable( void *dest, size_t maxSize ) = 0;

--- a/include/cinder/Stream.h
+++ b/include/cinder/Stream.h
@@ -120,7 +120,7 @@ class IStreamCinder : public virtual StreamBase {
 	void		readFixedString( char *t, size_t maxSize, bool nullTerminate );
 	void		readFixedString( std::string *t, size_t size );
 	std::string	readLine();
-	std::string readLineWithContinuation( char lineContinuationChar = '\\' );
+	std::string	readLineWithContinuation( char lineContinuationChar = '\\' );
 	
 	void			readData( void *dest, size_t size );
 	virtual size_t	readDataAvailable( void *dest, size_t maxSize ) = 0;

--- a/src/cinder/ObjLoader.cpp
+++ b/src/cinder/ObjLoader.cpp
@@ -188,7 +188,7 @@ void ObjLoader::parse( bool includeNormals, bool includeTexCoords )
 	size_t lineNumber = 0;
 	while( ! mStream->isEof() ) {
 		lineNumber++;
-		string line = mStream->readLine(), tag;
+		string line = mStream->readLineWithContinuation(), tag;
         if( line.empty() || line[0] == '#' )
             continue;
         

--- a/src/cinder/Stream.cpp
+++ b/src/cinder/Stream.cpp
@@ -125,6 +125,27 @@ std::string IStreamCinder::readLine()
 {
 	string result;
 	int8_t ch;
+	while( ! isEof() ) {
+		read( &ch );
+		if( ch == 0x0A )
+			break;
+		else if( ch == 0x0D ) {
+			read( &ch );
+			if( ch != 0x0A )
+				seekRelative( -1 );
+			break;
+		}
+		else
+			result += ch;
+	}
+
+	return result;
+}
+
+std::string IStreamCinder::readLineWithContinuation( char lineContinuationChar )
+{
+	string result;
+	int8_t ch;
 
 	auto check_newline = [this, &ch] () {
 		if( ch == 0x0A )
@@ -138,8 +159,8 @@ std::string IStreamCinder::readLine()
 		return false;
 	};
 
-	auto check_continuation = [this, &ch, &check_newline] () {
-		if( ch == '\\') {
+	auto check_continuation = [this, &ch, &check_newline, lineContinuationChar] () {
+		if( ch == lineContinuationChar ) {
 			read( &ch );
 			if( check_newline() ) {
 				return true;

--- a/src/cinder/Stream.cpp
+++ b/src/cinder/Stream.cpp
@@ -125,14 +125,41 @@ std::string IStreamCinder::readLine()
 {
 	string result;
 	int8_t ch;
-	while( ! isEof() ) {
-		read( &ch );
+
+	auto check_newline = [this, &ch] () {
 		if( ch == 0x0A )
-			break;
+			return true;
 		else if( ch == 0x0D ) {
 			read( &ch );
 			if( ch != 0x0A )
 				seekRelative( -1 );
+			return true;
+		}
+		return false;
+	};
+
+	auto check_continuation = [this, &ch, &check_newline] () {
+		if( ch == '\\') {
+			read( &ch );
+			if( check_newline() ) {
+				return true;
+			}
+			else {
+				seekRelative( -1 );
+			}
+		}
+		return false;
+	};
+
+	while( ! isEof() ) {
+		read( &ch );
+
+		if (check_continuation()) {
+			// skip the newline check
+			continue;
+		}
+
+		if( check_newline() ) {
 			break;
 		}
 		else


### PR DESCRIPTION
Add `IStreamCinder::readLineWithContinuation(char)` method to handle Unix-style line continuations in text files.
`ObjLoader` uses `readLinesWithContinuation` to enable parsing of OBJ files saved from Rhino/3DS Max that sometimes split faces/vertices across multiple lines.

Fixes #1121 