### PR TITLE
Fixed parameter type to glStencilMask.

### DIFF
--- a/include/cinder/gl/wrapper.h
+++ b/include/cinder/gl/wrapper.h
@@ -92,10 +92,10 @@ void clearStencil( const int s );
 	
 void colorMask( GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha );
 void depthMask( GLboolean flag );
-void stencilMask( GLboolean mask );
 	
 void stencilFunc( GLenum func, GLint ref, GLuint mask );
 void stencilOp( GLenum fail, GLenum zfail, GLenum zpass );
+void stencilMask( GLuint mask );
 
 std::pair<ivec2, ivec2> getViewport();
 void viewport( const std::pair<ivec2, ivec2> positionAndSize );

--- a/src/cinder/gl/wrapper.cpp
+++ b/src/cinder/gl/wrapper.cpp
@@ -234,11 +234,6 @@ void depthMask( GLboolean flag )
 	ctx->depthMask( flag );
 }
 
-void stencilMask( GLboolean mask )
-{
-	glStencilMask( mask );
-}
-
 void stencilFunc( GLenum func, GLint ref, GLuint mask )
 {
     glStencilFunc( func, ref, mask );
@@ -247,6 +242,11 @@ void stencilFunc( GLenum func, GLint ref, GLuint mask )
 void stencilOp( GLenum fail, GLenum zfail, GLenum zpass )
 {
     glStencilOp( fail, zfail, zpass );
+}
+
+void stencilMask( GLuint mask )
+{
+	glStencilMask( mask );
 }
 
 std::pair<ivec2, ivec2> getViewport()


### PR DESCRIPTION
```gl::stencilMask``` took a GLbool instead of a GLuint. 