### PR TITLE
Audio Mac: allow for input samplerate != output samplerate

### DIFF
--- a/include/cinder/audio/Node.h
+++ b/include/cinder/audio/Node.h
@@ -261,7 +261,9 @@ class NodeAutoPullable : public Node {
 	void connect( const NodeRef &output )					override;
 	void connectInput( const NodeRef &input )				override;
 	void disconnectInput( const NodeRef &input )			override;
-	//! Overridden to also remove from  Context's auto-pulled list
+	//! Overridden to remove from Context's auto-pulled list if there are no more outputs
+	void disconnectOutput( const NodeRef &output )			override;
+	//! Overridden to also remove from Context's auto-pulled list
 	void disconnectAllOutputs()								override;
 
   protected:

--- a/include/cinder/audio/cocoa/CinderCoreAudio.h
+++ b/include/cinder/audio/cocoa/CinderCoreAudio.h
@@ -37,26 +37,15 @@ namespace cinder { namespace audio { namespace cocoa {
 void printASBD( const ::AudioStreamBasicDescription &asbd );
 
 struct AudioBufferListDeleter {
-	void operator()( ::AudioBufferList *bufferList )
-	{
-		for( size_t i = 0; i < bufferList->mNumberBuffers; i++ )
-			free( bufferList->mBuffers[i].mData );
-		free( bufferList );
-	}
-};
+	void operator()( ::AudioBufferList *bufferList );
 
-struct AudioBufferListShallowDeleter {
-	void operator()( ::AudioBufferList *bufferList )
-	{
-		free( bufferList );
-	}
+	bool mShallow = false;
 };
 
 typedef std::unique_ptr<::AudioBufferList, AudioBufferListDeleter> AudioBufferListPtr;
-typedef std::unique_ptr<::AudioBufferList, AudioBufferListShallowDeleter> AudioBufferListShallowPtr;
 
 AudioBufferListPtr createNonInterleavedBufferList( size_t numFrames, size_t numChannels );
-AudioBufferListShallowPtr createNonInterleavedBufferListShallow( size_t numChannels );
+AudioBufferListPtr createNonInterleavedBufferListShallow( size_t numChannels );
 
 
 ::AudioComponent findAudioComponent( const ::AudioComponentDescription &componentDescription );
@@ -103,7 +92,7 @@ class ConverterImplCoreAudio : public dsp::Converter {
 	const Buffer *mSourceBuffer;
 	size_t mNumReadFramesNeeded, mNumSourceBufferFramesUsed;
 
-	AudioBufferListShallowPtr mOutputBufferList;
+	AudioBufferListPtr mOutputBufferList;
 	::AudioConverterRef mAudioConverter;
 };
 

--- a/include/cinder/audio/cocoa/ContextAudioUnit.h
+++ b/include/cinder/audio/cocoa/ContextAudioUnit.h
@@ -25,6 +25,7 @@
 
 #include "cinder/audio/Context.h"
 #include "cinder/audio/dsp/RingBuffer.h"
+#include "cinder/audio/dsp/Converter.h"
 #include "cinder/audio/cocoa/CinderCoreAudio.h"
 
 #include <AudioUnit/AudioUnit.h>
@@ -97,9 +98,10 @@ class InputDeviceNodeAudioUnit : public InputDeviceNode, public NodeAudioUnit {
 
 	dsp::RingBuffer						mRingBuffer;
 	size_t								mRingBufferPaddingFactor;
+	std::unique_ptr<dsp::Converter>		mConverter;
+	BufferDynamic						mReadBuffer, mConvertedReadBuffer;
 	AudioBufferListPtr					mBufferList;
 	bool								mSynchronousIO;
-
 };
 
 // TODO: when stopped / mEnabled = false; kAudioUnitProperty_BypassEffect should be used

--- a/include/cinder/audio/cocoa/FileCoreAudio.h
+++ b/include/cinder/audio/cocoa/FileCoreAudio.h
@@ -61,10 +61,10 @@ class SourceFileCoreAudio : public SourceFile {
 	void		performSeek( size_t readPositionFrames )	override;
 	bool		supportsConversion()						override	{ return true; }
 
-	ExtAudioFilePtr					mExtAudioFile;
-	AudioBufferListShallowPtr		mBufferList;
-	ci::DataSourceRef				mDataSource;
-	size_t							mNumChannels, mSampleRateNative;
+	ExtAudioFilePtr				mExtAudioFile;
+	AudioBufferListPtr			mBufferList;
+	ci::DataSourceRef			mDataSource;
+	size_t						mNumChannels, mSampleRateNative;
 };
 
 class TargetFileCoreAudio : public TargetFile {
@@ -78,7 +78,7 @@ class TargetFileCoreAudio : public TargetFile {
 	static ::AudioFileTypeID getFileTypeIdFromExtension( const std::string &ext );
 
 	ExtAudioFilePtr				mExtAudioFile;
-	AudioBufferListShallowPtr	mBufferList;
+	AudioBufferListPtr			mBufferList;
 };
 
 } } } // namespace cinder::audio::cocoa

--- a/src/cinder/audio/Node.cpp
+++ b/src/cinder/audio/Node.cpp
@@ -536,10 +536,21 @@ void NodeAutoPullable::disconnectInput( const NodeRef &input )
 	updatePullMethod();
 }
 
+void NodeAutoPullable::disconnectOutput( const NodeRef &output )
+{
+	// make sure we live past disconnection, as output could be the last guy with a strong reference to us
+	auto thisRef = shared_from_this();
+	Node::disconnectOutput( output );
+	updatePullMethod();
+}
+
 void NodeAutoPullable::disconnectAllOutputs()
 {
+	// make sure we live past disconnection, as output could be the last guy with a strong reference to us
+	auto thisRef = shared_from_this();
 	Node::disconnectAllOutputs();
 
+	// no need to query getOutputs() as we know it is empty now, so just remove from auto pull list if needed
 	if( mIsPulledByContext ) {
 		mIsPulledByContext = false;
 		getContext()->removeAutoPulledNode( shared_from_this() );

--- a/src/cinder/audio/cocoa/ContextAudioUnit.cpp
+++ b/src/cinder/audio/cocoa/ContextAudioUnit.cpp
@@ -237,6 +237,7 @@ void InputDeviceNodeAudioUnit::initialize()
 				mConverter = audio::dsp::Converter::create( device->getSampleRate(), sampleRate, getNumChannels(), getNumChannels(), framesPerBlock );
 				mReadBuffer.setSize( framesPerBlock, getNumChannels() );
 				mConvertedReadBuffer.setSize( mConverter->getDestMaxFramesPerBlock(), getNumChannels() );
+				mRingBuffer.resize( mConverter->getDestMaxFramesPerBlock() * getNumChannels() * mRingBufferPaddingFactor );
 
 				asbd = createFloatAsbd( device->getSampleRate(), getNumChannels() );
 
@@ -252,9 +253,8 @@ void InputDeviceNodeAudioUnit::initialize()
 		}
 		else {
 			mBufferList = createNonInterleavedBufferList( framesPerBlock, getNumChannels() );
+			mRingBuffer.resize( framesPerBlock * getNumChannels() * mRingBufferPaddingFactor );
 		}
-
-		mRingBuffer.resize( framesPerBlock * getNumChannels() * mRingBufferPaddingFactor );
 
 		::AURenderCallbackStruct callbackStruct = { InputDeviceNodeAudioUnit::inputCallback, &mRenderData };
 		setAudioUnitProperty( mAudioUnit, kAudioOutputUnitProperty_SetInputCallback, callbackStruct, kAudioUnitScope_Global, DeviceBus::INPUT );

--- a/src/cinder/audio/cocoa/DeviceManagerCoreAudio.cpp
+++ b/src/cinder/audio/cocoa/DeviceManagerCoreAudio.cpp
@@ -183,15 +183,16 @@ void DeviceManagerCoreAudio::setSampleRate( const DeviceRef &device, size_t samp
 {
 	::AudioDeviceID deviceId = mDeviceIds.at( device );
 
+	// If the device can't be set to this sampleRate, we leave it alone,
+	// users should check if sampleRate was actually updated if necessary
 	auto acceptable = getAcceptableSampleRates( deviceId );
-	if( find( acceptable.begin(), acceptable.end(), sampleRate ) == acceptable.end() )
-		throw AudioDeviceExc( "Invalid samplerate." );
+	if( find( acceptable.begin(), acceptable.end(), sampleRate ) != acceptable.end() ) {
+		mUserHasModifiedFormat = true;
 
-	mUserHasModifiedFormat = true;
-
-	::AudioObjectPropertyAddress property = getAudioObjectPropertyAddress( kAudioDevicePropertyNominalSampleRate );
-	Float64 data = static_cast<Float64>( sampleRate );
-	setAudioObjectProperty( deviceId, property, data );
+		::AudioObjectPropertyAddress property = getAudioObjectPropertyAddress( kAudioDevicePropertyNominalSampleRate );
+		Float64 data = static_cast<Float64>( sampleRate );
+		setAudioObjectProperty( deviceId, property, data );
+	}
 }
 
 size_t DeviceManagerCoreAudio::getFramesPerBlock( const DeviceRef &device )

--- a/test/_audio/DeviceTest/src/DeviceTestApp.cpp
+++ b/test/_audio/DeviceTest/src/DeviceTestApp.cpp
@@ -33,6 +33,7 @@ class DeviceTestApp : public App {
 
 	void setupSine();
 	void setupNoise();
+	void setupInputPulled();
 	void setupIOClean();
 	void setupIOProcessed();
 	void setupIOAndSine();
@@ -212,6 +213,14 @@ void DeviceTestApp::setupNoise()
 	mGen->enable();
 }
 
+void DeviceTestApp::setupInputPulled()
+{
+	mOutputDeviceNode->disconnectAllInputs();
+
+	mInputDeviceNode >> mGain >> mMonitor;
+	mInputDeviceNode->enable();
+}
+
 void DeviceTestApp::setupIOClean()
 {
 	mInputDeviceNode->connect( mGain );
@@ -293,6 +302,7 @@ void DeviceTestApp::setupUI()
 
 	mTestSelector.mSegments.push_back( "sinewave" );
 	mTestSelector.mSegments.push_back( "noise" );
+	mTestSelector.mSegments.push_back( "input (pulled)" );
 	mTestSelector.mSegments.push_back( "I/O (clean)" );
 	mTestSelector.mSegments.push_back( "I/O (processed)" );
 	mTestSelector.mSegments.push_back( "I/O and sine" );
@@ -462,6 +472,8 @@ void DeviceTestApp::setupTest( string test )
 		setupSine();
 	else if( test == "noise" )
 		setupNoise();
+	else if( test == "input (pulled)" )
+		setupInputPulled();
 	else if( test == "I/O (clean)" )
 		setupIOClean();
 	else if( test == "I/O (processed)" )
@@ -610,4 +622,5 @@ void DeviceTestApp::draw()
 
 CINDER_APP( DeviceTestApp, RendererGl, []( App::Settings *settings ) {
 	settings->setWindowSize( 800, 600 );
+	settings->setWindowPos( 10, 10 );
 } )


### PR DESCRIPTION
Use an audio::dsp::Converter if the Device used by an InputDeviceNode can't support the OutputDeviceNode's, and thereby entire Context's, samplerate. This is expected, as explained by Apple's [Technical Note TN2091](https://developer.apple.com/library/mac/technotes/tn2091/_index.html).

Also fixed a subtle bug I encountered during testing with NodeAutoPullable, where changes in connections resulted in a Node being 'auto pulled' created an inconsistent state.