### PR TITLE
More name normalization GitHub, Xcode and QuickTime

### DIFF
--- a/docs/htmlsrc/guides/boost/index.html
+++ b/docs/htmlsrc/guides/boost/index.html
@@ -36,7 +36,7 @@
          <a class="anchor" id="setup"></a>
          <h2>Setting up Boost</h2>
          
-         <p>Cinder ships with the required binaries for Boost and in general you should not need to build Boost itself, even if you're working from Github. However if you would like to upgrade your copy of Boost from the included version, these instructions will guide you through the process.</p>
+         <p>Cinder ships with the required binaries for Boost and in general you should not need to build Boost itself, even if you're working from GitHub. However if you would like to upgrade your copy of Boost from the included version, these instructions will guide you through the process.</p>
 
          <p>If you want to download the same version as the one we're using in Cinder, grab version 1.58. You can do so from this site: <a href="http://www.boost.org/users/download/">www.boost.org/users/download/</a></p>
       </section>

--- a/docs/htmlsrc/guides/index.html
+++ b/docs/htmlsrc/guides/index.html
@@ -52,7 +52,7 @@
 				<li><a href="audio/index.html">Audio in Cinder</a></li>
 				<li><a href="path2d/part1.html">Path2d</a></li>
 	            <li><a href="xml-tree/index.html">XML in Cinder</a></li>
-				<li><a href="movie-writer/index.html">Quicktime MovieWriter (Out of date)</a></li>
+				<li><a href="movie-writer/index.html">QuickTime MovieWriter (Out of date)</a></li>
 				
 			</ul>
 		</div>

--- a/docs/htmlsrc/guides/mac-setup/index.html
+++ b/docs/htmlsrc/guides/mac-setup/index.html
@@ -17,9 +17,9 @@
 		<!-- CONTENT STARTS HERE -->
 
 		<h1>OS X Setup</h1>
-		<p>This short guide will walk you through getting Cinder running on your OS X machine. You'll need XCode 5.1.1 or later. In general this is best installed through the App Store, and is <a href="https://itunes.apple.com/us/app/xcode/id497799835?mt=12">available here</a>.</p>
+		<p>This short guide will walk you through getting Cinder running on your OS X machine. You'll need Xcode 5.1.1 or later. In general this is best installed through the App Store, and is <a href="https://itunes.apple.com/us/app/xcode/id497799835?mt=12">available here</a>.</p>
 
-		<p>If you are using one of our <a href="http://libcinder.org/download/">packaged releases</a>, you already have everything you need. If you're working from github you'll want to follow the build instructions in our <a href="../git/index.html">Cinder + Git</a> guide.</p>
+		<p>If you are using one of our <a href="http://libcinder.org/download/">packaged releases</a>, you already have everything you need. If you're working from GitHub you'll want to follow the build instructions in our <a href="../git/index.html">Cinder + Git</a> guide.</p>
 
 		<p>To test your installation, we'll build one of the samples. From the Finder, navigate to the <em>samples/_opengl/CubeMapping</em> folder and open <em>xcode/CubeMapping.xcodeproj</em> by double-clicking it. From the <strong>Product</strong> menu select the <strong>Run</strong> item. Xcode will take a few seconds to build the sample and then it should launch and look similar to the screenshot below.</p>
 
@@ -31,10 +31,10 @@
 		<p><a href="../tinderbox/index.html">TinderBox</a> is Cinder's GUI tool for creating new projects quickly and easily. A guide to creating projects using TinderBox is <a href="../tinderbox/index.html">available here</a>.</p>
 
 		<h2>Debug Symbols</h2>
-		<p>While not strictly necessary, if you're working from a prepackaged release and would like to be able to step into Cinder's own code during your debug process, you'll want to build Cinder with debug symbols. This is straightforward - just open <em>xcode/cinder.xcodeproj</em> in XCode and build the Debug configuration for the Cinder target. If you are doing iOS development you'll want to do the same thing for the <em>cinder_iphone</em> and <em>cinder_iphone_sim</em> targets.</p>
+		<p>While not strictly necessary, if you're working from a prepackaged release and would like to be able to step into Cinder's own code during your debug process, you'll want to build Cinder with debug symbols. This is straightforward - just open <em>xcode/cinder.xcodeproj</em> in Xcode and build the Debug configuration for the Cinder target. If you are doing iOS development you'll want to do the same thing for the <em>cinder_iphone</em> and <em>cinder_iphone_sim</em> targets.</p>
 				
 		<h2>Cinder + Git</h2>
