### PR TITLE
Double quote HTML attributes in doc sources

### DIFF
--- a/docs/htmlsrc/guides/_start-here/start-here.html
+++ b/docs/htmlsrc/guides/_start-here/start-here.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/anatomy/index.html
+++ b/docs/htmlsrc/guides/anatomy/index.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		
 	</head>

--- a/docs/htmlsrc/guides/audio/index.html
+++ b/docs/htmlsrc/guides/audio/index.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/boost/index.html
+++ b/docs/htmlsrc/guides/boost/index.html
@@ -14,7 +14,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/cinder-blocks/index.html
+++ b/docs/htmlsrc/guides/cinder-blocks/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../../_assets/css/foundation.css">
     <link rel="stylesheet" href="../../_assets/css/prism.css">
     <link rel="stylesheet" href="../../_assets/css/style.css">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+    <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
     	
   </head>
 <body>

--- a/docs/htmlsrc/guides/cinder-images/index.html
+++ b/docs/htmlsrc/guides/cinder-images/index.html
@@ -16,7 +16,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/docs/building_docs.html
+++ b/docs/htmlsrc/guides/docs/building_docs.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/docs/documenting_cinder.html
+++ b/docs/htmlsrc/guides/docs/documenting_cinder.html
@@ -13,7 +13,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		<style type="text/css">
@@ -30,7 +30,7 @@
 
 		<h1>Documenting Cinder</h1>
 		
-		<p>As an open source project, the Cinder community welcomes anyone interested in helping to document the library and/or write guides to help other developers progress their understanding of the library. There are many different ways to contribute to this documentation and this guide is meant to walk through those different avenues. You may want to take a look at the <a href='building_docs.html'>Building Docs guide</a> before reading this one.</p>
+		<p>As an open source project, the Cinder community welcomes anyone interested in helping to document the library and/or write guides to help other developers progress their understanding of the library. There are many different ways to contribute to this documentation and this guide is meant to walk through those different avenues. You may want to take a look at the <a href="building_docs.html">Building Docs guide</a> before reading this one.</p>
 
 		<section>
 			<a name="anatomy"></a>

--- a/docs/htmlsrc/guides/flocking/chapter1.html
+++ b/docs/htmlsrc/guides/flocking/chapter1.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/flocking/chapter2.html
+++ b/docs/htmlsrc/guides/flocking/chapter2.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="../../_assets/css/foundation.css">
     <link rel="stylesheet" href="../../_assets/css/prism.css">
     <link rel="stylesheet" href="../../_assets/css/style.css">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+    <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
     <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
     

--- a/docs/htmlsrc/guides/flocking/chapter3.html
+++ b/docs/htmlsrc/guides/flocking/chapter3.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="../../_assets/css/foundation.css">
     <link rel="stylesheet" href="../../_assets/css/prism.css">
     <link rel="stylesheet" href="../../_assets/css/style.css">
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+    <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
     <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
     

--- a/docs/htmlsrc/guides/flocking/chapter4.html
+++ b/docs/htmlsrc/guides/flocking/chapter4.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="../../_assets/css/foundation.css">
         <link rel="stylesheet" href="../../_assets/css/prism.css">
         <link rel="stylesheet" href="../../_assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+        <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
         <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
         

--- a/docs/htmlsrc/guides/flocking/chapter5.html
+++ b/docs/htmlsrc/guides/flocking/chapter5.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="../../_assets/css/foundation.css">
         <link rel="stylesheet" href="../../_assets/css/prism.css">
         <link rel="stylesheet" href="../../_assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+        <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
         <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
         

--- a/docs/htmlsrc/guides/git/index.html
+++ b/docs/htmlsrc/guides/git/index.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		<link rel="stylesheet" type="text/css" href="../_common/js/jquery.lightbox-0.5.css" media="screen" />		

--- a/docs/htmlsrc/guides/gl/fbo/index.html
+++ b/docs/htmlsrc/guides/gl/fbo/index.html
@@ -12,7 +12,7 @@
       <link rel="stylesheet" href="../../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
       
    </head>
 

--- a/docs/htmlsrc/guides/graphics/index.html
+++ b/docs/htmlsrc/guides/graphics/index.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/ios-notes/index.html
+++ b/docs/htmlsrc/guides/ios-notes/index.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/mac-setup/index.html
+++ b/docs/htmlsrc/guides/mac-setup/index.html
@@ -9,7 +9,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>		
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 	</head>
 
 	<body id="guide-contents" class="language-c++">
@@ -24,22 +24,22 @@
 		<p>To test your installation, we'll build one of the samples. From the Finder, navigate to the <em>samples/_opengl/CubeMapping</em> folder and open <em>xcode/CubeMapping.xcodeproj</em> by double-clicking it. From the <strong>Product</strong> menu select the <strong>Run</strong> item. Xcode will take a few seconds to build the sample and then it should launch and look similar to the screenshot below.</p>
 
 		<center><img class="shadow" alt="CubeMapping Sample" src="images/cubemapping_sample.jpg"></center>
-		
+
 		<br />
-		
+
 		<h2>Creating New Projects</h2>
 		<p><a href="../tinderbox/index.html">TinderBox</a> is Cinder's GUI tool for creating new projects quickly and easily. A guide to creating projects using TinderBox is <a href="../tinderbox/index.html">available here</a>.</p>
 
 		<h2>Debug Symbols</h2>
 		<p>While not strictly necessary, if you're working from a prepackaged release and would like to be able to step into Cinder's own code during your debug process, you'll want to build Cinder with debug symbols. This is straightforward - just open <em>xcode/cinder.xcodeproj</em> in XCode and build the Debug configuration for the Cinder target. If you are doing iOS development you'll want to do the same thing for the <em>cinder_iphone</em> and <em>cinder_iphone_sim</em> targets.</p>
