### PR TITLE
Fix broken CinderBlocks guide render

### DIFF
--- a/docs/htmlsrc/guides/cinder-blocks/index.html
+++ b/docs/htmlsrc/guides/cinder-blocks/index.html
@@ -66,7 +66,7 @@
   
     <div>
       <p>Every CinderBlock must have a file named <em>cinderblock.xml</em> in its root.
-      This file enumerates the files and dependencies of the CinderBlock using XML of the following form:
+      This file enumerates the files and dependencies of the CinderBlock using XML of the following form:</p>
     </div>
   
 <pre><code class="language-markup">
@@ -214,7 +214,7 @@
     <div>
       <strong>&nbsp;
       "replaceContents"</strong><strong>&nbsp;(boolean)</strong><strong>:</strong>&nbsp;When&nbsp;<em>true</em>, the
-      string&nbsp;<span style="white-space: pre;">em>_TBOX_PREFIX_</em> is replaced with the
+      string&nbsp;<span style="white-space: pre;"><em>_TBOX_PREFIX_</em> is replaced with the
       project's name throughout the file's contents</span><br />
     </div>
   
@@ -501,7 +501,7 @@
     <ul style="">
       <li>
           Libraries should be universal binaries, supporting the i386 and x86_64
-          architectures on OS X and the armv7 and armv7s architectures on iOS
+          architectures on OS X and the armv7 and arm64 architectures on iOS.
       </li>
   
       <li>


### PR DESCRIPTION
The page wasn't rendering properly due to couple of broken tags and I've also removed the `armv7s` reference and replaced it with `arm64` given [glNext: removing armv7s](https://forum.libcinder.org/topic/glnext-removing-armv7s).