### PR TITLE
Logging restructure

### DIFF
--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -157,7 +157,7 @@ protected:
 	int				mYearDay;
 };
 	
-//! LoggerBreakpoint doesn't actually print anything, but triggers a breakpoint on log events above a specified threshold
+//! LoggerBreakpoint doesn't actually print anything, but triggers a breakpoint on log events above a specified threshold.
 class LoggerBreakpoint : public Logger {
   public:
 	LoggerBreakpoint( Level triggerLevel = LEVEL_ERROR )
@@ -181,6 +181,8 @@ public:
 	virtual ~LoggerSystem();
 	
 	void write( const Metadata &meta, const std::string &text ) override;
+	//! Sets the minimum logging level that will trigger a system log.
+	//! \note Setting \p minLevel below CI_MIN_LOG_LEVEL is pointless; minLevel will act like CI_MIN_LOG_LEVEL.
 	void setLoggingLevel( Level minLevel ) { mMinLevel = minLevel; }
 	
 protected:
@@ -203,7 +205,7 @@ public:
 	static LogManager* instance()	{ return sInstance; }
 	//! Destroys the shared instance. Useful to remove false positives with leak detectors like valgrind.
 	static void destroyInstance()	{ delete sInstance; }
-	//! Restores LogManager to its default state.
+	//! Restores LogManager to its default state - a single LoggerConsole.
 	void restoreToDefault();
 
 	//! Removes all loggers from the stack.

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -205,42 +205,12 @@ public:
 	//! Returns the mutex used for thread safe loggers. Also used when adding or resetting new loggers.
 	std::mutex& getMutex() const			{ return mMutex; }
 
-	void enableConsoleLogging();
-	void disableConsoleLogging();
-	void setConsoleLoggingEnabled( bool enable )		{ enable ? enableConsoleLogging() : disableConsoleLogging(); }
-	bool isConsoleLoggingEnabled() const				{ return mConsoleLoggingEnabled; }
-
-	void enableFileLogging( const fs::path &filePath = fs::path(), bool appendToExisting = true );
-	void enableFileLoggingRotating( const fs::path &folder, const std::string& formatStr, bool appendToExisting = true);
-	void disableFileLogging();
-	void setFileLoggingEnabled( bool enable, const fs::path &filePath = fs::path(), bool appendToExisting = true );
-	void setFileLoggingRotatingEnabled( bool enable, const fs::path &folder, const std::string &formatStr, bool appendToExisting = true );
-	bool isFileLoggingEnabled() const					{ return mFileLoggingEnabled; }
-
-	void enableSystemLogging();
-	void disableSystemLogging();
-	void setSystemLoggingEnabled( bool enable = true )		{ enable ? enableSystemLogging() : disableSystemLogging(); }
-	bool isSystemLoggingEnabled() const					{ return mSystemLoggingEnabled; }
-	void setSystemLoggingLevel( Level level );
-	Level getSystemLoggingLevel() const					{ return mSystemLoggingLevel; }
-
-	//! Enables a breakpoint to be triggered when a log message happens at `LEVEL_ERROR` or higher
-	void enableBreakOnError()							{ enableBreakOnLevel( LEVEL_ERROR ); }
-	//! Enables a breakpoint to be triggered when a log message happens at \a trigerLevel or higher.
-	void enableBreakOnLevel( Level trigerLevel );
-	//! Disables any breakpoints set for logging.
-	void disableBreakOnLog();
-
 protected:
 	LogManager();
-
-	bool initFileLogging();
 
 	std::unique_ptr<Logger>	mLogger;
 	LoggerMulti*			mLoggerMulti;
 	mutable std::mutex		mMutex;
-	bool					mConsoleLoggingEnabled, mFileLoggingEnabled, mSystemLoggingEnabled, mBreakOnLogEnabled;
-	Level					mSystemLoggingLevel;
 
 	static LogManager *sInstance;
 };

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -218,7 +218,7 @@ public:
 	void removeLogger( const LoggerRef& logger );
 	//! Returns a vector of raw pointers that contain all active loggers of a specifc type.
 	template<typename LoggerT>