-				
+
 		<h2>Cinder + Git</h2>
 		<p>If you would like to keep up with the latest Cinder development, the project is <a href="http://github.com/cinder">hosted on github</a>. A guide for setting up Cinder using git is <a href="../git/index.html">available here</a>.</p>
-		
+
 		<!-- END CONTENT -->
 
 		<!-- Scripts -->
 		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
 
 	</body>
-</html> 
+</html>

--- a/docs/htmlsrc/guides/opengl/further_reading.html
+++ b/docs/htmlsrc/guides/opengl/further_reading.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 	</head>
 
 <body id="guide-contents" >

--- a/docs/htmlsrc/guides/opengl/index.html
+++ b/docs/htmlsrc/guides/opengl/index.html
@@ -13,7 +13,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/opengl/part1.html
+++ b/docs/htmlsrc/guides/opengl/part1.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 	</head>
 
 <body id="guide-contents" >

--- a/docs/htmlsrc/guides/opengl/part2.html
+++ b/docs/htmlsrc/guides/opengl/part2.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 	</head>
 
 <body id="guide-contents" >

--- a/docs/htmlsrc/guides/opengl/part3.html
+++ b/docs/htmlsrc/guides/opengl/part3.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 	</head>
 
 <body id="guide-contents" >

--- a/docs/htmlsrc/guides/opengl/part4.html
+++ b/docs/htmlsrc/guides/opengl/part4.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 	</head>
 
 <body id="guide-contents" >

--- a/docs/htmlsrc/guides/opengl/part5.html
+++ b/docs/htmlsrc/guides/opengl/part5.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 	</head>
 
 <body id="guide-contents" >

--- a/docs/htmlsrc/guides/osx-notes/index.html
+++ b/docs/htmlsrc/guides/osx-notes/index.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/path2d/part1.html
+++ b/docs/htmlsrc/guides/path2d/part1.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="../../_assets/css/foundation.css">
         <link rel="stylesheet" href="../../_assets/css/prism.css">
         <link rel="stylesheet" href="../../_assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+        <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
         <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
         <link rel="stylesheet" href="path2d.css">

--- a/docs/htmlsrc/guides/path2d/part2.html
+++ b/docs/htmlsrc/guides/path2d/part2.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="../../_assets/css/foundation.css">
         <link rel="stylesheet" href="../../_assets/css/prism.css">
         <link rel="stylesheet" href="../../_assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+        <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
         <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
         <link rel="stylesheet" href="path2d.css">

--- a/docs/htmlsrc/guides/path2d/part3.html
+++ b/docs/htmlsrc/guides/path2d/part3.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="../../_assets/css/foundation.css">
         <link rel="stylesheet" href="../../_assets/css/prism.css">
         <link rel="stylesheet" href="../../_assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+        <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
         <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
         <link rel="stylesheet" href="path2d.css">

--- a/docs/htmlsrc/guides/resources/index.html
+++ b/docs/htmlsrc/guides/resources/index.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/screensavers/index.html
+++ b/docs/htmlsrc/guides/screensavers/index.html
@@ -13,7 +13,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/tinderbox/index.html
+++ b/docs/htmlsrc/guides/tinderbox/index.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/tour/hello_cinder.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/tour/hello_cinder_chapter1.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder_chapter1.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/tour/hello_cinder_chapter2.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder_chapter2.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/tour/hello_cinder_chapter3.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder_chapter3.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/tour/hello_cinder_chapter4.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder_chapter4.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/tour/hello_cinder_chapter5.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder_chapter5.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/guides/transition_0_9/index.html
+++ b/docs/htmlsrc/guides/transition_0_9/index.html
@@ -7,7 +7,7 @@
 	<link rel="stylesheet" href="../../_assets/css/foundation.css">
 	<link rel="stylesheet" href="../../_assets/css/prism.css">
 	<link rel="stylesheet" href="../../_assets/css/style.css">
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+	<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 </head>
 <body id="guide-contents" >
 <h1>Cinder 0.9 Transition Guide</h1>

--- a/docs/htmlsrc/guides/windows-notes/index.html
+++ b/docs/htmlsrc/guides/windows-notes/index.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/windows-setup/MSWNewProject.html
+++ b/docs/htmlsrc/guides/windows-setup/MSWNewProject.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/windows-setup/index.html
+++ b/docs/htmlsrc/guides/windows-setup/index.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="../../_assets/css/foundation.css">
         <link rel="stylesheet" href="../../_assets/css/prism.css">
         <link rel="stylesheet" href="../../_assets/css/style.css">
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+        <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
         <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
         

--- a/docs/htmlsrc/guides/winrt-notes/index.html
+++ b/docs/htmlsrc/guides/winrt-notes/index.html
@@ -15,7 +15,7 @@
 		<link rel="stylesheet" href="../../_assets/css/foundation.css">
 		<link rel="stylesheet" href="../../_assets/css/prism.css">
 		<link rel="stylesheet" href="../../_assets/css/style.css">
-		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
 		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
 		

--- a/docs/htmlsrc/guides/xml-tree/index.html
+++ b/docs/htmlsrc/guides/xml-tree/index.html
@@ -15,7 +15,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       

--- a/docs/htmlsrc/search.html
+++ b/docs/htmlsrc/search.html
@@ -8,7 +8,7 @@
       <link rel="stylesheet" href="../../_assets/css/foundation.css">
       <link rel="stylesheet" href="../../_assets/css/prism.css">
       <link rel="stylesheet" href="../../_assets/css/style.css">
-      <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+      <link href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css">
 
       <!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
       


### PR DESCRIPTION
This change just resolves the issue when editing the HTML source files, it appears as though the generator fixes the issue at build time so it isn't seen by doc consumers.