### PR TITLE
Support App Transport Security on iOS

### DIFF
--- a/samples/Kaleidoscope/xcode_ios/Instascope-Info.plist
+++ b/samples/Kaleidoscope/xcode_ios/Instascope-Info.plist
@@ -24,6 +24,17 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>api.instagram.com</key>
+			<dict>
+				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSMainNibFile</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
Bring over c56a404 from the OS X Kaleidoscope project for iOS - it appears as though Kaleidoscope is the only iOS sample that requests a URL. Tested with the Xcode 7.1 Beta 2 / iOS 9 simulator.

The Kaleidoscope project also needs to link to the Accelerate framework, but I ran into another issue building with Xcode 7.x and I'm thinking many of the iOS samples need updates.

The `cinder_iphone_sim` scheme of the Cinder project itself seems to have gone sideways and refuses to build with Xcode 7.x. To work around it to test this particular issue, I killed the `cinder_iphone_sim` scheme and simplified to have the `cinder_iphone` scheme support both the device and simulator, `lipo`'ed the `lib/ios/` and `lib/ios-sim` boost libs together, and then simplified the Kaleidoscope project settings to link to:
- `libcinder-iphone_d.a`
- `libcinder-iphone.a`