### PR TITLE
Fix download links and migrate links to https

### DIFF
--- a/docs/htmlsrc/guides/docs/building_docs.html
+++ b/docs/htmlsrc/guides/docs/building_docs.html
@@ -27,7 +27,7 @@
 
 		<h1>Building Cinder Docs</h1>
 		
-		<p>The bundled Cinder source files includes documentation that you can view locally. You can find the <a href="http://libcinder.org/docs">online version here</a>. If you are cloning the Cinder GitHub repo, the docs will need to be generated in your cloned local repo. This is a 2-step process.</p>
+		<p>The bundled Cinder source files includes documentation that you can view locally. You can find the <a href="https://libcinder.org/docs">online version here</a>. If you are cloning the Cinder GitHub repo, the docs will need to be generated in your cloned local repo. This is a 2-step process.</p>
 
 		<section>
 			<h2>Step 1: Doxygen Export</h2>

--- a/docs/htmlsrc/guides/mac-setup/index.html
+++ b/docs/htmlsrc/guides/mac-setup/index.html
@@ -19,7 +19,7 @@
 		<h1>OS X Setup</h1>
 		<p>This short guide will walk you through getting Cinder running on your OS X machine. You'll need Xcode 5.1.1 or later. In general this is best installed through the App Store, and is <a href="https://itunes.apple.com/us/app/xcode/id497799835?mt=12">available here</a>.</p>
 
-		<p>If you are using one of our <a href="http://libcinder.org/download/">packaged releases</a>, you already have everything you need. If you're working from GitHub you'll want to follow the build instructions in our <a href="../git/index.html">Cinder + Git</a> guide.</p>
+		<p>If you are using one of our <a href="https://libcinder.org/download">packaged releases</a>, you already have everything you need. If you're working from GitHub you'll want to follow the build instructions in our <a href="../git/index.html">Cinder + Git</a> guide.</p>
 
 		<p>To test your installation, we'll build one of the samples. From the Finder, navigate to the <em>samples/_opengl/CubeMapping</em> folder and open <em>xcode/CubeMapping.xcodeproj</em> by double-clicking it. From the <strong>Product</strong> menu select the <strong>Run</strong> item. Xcode will take a few seconds to build the sample and then it should launch and look similar to the screenshot below.</p>
 

--- a/docs/htmlsrc/guides/tour/hello_cinder.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder.html
@@ -36,7 +36,7 @@
                <br />
                In Section Two, I will tweak the particle engine from Section One and use it as a basis for a flocking simulation. Over five chapters, I will show how to create and control a 3D camera system and show how to set up a graphical interface for controlling variables in runtime. Then I will explain and implement four rules for a robust flocking simulation. By the end of Section Two, you will have a fully functioning 3D flocking simulation complete with predators and collision avoidance.<br />
                <br />
-               Below you will find some brief chapter descriptions. Each chapter has a corresponding project, which you can find in the <em>cinder/tour</em> directory. If you don't already have the Hello Cinder tour, you can download it <a href="http://libcinder.org/docs/hello_cinder/tour.zip">here</a>.<br />
+               Below you will find some brief chapter descriptions. Each chapter has a corresponding project, which you can find in the <em>cinder/tour</em> directory. If you don't already have the Hello Cinder tour, you can download it <a href="https://libcinder.org/docs/hello_cinder/tour.zip">here</a>.<br />
                <br />
             </p>
             <div class="image">

--- a/docs/htmlsrc/guides/windows-setup/index.html
+++ b/docs/htmlsrc/guides/windows-setup/index.html
@@ -25,7 +25,7 @@
 
         <!-- CONTENT STARTS HERE -->
         <h1>Windows Setup</h1>
-        <p>This guide will help you get started using Cinder on Windows. Start by downloading Cinder itself from the site's <a href="http://libcinder.org/download/">Download Page</a> if you haven't already. Choose the Visual C++ 2013 version if you don't already have Visual C++ installed.</p>
+        <p>This guide will help you get started using Cinder on Windows. Start by downloading Cinder itself from the site's <a href="https://libcinder.org/download">Download Page</a> if you haven't already. Choose the Visual C++ 2013 version if you don't already have Visual C++ installed.</p>
            
 
         <section> 
@@ -36,7 +36,7 @@
             <p>The first step is to install Visual C++ itself - click the <em>Download Community Free</em> button on the <a href="https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx">Visual Studio download page</a>. Next, launch the installer. Make sure that the Visual C++ option is selected under <em>Programming Languages</em> and press the <em>Install</em> button.
             </p>
 
-            <p>If you are using one of our <a href="http://libcinder.org/download/">packaged releases</a>, you should be all set. If you're working from GitHub you'll want to follow the build instructions in our <a href="GitSetup.html">Cinder + Git</a> guide.</p>
+            <p>If you are using one of our <a href="https://libcinder.org/download">packaged releases</a>, you should be all set. If you're working from GitHub you'll want to follow the build instructions in our <a href="GitSetup.html">Cinder + Git</a> guide.</p>
             
             <p>To verify your installation, try opening and building one of the samples. From Windows Explorer, navigate to the <em>cinder\samples\_opengl\CubeMapping\vc2013</em> folder and open <em>CubeMapping.sln</em>.</p>
             

--- a/docs/htmlsrc/index.html
+++ b/docs/htmlsrc/index.html
@@ -11,8 +11,8 @@
 		        <!-- cinder docs version links -->
 		        <div id="downloads" class="columns medium-4 large-3 hide-for-small">
 		            <ul>
-		                <li data-ci-version="0.9.0"><a href="http://libcinder.org/docs/release/v0.9.0/">Latest Release (v0.9.0)</a></li>
-		                <li data-ci-version="0.9.1dev"><a href="http://libcinder.org/docs/branch/master/">Master (v0.9.1dev)</a></li>
+		                <li data-ci-version="0.9.0"><a href="https://libcinder.org/docs/release/v0.9.0/">Latest Release (v0.9.0)</a></li>
+		                <li data-ci-version="0.9.1dev"><a href="https://libcinder.org/docs/branch/master/">Master (v0.9.1dev)</a></li>
 		            </ul>
 		        </div>
 


### PR DESCRIPTION
Fixes part of the issue @computersarecool reported in #1182.

Might be worth merging into release_v0.9.0 if that's what on the site now?