### PR TITLE
Updating GL names for depth, stencil and alpha, per #792, #1094, #1084

### DIFF
--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -243,18 +243,41 @@ private:
 
 //! Scopes state of depth testing and writing
 struct ScopedDepth : private Noncopyable {
-	//! Enables or disables both depth comparisons and writing to the depth buffer
+	//! Enables or disables both depth testing and writing to the depth buffer
 	ScopedDepth( bool enableReadAndWrite );
-	//! Enables or disables depth comparisons and/or writing to the depth buffer
-	ScopedDepth( bool enableRead, bool enableWrite );
-	//! Enables or disables depth comparisons, writing to the depth buffer and specifies a depth comparison function, either \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS.
-	ScopedDepth( bool enableRead, bool enableWrite, GLenum depthFunc );
+	//! Enables or disables depth comparisons and writing to the depth buffer, and specifies a depth comparison function, either \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS.
+	ScopedDepth( bool enableReadAndWrite, GLenum depthFunc );
 	~ScopedDepth();
 	
   private:
 	Context		*mCtx;
 	bool		mSaveMask;
 	bool		mSaveFunc;
+};
+
+//! Scopes state to control the depth testing / reading operation. See information on c\ GL_DEPTH_TEST.
+struct ScopedDepthTest : private Noncopyable {
+	//! Enables or disables the depth testing / reading operation for the scope of this object.
+	ScopedDepthTest( bool enableTest );
+	//! Enables or disables the depth test operation, which controls reading and writing to the depth buffer, for the scope of this object. Also specifies a depth comparison function, either \c GL_NEVER, \c GL_LESS, \c GL_EQUAL, \c GL_LEQUAL, \c GL_GREATER, \c GL_NOTEQUAL, \c GL_GEQUAL and \c GL_ALWAYS (see info on `glDepthFunc`).
+	ScopedDepthTest( bool enableTest, GLenum depthFunc );
+	//! Destructor returns state to how it was before this object was constructed.
+	~ScopedDepthTest();
+
+  private:
+	Context		*mCtx;
+	bool		mSaveFunc;
+};
+
+//! Scopes state to control whether successful depth tests write to the depth buffer. See information on `glDepthMask()`. \note You must enable depth testing / reading (`GL_DEPTH_TEST`) for this to take place.
+struct ScopedDepthWrite : private Noncopyable {
+	//! Enables or disables writing to the depth buffer for the scope of this object.
+	ScopedDepthWrite( bool enableWrite );
+	//! Destructor returns state to how it was before this object was constructed.
+	~ScopedDepthWrite();
+
+private:
+	Context		*mCtx;
 };
 
 //! Scopes state of Renderbuffer binding

--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -276,7 +276,7 @@ struct ScopedDepthWrite : private Noncopyable {
 	//! Destructor returns state to how it was before this object was constructed.
 	~ScopedDepthWrite();
 
-private:
+  private:
 	Context		*mCtx;
 };
 