-		<p>If you would like to keep up with the latest Cinder development, the project is <a href="http://github.com/cinder">hosted on github</a>. A guide for setting up Cinder using git is <a href="../git/index.html">available here</a>.</p>
+		<p>If you would like to keep up with the latest Cinder development, the project is <a href="https://github.com/cinder">hosted on GitHub</a>. A guide for setting up Cinder using git is <a href="../git/index.html">available here</a>.</p>
 		
 		<!-- END CONTENT -->
 

--- a/docs/htmlsrc/guides/movie-writer/index.html
+++ b/docs/htmlsrc/guides/movie-writer/index.html
@@ -2,7 +2,7 @@
 <html>
    <head>
       <!-- Update title -->
-      <title>Quicktime MovieWriter Guide</title>
+      <title>QuickTime MovieWriter Guide</title>
 
       <!-- keywords used for searching -->
       <meta name="keywords" content="quicktime">
@@ -19,7 +19,7 @@
 
       <!-- CONTENT STARTS HERE -->
 
-      <h1>Quicktime MovieWriter Guide</h1>
+      <h1>QuickTime MovieWriter Guide</h1>
       
       <h2>Introduction</h2>
       <p>Cinder makes writing QuickTime movies a straightforward task via the <ci>qtime::MovieWriter</ci> class. Creating a basic QuickTime movie is easy, and <ci>qtime::MovieWriter</ci> also exposes more advanced options which allow you to take full advantage of the features of modern codecs like <a href="http://en.wikipedia.org/wiki/H.264/MPEG-4_AVC">H.264</a>. <br />

--- a/docs/htmlsrc/guides/windows-setup/index.html
+++ b/docs/htmlsrc/guides/windows-setup/index.html
@@ -36,7 +36,7 @@
             <p>The first step is to install Visual C++ itself - click the <em>Download Community Free</em> button on the <a href="https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx">Visual Studio download page</a>. Next, launch the installer. Make sure that the Visual C++ option is selected under <em>Programming Languages</em> and press the <em>Install</em> button.
             </p>
 
-            <p>If you are using one of our <a href="http://libcinder.org/download/">packaged releases</a>, you should be all set. If you're working from github you'll want to follow the build instructions in our <a href="GitSetup.html">Cinder + Git</a> guide.</p>
+            <p>If you are using one of our <a href="http://libcinder.org/download/">packaged releases</a>, you should be all set. If you're working from GitHub you'll want to follow the build instructions in our <a href="GitSetup.html">Cinder + Git</a> guide.</p>
             
             <p>To verify your installation, try opening and building one of the samples. From Windows Explorer, navigate to the <em>cinder\samples\_opengl\CubeMapping\vc2013</em> folder and open <em>CubeMapping.sln</em>.</p>
             
@@ -57,7 +57,7 @@
 
         <section>    
         <h2>Cinder + Git</h2>
-            <p>If you would like to keep up with the latest Cinder development, the project is <a href="http://github.com/cinder">hosted on github</a>. A guide for setting up Cinder using git is <a href="GitSetup.html">available here</a>.</p>
+            <p>If you would like to keep up with the latest Cinder development, the project is <a href="https://github.com/cinder">hosted on GitHub</a>. A guide for setting up Cinder using git is <a href="GitSetup.html">available here</a>.</p>
         </section>
 
         <script type="text/javascript" src="../_common/js/jquery-1.4.2.min.js"></script>

--- a/docs/htmlsrc/index.html
+++ b/docs/htmlsrc/index.html
@@ -121,7 +121,7 @@
 				<!-- sample links -->
 				<div class="columns large-12 content">
 					<label>Samples</label>
-					<p>Cinder ships with numerous <a href="http://github.com/cinder/Cinder/tree/master/samples">samples</a> which are designed to demonstrate specific features of the library. Studying these samples is one one of the most direct routes for learning Cinder. A few examples:</p>
+					<p>Cinder ships with numerous <a href="https://github.com/cinder/Cinder/tree/master/samples">samples</a> which are designed to demonstrate specific features of the library. Studying these samples is one one of the most direct routes for learning Cinder. A few examples:</p>
 				</div>
 			</div>
 			<ul class="row samples fancy">


### PR DESCRIPTION
Apparently my previous regex attempt still missed a bunch of cases of GitHub, Xcode and I've also added QuickTime to the mix as well as using https github links where relevant.