-	std::vector<LoggerT*> getLoggers();
+	std::vector<LoggerRef> getLoggers();
 	//! Returns a vector of LoggerRef that contains all active loggers
 	std::vector<LoggerRef> getAllLoggers();
 	//! Returns the mutex used for thread safe logging.
@@ -308,15 +308,15 @@ std::shared_ptr<LoggerT> LogManager::makeLogger( Args&&... args )
 }
 
 template<typename LoggerT>
-std::vector<LoggerT*> LogManager::getLoggers()
+std::vector<LoggerRef> LogManager::getLoggers()
 {
-	std::vector<LoggerT*> result;
+	std::vector<LoggerRef> result;
 	
 	std::lock_guard<std::mutex> lock( manager()->getMutex() );
 	for( const auto& logger : mLoggers ) {
 		auto ret = dynamic_cast<LoggerT *>( logger.get() );
 		if( ret ) {
-			result.push_back( ret );
+			result.push_back( logger );
 		}
 	}
 

--- a/include/cinder/Log.h
+++ b/include/cinder/Log.h
@@ -101,10 +101,7 @@ class LoggerFile : public Logger {
 	// Standard loggerFile, will write to a single log file.  File appending is configurable.
 	// ! If \a filePath is empty, uses the default ('cinder.log' next to app binary)
 	LoggerFile( const fs::path &filePath = fs::path(), bool appendToExisting = true );
-	// daily rotating logger, will write to a formatted log file, updated at the first log request
-	// after midnight.
-	// ! If \a folder or \a formatStr are empty, ignores request
-	LoggerFile( const fs::path &folder, const std::string &formatStr, bool appendToExisting = true );
+
 	virtual ~LoggerFile();
 
 	void write( const Metadata &meta, const std::string &text ) override;
@@ -116,14 +113,24 @@ class LoggerFile : public Logger {
 	void		ensureDirectoryExists();
 
 	fs::path		mFilePath;
-	fs::path		mFolderPath;
-	std::string		mDailyFormatStr;
-	int				mYearDay;
 	bool			mAppend;
-	bool			mRotating;
 	std::ofstream	mStream;
 };
 
+class LoggerFileRotating : public LoggerFile {
+public:
+	LoggerFileRotating( const fs::path &folder, const std::string &formatStr, bool appendToExisting = true );
+	
+	virtual ~LoggerFileRotating() { }
+	
+	void write( const Metadata &meta, const std::string &text ) override;
+	
+protected:
+	fs::path		mFolderPath;
+	std::string		mDailyFormatStr;
+	int				mYearDay;
+};
+	
 //! Logger that doesn't actually print anything, but triggers a breakpoint if a log event happens past a specified threshold
 class LoggerBreakpoint : public Logger {
   public:

--- a/samples/Logging/src/LoggingApp.cpp
+++ b/samples/Logging/src/LoggingApp.cpp
@@ -47,7 +47,7 @@ void LoggingApp::enableFileLogging()
 	//! This call will append log messages to the file `cinder.log` in the folder `/tmp/logging`.
 	//! If the folder path `/tmp/logging` does not exist, it will be created for you.
 	
-	log::manager()->createLogger<log::LoggerFile>( "/tmp/logging/cinder.log", true );
+	log::manager()->makeLogger<log::LoggerFile>( "/tmp/logging/cinder.log", true );
 }
 
 void LoggingApp::enableFileLoggingRotating()
@@ -56,7 +56,7 @@ void LoggingApp::enableFileLoggingRotating()
 	//! The filename `cinder.%Y.%m.%d.log` will be evaluated by strftime.  For the example
 	//! below, the filename could evaluate to `cinder.2015.08.28.log`.
 
-	log::manager()->createLogger<log::LoggerFileRotating>( "/tmp/logging", "cinder.%Y.%m.%d.log" );
+	log::manager()->makeLogger<log::LoggerFileRotating>( "/tmp/logging", "cinder.%Y.%m.%d.log" );
 }
 
 void LoggingApp::enableSysLogging()
@@ -64,7 +64,7 @@ void LoggingApp::enableSysLogging()
 	//! This call will enable system logging, which will default to the same logging
 	//! level as console/file logging.
 	
-	auto sysLogger = log::manager()->createLogger<log::LoggerSystem>();
+	auto sysLogger = log::manager()->makeLogger<log::LoggerSystem>();
 	
 	//! This call will set the system logging level independent of the file/console logging level.
 	//! The system logging level can not be lower than the file/console logging.

--- a/samples/Logging/src/LoggingApp.cpp
+++ b/samples/Logging/src/LoggingApp.cpp
@@ -10,14 +10,10 @@ using namespace std;
 
 class LoggingApp : public App {
 	
-	/**
-	 * This sample shows three basic logging use cases:
-	 * - File Logging
-	 * - Rotating File Logging
-	 * - System Logging
-	 *
-	 * Note: only one file logging type can be enabled at a time.
-	 */
+	//! This sample shows three basic logging use cases:
+	//!  - File Logging
+	//!  - Rotating File Logging
+	//!  - System Logging
 	
   public:
 	void setup() override;
@@ -25,70 +21,54 @@ class LoggingApp : public App {
 	void update() override;
 	void draw() override;
 	
-	/** @breif enableFileLogging will enable logging to a given file.
-	 * This file will not rotate, but you can control the file appending. 
-	 */
+	//! enableFileLogging will enable logging to a given file.
+	//! This file will not rotate, but you can control the file appending.
 	void enableFileLogging();
 	
-	/** @breif enableFileLoggingRotating will enable logging to a daily rotating file.
-	 * The file will rotate daily at the first logging event past midnight.
-	 */
+	//! enableFileLoggingRotating will enable logging to a daily rotating file.
+	//! The file will rotate daily at the first logging event past midnight.
 	void enableFileLoggingRotating();
 	
-	/** @breif enableSysLogging will enable platform specific system logging.
- 	 * Currently this means syslog (OS X) and EventLog (Windows).
-	 */
+	//! enableSysLogging will enable platform specific system logging.
+	//! Currently this means syslog (OS X) and EventLog (Windows).
 	void enableSysLogging();
+	
 };
 
 void LoggingApp::setup()
 {
-	/**
-	 * Logging is only supported for one file at a time.  Calling both
-	 * enableFileLogging and enableRotatingFileLogging at the same tile 
-	 * will cause the most recent call to take precedence.
-	 */
-	
-	//enableFileLogging();
+	enableFileLogging();
 	enableFileLoggingRotating();
 	enableSysLogging();
 }
 
 void LoggingApp::enableFileLogging()
 {
-	/**
-	 * This call will append log messages to the file `cinder.log` in the folder
-	 * `/tmp/logging`.  If the folder path `/tmp/logging` does not exist,
-	 * it will be created for you.
-	 */
+	//! This call will append log messages to the file `cinder.log` in the folder `/tmp/logging`.
+	//! If the folder path `/tmp/logging` does not exist, it will be created for you.
 	
-	log::manager()->enableFileLogging( "/tmp/logging/cinder.log", true );
+	log::manager()->createLogger<log::LoggerFile>( "/tmp/logging/cinder.log", true );
 }
 
 void LoggingApp::enableFileLoggingRotating()
 {
-	/**
-	 * This call will append log messages to a rotating file in the folder `/tmp/logging`.
-	 * The filename `cinder.%Y.%m.%d.log` will be evaluated by strftime.  For example
-	 * the filename could evaluate to `cinder.2015.08.28.log`.
-	 */
-	log::manager()->enableFileLoggingRotating( "/tmp/logging", "cinder.%Y.%m.%d.log" );
+	//! This call will append log messages to a rotating file in the folder `/tmp/logging`.
+	//! The filename `cinder.%Y.%m.%d.log` will be evaluated by strftime.  For the example
+	//! below, the filename could evaluate to `cinder.2015.08.28.log`.
+
+	log::manager()->createLogger<log::LoggerFileRotating>( "/tmp/logging", "cinder.%Y.%m.%d.log" );
 }
 
 void LoggingApp::enableSysLogging()
 {
-	/**
-	 * This call will enable system logging, which will default to the same logging 
-	 * level as console/file logging.
-	 */
-	log::manager()->enableSystemLogging();
+	//! This call will enable system logging, which will default to the same logging
+	//! level as console/file logging.
 	
-	/**
-	 * This call will set the system logging level independent of the file/console
-	 * logging level.  The system logging level can not be lower than the
-	 * file/console logging.
-	 */
-	log::manager()->setSystemLoggingLevel(log::LEVEL_WARNING);
+	auto sysLogger = log::manager()->createLogger<log::LoggerSystem>();
+	
+	//! This call will set the system logging level independent of the file/console logging level.
+	//! The system logging level can not be lower than the file/console logging.
+	sysLogger->setLoggingLevel( log::LEVEL_WARNING );
 }
 
 void LoggingApp::mouseDown( MouseEvent event )

--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -102,7 +102,13 @@ void LogManager::clearLoggers()
 {
 	lock_guard<mutex> lock( mMutex );
 	mLoggers.clear();
-	mLoggerConsole = nullptr;
+}
+	
+void LogManager::resetLogger( const LoggerRef& logger )
+{
+	lock_guard<mutex> lock( mMutex );
+	mLoggers.clear();
+	mLoggers.push_back( logger );
 }
 
 void LogManager::addLogger( const LoggerRef& logger )
@@ -110,7 +116,6 @@ void LogManager::addLogger( const LoggerRef& logger )
 	lock_guard<mutex> lock( mMutex );
 	mLoggers.push_back( logger );
 }
-
 
 void LogManager::removeLogger( const LoggerRef& logger )
 {
@@ -125,17 +130,13 @@ void LogManager::removeLogger( const LoggerRef& logger )
 void LogManager::restoreToDefault()
 {
 	clearLoggers();
-	mLoggerConsole = unique_ptr<LoggerConsole>( new LoggerConsole );
+	makeLogger<LoggerConsole>();
 }
 	
 void LogManager::write( const Metadata &meta, const std::string &text )
 {
 	// TODO move this to a shared_lock_timed with c++14 support
 	lock_guard<mutex> lock( mMutex );
-	
-	if( mLoggerConsole ) {
-		mLoggerConsole->write( meta, text );
-	}
 
 	for( auto& logger : mLoggers ) {
 		logger->write( meta, text );

--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -127,6 +127,12 @@ void LogManager::removeLogger( const LoggerRef& logger )
 				   mLoggers.end() );
 }
 
+std::vector<LoggerRef> LogManager::getAllLoggers()
+{
+	lock_guard<mutex> lock( mMutex );
+	return mLoggers;
+}
+	
 void LogManager::restoreToDefault()
 {
 	clearLoggers();

--- a/test/DebugTest/src/DebugTestApp.cpp
+++ b/test/DebugTest/src/DebugTestApp.cpp
@@ -280,11 +280,11 @@ void DebugTestApp::testPerformance()
 	CI_LOG_D( "Single logging took " << ss.str() << " ms / log." );
 
 	ss = stringstream();
-	ss << std::fixed << setprecision(5) << ( run2.duration + run3.duration ) * 1000 / ( run2.hits + run3.hits );
+	ss << std::fixed << setprecision(5) << std::max( run2.duration, run3.duration ) * 1000 / ( run2.hits + run3.hits );
 	CI_LOG_D( "2 threads logging took " << ss.str() << " ms / log." );
 
 	ss = stringstream();
-	ss << std::fixed << setprecision(5) << ( run4.duration + run5.duration + run6.duration ) * 1000 / ( run4.hits + run5.hits + run6.hits );
+	ss << std::fixed << setprecision(5) << std::max( std::max( run4.duration, run5.duration ), run6.duration ) * 1000 / ( run4.hits + run5.hits + run6.hits );
 	CI_LOG_D( "3 threads logging took " << ss.str() << " ms / log." );
 	
 	CI_LOG_I( "\n--- TESTING PERFORMANCE END----\n\n");

--- a/test/DebugTest/src/DebugTestApp.cpp
+++ b/test/DebugTest/src/DebugTestApp.cpp
@@ -3,6 +3,7 @@
 //#define CI_MIN_LOG_LEVEL 1
 
 #include "cinder/Log.h"
+#include <sstream>
 
 #define CI_ASSERT_DEBUG_BREAK
 #include "cinder/CinderAssert.h"
@@ -15,17 +16,14 @@ class DebugTestApp : public App {
 	void setup();
 
     void testLevels();
-	void testEnableFileLogger();
-	void testEnableSysLogger();
-	void testEnableBadFilePath();
-	void testRotatingFile();
-	void testEnableDisable();
-	void testSystemLevel();
-	void testAddFile();
+	void testFileLogging();
+	void testSystemLogging();
+	void testFindLoggers();
 	void testAddRemove();
+	void testThreadSafety();
 	void testAsserts();
+	void testPerformance();
 	void testBreakOnLog();
-    void testRestore();
 
 	void keyDown( KeyEvent event );
 
@@ -33,41 +31,169 @@ class DebugTestApp : public App {
 
 void DebugTestApp::setup()
 {
-    testLevels();
-    //testEnableFileLogger();
-    //testEnableSysLogger();
-    //testEnableBadFilePath();
-    //testEnableDisable();
-    //testAddRemove();
-    testRotatingFile();
-    //testSystemLevel();
-    //testAddFile();
-    //testAsserts();
-    //testBreakOnLog();
-    //testRestore();
-}
+	/*
+	testLevels();
+	testFileLogging();
+	testSystemLogging();
 
-void DebugTestApp::testRestore()
-{
-    log::manager()->enableSystemLogging();
-    log::manager()->setSystemLoggingLevel(log::LEVEL_ERROR);
-    CI_LOG_E( "Error log shows in system logs" );
-    CI_LOG_D( "Debug log doesn't show in system logs.");
-    log::manager()->restoreToDefault();
-    log::manager()->enableSystemLogging();
-    CI_LOG_E( "Error log shows in system logs" );
-    CI_LOG_D( "Debug log shows in system logs.");
-    
+	testAsserts();
+	
+	testFindLoggers();
+	testAddRemove();*/
+	
+	// WARNING: don't run these two unless you have 500 MB free disk space
+	//testThreadSafety();
+	testPerformance();
+	
+	//testBreakOnLog();
 }
 
 void DebugTestApp::testLevels()
 {
-    CI_LOG_V( "verbose" );
-    CI_LOG_D( "debug" );
-    CI_LOG_I( "info" );
-    CI_LOG_W( "warning" );
-    CI_LOG_E( "error" );
-    CI_LOG_F( "fatal" );
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING LEVELS START----");
+	
+	CI_LOG_V( "verbose" );
+	CI_LOG_D( "debug" );
+	CI_LOG_I( "info" );
+	CI_LOG_W( "warning" );
+	CI_LOG_E( "error" );
+	CI_LOG_F( "fatal" );
+	
+	CI_LOG_I( "\n--- TESTING LEVELS END----\n\n");
+}
+
+void DebugTestApp::testFileLogging()
+{
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING FILES START----");
+	
+	
+	log::manager()->makeLogger<log::LoggerFile>( "/tmp/cinder/cinder.log" );
+	log::manager()->makeLogger<log::LoggerFile>( "/tmp/cinder/ggg__Idontexist___/cinder.log" );
+	log::manager()->makeLogger<log::LoggerFileRotating>( "/tmp/cinder", "loggingTests.%Y.%m.%d.log", false );
+
+	CI_LOG_I( "This output should be in three logs." );
+	CI_LOG_I( "\n--- TESTING FILES END----\n\n");
+}
+
+void DebugTestApp::testSystemLogging()
+{
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING SYSTEM START----");
+	
+	auto sysLog = log::manager()->makeLogger<log::LoggerSystem>();
+    sysLog->setLoggingLevel( log::LEVEL_ERROR );
+    CI_LOG_E( "Error log shows in system logs" );
+    CI_LOG_D( "Debug log doesn't show in system logs.");
+	
+    log::manager()->restoreToDefault();
+    log::manager()->makeLogger<log::LoggerSystem>();
+    CI_LOG_E( "Error log shows in system logs" );
+    CI_LOG_D( "Debug log shows in system logs.");
+	
+	CI_LOG_I( "\n--- TESTING SYSTEM END----\n\n");
+}
+
+void DebugTestApp::testFindLoggers()
+{
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING FIND START----");
+	
+	log::manager()->makeLogger<log::LoggerConsole>();
+	log::manager()->makeLogger<log::LoggerConsole>();
+	
+	CI_ASSERT( 3 == log::manager()->getLoggers<log::LoggerConsole>().size() );
+	CI_ASSERT( 3 == log::manager()->getAllLoggers().size() );
+	
+	auto logger = log::Logger::makeLogger<log::LoggerFile>( "/tmp/cinder/cinder.log" );
+	log::manager()->addLogger( logger );
+	log::manager()->makeLogger<log::LoggerFile>( "/tmp/cinder/cinder.log" );
+	
+	CI_ASSERT( 3 == log::manager()->getLoggers<log::LoggerConsole>().size() );
+	CI_ASSERT( 2 == log::manager()->getLoggers<log::LoggerFile>().size() );
+	CI_ASSERT( 0 == log::manager()->getLoggers<log::LoggerBreakpoint>().size() );
+	CI_ASSERT( 5 == log::manager()->getAllLoggers().size() );
+	
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "Logger searching passed." );
+	CI_LOG_I( "\n--- TESTING FIND END----\n\n");
+}
+
+void DebugTestApp::testAddRemove()
+{
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING ADD/REMOVE START----");
+	
+	log::manager()->clearLoggers();
+	
+	auto logger1 = log::manager()->makeLogger<log::LoggerConsole>();
+	auto logger2 = log::manager()->makeLogger<log::LoggerConsole>();
+
+	CI_LOG_I( "This should  show up in the console twice." );
+	
+	auto logger3 = log::manager()->makeLogger<log::LoggerConsole>();
+	auto logger4 = log::manager()->makeLogger<log::LoggerConsole>();
+	auto logger5 = log::Logger::makeLogger<log::LoggerConsole>();
+	
+	log::manager()->removeLogger( logger1 );
+	log::manager()->removeLogger( logger1 );
+	log::manager()->removeLogger( logger1 );
+
+	log::manager()->removeLogger( logger2 );
+	log::manager()->removeLogger( logger3 );
+	
+	log::manager()->addLogger( logger2 );
+	
+	log::manager()->removeLogger( logger4 );
+	log::manager()->removeLogger( logger5 );
+	log::manager()->removeLogger( nullptr );
+	
+	CI_LOG_I( "This should only show up in the console once." );
+	
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING ADD/REMOVE END----\n\n");
+}
+
+void DebugTestApp::testThreadSafety()
+{
+
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING THREADS START----");
+	CI_LOG_I( "... this may take a while, don't fret." );
+	
+	log::manager()->clearLoggers();
+	
+	auto looper = [](std::string log) {
+		auto logger = log::manager()->makeLogger<log::LoggerFile>( log, false );
+		for( int i=0; i<500; ++i ) {
+			for( int j=0; j<500; ++j ) {
+				CI_LOG_D( i * j );
+			}
+			log::manager()->removeLogger( logger );
+			log::manager()->addLogger( logger );
+		}
+		
+		// clean up our mess
+		auto path = logger->getFilePath();
+		log::manager()->removeLogger( logger );
+		logger.reset();
+		fs::remove( path );
+	};
+	
+	std::thread t1( [looper] () { looper( "/tmp/thread1.log" ); } );
+	std::thread t2( [looper] () { looper( "/tmp/thread2.log" ); } );
+	std::thread t3( [looper] () { looper( "/tmp/thread3.log" ); } );
+	
+	t1.join();
+	t2.join();
+	t3.join();
+
+	log::manager()->clearLoggers();
+	log::manager()->makeLogger<log::LoggerConsole>();
+	
+	CI_LOG_I( "Threading didn't crash." );
+	CI_LOG_I( "\n--- TESTING THREADS END----\n\n");
 }
 
 void DebugTestApp::testAsserts()
@@ -81,10 +207,96 @@ void DebugTestApp::testAsserts()
 //	CI_ASSERT_MSG( false, "blarg" );
 }
 
+void DebugTestApp::testPerformance()
+{
+	
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING PERFORMANCE START----");
+	CI_LOG_I( "... this may take a while, don't fret." );
+	
+	log::manager()->clearLoggers();
+	
+	typedef struct {
+		double duration;
+		int hits;
+	} LogMeasure;
+	
+	auto looper = [](std::string log, LogMeasure &stats ) {
+		
+		shared_ptr<log::LoggerFile> logger = nullptr;
+		if( !log.empty() ) {
+			logger = log::manager()->makeLogger<log::LoggerFile>( log, false );
+		}
+		int logHits = 0;
+		ci::Timer timer;
+		timer.start();
+		for( int i=0; i<1000; ++i ) {
+			for( int j=0; j<1000; ++j ) {
+				CI_LOG_D( ++logHits );
+			}
+		}
+		timer.stop();
+		
+		if( logger ) {
+			// clean up our mess
+			auto path = logger->getFilePath();
+			log::manager()->removeLogger( logger );
+			logger.reset();
+			fs::remove( path );
+		}
+
+		stats.hits = logHits;
+		stats.duration = timer.getSeconds();
+	};
+	
+	LogMeasure run1, run2, run3, run4, run5, run6;
+	
+	// test single log single thread
+	looper( "/tmp/performance.log", run1 );
+	
+	// test two threads single log
+	std::thread t1( [ looper, &run2 ] () { looper( "/tmp/performance.log", run2 ); } );
+	std::thread t2( [ looper, &run3 ] () { looper( "", run3 ); } );
+	
+	t1.join();
+	t2.join();
+
+	// test three threads single log
+	std::thread t3( [ looper, &run4 ] () { looper( "/tmp/performance.log", run4 ); } );
+	std::thread t4( [ looper, &run5 ] () { looper( "", run5 ); } );
+	std::thread t5( [ looper, &run6 ] () { looper( "", run6 ); } );
+	
+	t3.join();
+	t4.join();
+	t5.join();
+	
+	log::manager()->clearLoggers();
+	log::manager()->makeLogger<log::LoggerConsole>();
+	
+	
+	stringstream ss;
+
+	ss << std::fixed << setprecision(5) << (run1.duration * 1000 / run1.hits) ;
+	CI_LOG_D( "Single logging took " << ss.str() << " ms / log." );
+
+	ss = stringstream();
+	ss << std::fixed << setprecision(5) << ( run2.duration + run3.duration ) * 1000 / ( run2.hits + run3.hits );
+	CI_LOG_D( "2 threads logging took " << ss.str() << " ms / log." );
+
+	ss = stringstream();
+	ss << std::fixed << setprecision(5) << ( run4.duration + run5.duration + run6.duration ) * 1000 / ( run4.hits + run5.hits + run6.hits );
+	CI_LOG_D( "3 threads logging took " << ss.str() << " ms / log." );
+	
+	CI_LOG_I( "\n--- TESTING PERFORMANCE END----\n\n");
+}
+
 void DebugTestApp::testBreakOnLog()
 {
-	log::manager()->enableBreakOnError();
-    //log::manager()->enableBreakOnLevel( log::LEVEL_DEBUG );
+	log::manager()->restoreToDefault();
+	CI_LOG_I( "\n--- TESTING BREAKPOINTS START----");
+	
+	auto bLog = log::manager()->makeLogger<log::LoggerBreakpoint>();
+    bLog->setTriggerLevel( log::LEVEL_DEBUG );
 
 	CI_LOG_V( "bang" );
 	CI_LOG_D( "bang" );
@@ -94,88 +306,8 @@ void DebugTestApp::testBreakOnLog()
 	CI_LOG_F( "bang" );
 }
 
-void DebugTestApp::testEnableFileLogger()
-{
-//	log::manager()->enableFileLogging();
-
-	log::manager()->enableFileLogging( "/tmp/blarg/cinder.log" );
-//	log::manager()->enableFileLogging( "/tmp", "loggingTests.%Y.%m.%d.log", false );
-//	log::manager()->enableFileLogging( "/tmp/cinder", "loggingTests.%Y.%m.%d.log", false );
-
-	CI_LOG_I( "enabled file logging" );
-}
-
-void DebugTestApp::testRotatingFile()
-{
-    log::manager()->enableFileLoggingRotating( "/tmp", "loggingTests.%Y.%m.%d.log" );
-
-	// empty formatStr causes an assertion failure:
-    //log::manager()->enableFileLoggingRotating( "", "", false );
-
-	// test nested folder path:
-    //log::manager()->enableFileLoggingRotating( "/tmp/cinder", "loggingTests.%Y.%m.%d.log", false );
-	
-	CI_LOG_D( "enable rotating file logging" );
-}
-
-void DebugTestApp::testEnableSysLogger()
-{
-	log::manager()->enableSystemLogging();
-	CI_LOG_I( "enabled system logging" );
-	CI_LOG_V( "verbose message" );
-	CI_LOG_D( "debug message" );
-}
-
-void DebugTestApp::testSystemLevel()
-{
-	log::manager()->enableSystemLogging();
-	log::manager()->setSystemLoggingLevel(log::LEVEL_ERROR);
-	CI_LOG_I( "This should not show up in the sys log." );
-	CI_LOG_D( "This should not show up in the sys log." );
-	CI_LOG_E( "This should show up in the sys log." );
-	log::manager()->setSystemLoggingLevel(log::LEVEL_VERBOSE);
-	CI_LOG_V( "This should show up in the sys log as well." );
-	CI_LOG_D( "This should show up in the sys log as well." );
-}
-
-void DebugTestApp::testEnableDisable()
-{
-	log::manager()->enableFileLogging();
-	CI_LOG_I( "enabled file logger" );
-
-	log::manager()->disableFileLogging();
-	CI_LOG_I( "disable file logger" );
-}
-
-void DebugTestApp::testAddFile()
-{
-	log::manager()->addLogger( new log::LoggerFileThreadSafe );
-
-	CI_LOG_I( "added file logger" );
-}
-
-void DebugTestApp::testAddRemove()
-{
-    auto logger = new log::LoggerSystem;
-    log::manager()->addLogger( logger );
-    
- 	CI_LOG_I( "added LoggerSystem" );
- 	log::manager()->removeLogger( logger );
- 	CI_LOG_I( "removed LoggerSystem" );
-}
-
-void DebugTestApp::testEnableBadFilePath()
-{
-    // will fail
-	log::manager()->enableFileLogging( "/blah/__THISDOESNOTEXIST_gf5jk313__/tmp/cinder.log" );
-	
-	CI_LOG_I( "This will fail when it tries to create a path that it can not create." );
-}
-
-
 void DebugTestApp::keyDown( KeyEvent event )
 {
-	auto loggers = log::manager()->getAllLoggers();
 	CI_LOG_I( "event char: " << event.getChar() << ", code: " << event.getCode() );
 }
 


### PR DESCRIPTION
Related to #1107

#### Tasks completed in this rewrite
* LogManager's enable/disable routines were removed
* LogManager's interface was standardized with addLogger and removeLogger, etc
* LoggerMulti was removed and replaced with an internal vector of Loggers
* DebugTest was rewritten to be an easier to use test case
* Logger example updated
* Restructured locking so that there is no risk of crash, and wrote test case to confirm this

#### Performance
The good news is we now prevent a crash when adding and removing loggers from threads.  I confirmed the crash exists in the main branch, and confirmed the crash is fixed in this PR.

The bad news is that, in order to stop this crash, we had to move the lock mutex to the lowest level write() routine.  This really starts to show when you are logging from multiple threads.  

_For tests below, each thread logged 1 million times to a single log file._

##### Main branch (localized locks, not thread safe)
```
|debug  | void DebugTestApp::testPerformance()[244] Single logging took 0.01393 ms / log.
|debug  | void DebugTestApp::testPerformance()[248] 2 threads logging took 0.02628 ms / log.
|debug  | void DebugTestApp::testPerformance()[252] 3 threads logging took 0.06138 ms / log.
```

##### This branch (lock in write(), thread safe)
```
|debug  | void DebugTestApp::testPerformance()[280] Single logging took 0.01441 ms / log.
|debug  | void DebugTestApp::testPerformance()[284] 2 threads logging took 0.06125 ms / log.
|debug  | void DebugTestApp::testPerformance()[288] 3 threads logging took 0.10274 ms / log.
```

This is, of course, probably worse case since my test case has multiple threads logging from within loops.  I think we'll be able to improve this considerably when we can introduce shared_locks into the code base.