--- a/include/cinder/gl/wrapper.h
+++ b/include/cinder/gl/wrapper.h
@@ -117,8 +117,17 @@ inline void scissor( const ivec2 &position, const ivec2 &size ) { scissor( std::
 void enable( GLenum state, bool enable = true );
 inline void disable( GLenum state ) { enable( state, false ); }
 
-void enableAlphaBlending( bool premultiplied = false );
-void disableAlphaBlending();
+//! Enables or disables blending state as governed by \c GL_BLEND but does not modify blend function.
+void enableBlending( bool enable = false );
+//! Disables blending state via \c GL_BLEND, but does not modify blend function
+inline void disableBlending() { enableBlending( false ); }
+//! Enables blending via \c GL_BLEND and sets the blend function to unpremultiplied alpha blending when \p enable is \c true; otherwise disables blending without modifying the blend function.
+void enableAlphaBlending( bool enable = false );
+//! Enables blending via \c GL_BLEND and sets the blend function to premultiplied alpha blending
+void enableAlphaBlendingPremult();
+//! Disables blending state as governed by \c GL_BLEND but does not modify blend function.. Deprecated; prefer disableBlending()
+inline void disableAlphaBlending() { disableBlending(); }
+//! Enables \c GL_BLEND and sets the blend function to additive blending
 void enableAdditiveBlending();
 
 //! Specifies whether polygons are culled. Equivalent to calling enable( \c GL_CULL_FACE, \a enable ). Specify front or back faces with gl::cullFace().

--- a/include/cinder/gl/wrapper.h
+++ b/include/cinder/gl/wrapper.h
@@ -144,11 +144,11 @@ void enableDepthWrite( bool enable = true );
 //! Enables or disables writing to and reading / testing from depth buffer
 inline void enableDepth( bool enable = true ) { enableDepthRead( enable ); enableDepthWrite( enable ); }
 
-void enableStencilRead( bool enable = true );
-void disableStencilRead();
-void enableStencilWrite( bool enable = true );
-void disableStencilWrite();
-
+//! Enables or disables the stencil test operation, which controls reading and writing to the stencil buffer. Analagous to `glEnable( GL_STENCIL_TEST, enable );`
+void enableStencilTest( bool enable = true );
+//! Disables the stencil test operation. Analagous to `glEnable( GL_STENCIL_TEST, false );`
+void disableStencilTest();
+ 
 //! Sets the View and Projection matrices based on a Camera
 void setMatrices( const ci::Camera &cam );
 void setModelMatrix( const ci::mat4 &m );

--- a/include/cinder/gl/wrapper.h
+++ b/include/cinder/gl/wrapper.h
@@ -133,10 +133,16 @@ void enableLogicOp( bool enable = true );
 void logicOp( GLenum mode );
 #endif
 
+//! Disables reading / testing from the depth buffer. Disables \c GL_DEPTH_TEST
 void disableDepthRead();
+//! Disables writing to depth buffer; analogous to calling glDepthMask( GL_FALSE );
 void disableDepthWrite();
+//! Enables or disables reading / testing from depth buffer; analogous to setting \c GL_DEPTH_TEST to \p enable
 void enableDepthRead( bool enable = true );
+//! Enables or disables writing to depth buffer; analogous to calling glDepthMask( \p enable ); Note that reading must also be enabled for writing to have any effect.
 void enableDepthWrite( bool enable = true );
+//! Enables or disables writing to and reading / testing from depth buffer
+inline void enableDepth( bool enable = true ) { enableDepthRead( enable ); enableDepthWrite( enable ); }
 
 void enableStencilRead( bool enable = true );
 void disableStencilRead();

--- a/samples/Earthquake/src/Earth.cpp
+++ b/samples/Earthquake/src/Earth.cpp
@@ -107,7 +107,8 @@ void Earth::drawQuakes()
 
 void Earth::drawQuakeLabelsOnSphere( const vec3 &eyeNormal, const float eyeDist )
 {
-	gl::ScopedDepth depth( true, false );
+	gl::ScopedDepthTest depthTest( true );
+	gl::ScopedDepthWrite depthWrite( false );
 	gl::ScopedGlslProg shader( gl::getStockShader( gl::ShaderDef().color().texture() ) );
 
 	gl::ScopedColor color( 1, 1, 1 );

--- a/samples/Earthquake/src/EarthquakeApp.cpp
+++ b/samples/Earthquake/src/EarthquakeApp.cpp
@@ -146,7 +146,7 @@ void EarthquakeApp::draw()
 {
 	gl::clear( Color( 1, 0, 0 ) );
 
-	gl::ScopedDepth       depth( true, true );
+	gl::ScopedDepth       depth( true );
 	gl::ScopedColor       color( 1, 1, 1 );
 
 	// Draw stars.

--- a/samples/Picking3D/src/Picking3DApp.cpp
+++ b/samples/Picking3D/src/Picking3DApp.cpp
@@ -92,7 +92,7 @@ void Picking3DApp::draw()
 	gl::setMatrices( mCamera );
 
 	// Enable depth buffer.
-	gl::ScopedDepth depth( true, true );
+	gl::ScopedDepth depth( true );
 
 	// Draw the grid on the floor.
 	{

--- a/samples/QuaternionAccum/src/QuaternionAccumApp.cpp
+++ b/samples/QuaternionAccum/src/QuaternionAccumApp.cpp
@@ -26,7 +26,7 @@ public:
 	void drawPlane();
 	void drawSpline();
 	void drawBall();
-	void draw();
+	void draw() override;
 
 private:
 	CameraPersp		mCam;
@@ -160,7 +160,7 @@ void QuaternionAccumApp::draw()
 	gl::setMatrices( mCam );
 
 	// Enable depth buffer reading and writing.
-	gl::ScopedDepth depth( true, true );
+	gl::ScopedDepth depth( true );
 
 	// Draw our scene.
 	drawPlane();

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -347,18 +347,11 @@ ScopedDepth::ScopedDepth( bool enableReadAndWrite )
 	mCtx->pushDepthMask( enableReadAndWrite );
 }
 	
-ScopedDepth::ScopedDepth( bool enableRead, bool enableWrite )
-	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( false )
-{
-	mCtx->pushBoolState( GL_DEPTH_TEST, enableRead );
-	mCtx->pushDepthMask( enableWrite );
-}
-	
-ScopedDepth::ScopedDepth( bool enableRead, bool enableWrite, GLenum depthFunc )
+ScopedDepth::ScopedDepth( bool enableReadAndWrite, GLenum depthFunc )
 	: mCtx( gl::context() ), mSaveMask( true ), mSaveFunc( true )
 {
-	mCtx->pushBoolState( GL_DEPTH_TEST, enableRead );
-	mCtx->pushDepthMask( enableWrite );
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableReadAndWrite );
+	mCtx->pushDepthMask( enableReadAndWrite );
 	mCtx->pushDepthFunc( depthFunc );
 }
 
@@ -369,6 +362,37 @@ ScopedDepth::~ScopedDepth()
 		mCtx->popDepthMask();
 	if( mSaveFunc )
 		mCtx->popDepthFunc();
+}
+
+ScopedDepthTest::ScopedDepthTest( bool enableTest )
+	: mCtx( gl::context() ), mSaveFunc( false )
+{
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableTest );
+}
+
+ScopedDepthTest::ScopedDepthTest( bool enableTest, GLenum depthFunc )
+	: mCtx( gl::context() ), mSaveFunc( true )
+{
+	mCtx->pushBoolState( GL_DEPTH_TEST, enableTest );
+	mCtx->pushDepthFunc( depthFunc );
+}
+
+ScopedDepthTest::~ScopedDepthTest()
+{
+	mCtx->popBoolState( GL_DEPTH_TEST );
+	if( mSaveFunc )
+		mCtx->popDepthFunc();
+}
+
+ScopedDepthWrite::ScopedDepthWrite( bool enableWrite )
+	: mCtx( gl::context() )
+{
+	mCtx->pushDepthMask( enableWrite );
+}
+
+ScopedDepthWrite::~ScopedDepthWrite()
+{
+	mCtx->popDepthMask();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cinder/gl/wrapper.cpp
+++ b/src/cinder/gl/wrapper.cpp
@@ -292,21 +292,25 @@ void enable( GLenum state, bool enable )
 	ctx->enable( state, enable );
 }
 
-void enableAlphaBlending( bool premultiplied )
+void enableBlending( bool enable )
+{
+	auto ctx = gl::context();
+	ctx->enable( GL_BLEND, enable );
+}
+
+void enableAlphaBlending( bool enable )
 {
 	auto ctx = gl::context();
 	ctx->enable( GL_BLEND );
-	if( ! premultiplied ) {
+	if( enable )
 		ctx->blendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-	}
-	else {
-		ctx->blendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
-	}
 }
 
-void disableAlphaBlending()
+void enableAlphaBlendingPremult()
 {
-	gl::disable( GL_BLEND );
+	auto ctx = gl::context();
+	ctx->enable( GL_BLEND );
+	ctx->blendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
 }
 
 void enableAdditiveBlending()

--- a/src/cinder/gl/wrapper.cpp
+++ b/src/cinder/gl/wrapper.cpp
@@ -186,9 +186,10 @@ void clear( const ColorA& color, bool clearDepthBuffer )
 {
 	clearColor( color );
 	if ( clearDepthBuffer ) {
-		depthMask( GL_TRUE );
+		ScopedDepthWrite depthWriteScp( GL_TRUE );
 		clear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT );
-	} else {
+	}
+	else {
 		clear( GL_COLOR_BUFFER_BIT );
 	}
 }


### PR DESCRIPTION
See the cited issues for changes. The main breaking change here is that `gl::enableAlphaBlending(bool)`'s boolean parameter is now not governing premultiplication but enablement.

#792, #1094, #1084