### PR TITLE
Allows showing or hiding an existing parameter.

### DIFF
--- a/include/cinder/params/Params.h
+++ b/include/cinder/params/Params.h
@@ -66,6 +66,8 @@ class InterfaceGl {
 		const std::string&	getKeyIncr() const			{ return mKeyIncr; }
 		const std::string&	getKeyDecr() const			{ return mKeyDecr; }
 
+		void				setVisible( bool visible = true );
+
 	  protected:
 		OptionsBase( const std::string &name, void *targetVoidPtr, InterfaceGl *parent );
 
@@ -126,6 +128,9 @@ class InterfaceGl {
 		//!! Sets an update function that will be called after the target param is updated.
 		Options&	updateFn( const UpdateFn &updateFn );
 
+		//! Shows or hides this param.
+		Options&	visible( bool visible = true ) { setVisible( visible ); return *this; }
+
 	  private:
 		T*				mTarget;
 		int				mTwType;
@@ -148,8 +153,18 @@ class InterfaceGl {
 	void	minimize();
 	//! Returns whether the interface is maximized or not. \see maximize(), minimize()
 	bool	isMaximized() const;
+	//! Gets the position of this interface instance
+	ivec2	getPosition() const;
 	//! Sets the position of this interface instance
 	void	setPosition( const ci::ivec2 &pos );
+	//! Gets the width of this interface instance
+	int		getWidth() const { return getSize().x; }
+	//! Gets the height of this interface instance
+	int		getHeight() const { return getSize().y; }
+	//! Gets the size of this interface instance
+	ivec2	getSize() const;
+	//! Sets the size of this interface instance
+	void	setSize( const ci::ivec2 &size );
 	//! Adds \a target as a param to the interface, referring to it with \a name. \return Options<T> for chaining options to the param.
 	template <typename T>
 	Options<T>	addParam( const std::string &name, T *target, bool readOnly = false );

--- a/src/cinder/params/Params.cpp
+++ b/src/cinder/params/Params.cpp
@@ -427,10 +427,32 @@ bool InterfaceGl::isMaximized() const
 	return maximizedInt == 0;
 }
 
+ivec2 InterfaceGl::getPosition() const
+{
+	ivec2 pos;
+	TwGetParam( mBar.get(), NULL, "position", TW_PARAM_INT32, 2, &pos );
+
+	return pos;
+}
+
 void InterfaceGl::setPosition( const ci::ivec2 &pos )
 {
 	string posStr = string( "position='" ) + to_string( pos.x ) + " " + to_string( pos.y ) + "'";
 	setOptions( "", posStr );
+}
+
+ivec2 InterfaceGl::getSize() const
+{
+	ivec2 size;
+	TwGetParam( mBar.get(), NULL, "size", TW_PARAM_INT32, 2, &size );
+
+	return size;
+}
+
+void InterfaceGl::setSize( const ci::ivec2 &size )
+{
+	string sizeStr = string( "size='" ) + to_string( size.x ) + " " + to_string( size.y ) + "'";
+	setOptions( "", sizeStr );
 }
 
 InterfaceGl::OptionsBase::OptionsBase( const std::string &name, void *targetVoidPtr, InterfaceGl *parent )
@@ -521,6 +543,14 @@ void InterfaceGl::OptionsBase::setGroup( const std::string &group )
 	string optionsStr = "group=`" + group + "`";
 	mParent->setOptions( getName(), optionsStr );
 	mGroup = group;
+}
+
+void InterfaceGl::OptionsBase::setVisible( bool visible )
+{
+	assert( mParent );
+
+	string optionsStr = "visible=" + string( visible ? "true" : "false" );
+	mParent->setOptions( getName(), optionsStr );
 }
 
 void InterfaceGl::OptionsBase::setOptionsStr( const string &optionsStr )


### PR DESCRIPTION
Also adds a getPosition, getSize and setSize function to the InterfaceGl class.

I've added these functions in preparation of an updated Geometry sample. Due to the sheer number of tweakable parameters, I wanted to have the option to show or hide parameters based on the currently selected primitive.

Probably the only change up for debate is the public method ```OptionsBase::setVisible```, as it is the only public setter on the class. In the revised sample, I store all the parameters in a ```vector<OptionsBase>```, so I need a method on this base class to show and hide individual parameters. Perhaps the other setters should become public as well. The only drawback I can think of is that they will show up in the auto-completion dialog, making it bit harder to create a parameter using the Named Parameter Idiom. 

Let me know what you think.