### PR TITLE
Supplying valid EventID values for windows logging

### DIFF
--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -524,7 +524,10 @@ public:
 		wStrings[0] = wMeta.c_str();
 		wStrings[1] = wText.c_str();
 	
-		::ReportEventW( mHLog, eventLevel, 0, 0, 0, 2, 0, wStrings, 0 );
+		// Windows manifests do not allow 0 based event IDs.
+		DWORD eventID = meta.mLevel + 100;
+
+		::ReportEventW( mHLog, eventLevel, 0, eventID, 0, 2, 0, wStrings, 0 );
 	}
 
 protected:


### PR DESCRIPTION
Per #1109, we needed unique, non-zero EventIDs for windows logging in conjunction with a manifest file.  I believe this is what is holding up our WinRT logging.

My understanding based on some research, and [this](http://stackoverflow.com/questions/1755615/what-event-id-to-use-for-my-custom-event-log-entries) post, is that EventID values are application specific, so the use of 100, 101, etc, should't pose an issue in windows.  I just need to explicitly document this in the windows section of the logging guide.