### PR TITLE
GLSL preprocessor regex replacement

### DIFF
--- a/test/_opengl/ShaderPreprocessorTest/assets/wrong_hash.glsl
+++ b/test/_opengl/ShaderPreprocessorTest/assets/wrong_hash.glsl
@@ -1,4 +1,4 @@
 float hash( float n )
 {
-	return 0.0;
+	return sin( n );
 }

--- a/test/_opengl/ShaderPreprocessorTest/src/ShaderPreprocessorTestApp.cpp
+++ b/test/_opengl/ShaderPreprocessorTest/src/ShaderPreprocessorTestApp.cpp
@@ -44,7 +44,7 @@ void ShaderPreprocessorTestApp::testGlslProgInclude()
 							.vertex(  loadAsset( "passthrough.vert" ) )
 							.fragment( loadAsset( "shaderWithInclude.frag" ) )
         //                    .define( "COLOR_RED", "vec4( 0, 0, 1, 1 )" )
-        //                    .define( "WRONG_HASH" )
+                            .define( "WRONG_HASH" )
         ;
 
 		mGlslProg = gl::GlslProg::create( format );

--- a/test/_opengl/ShaderPreprocessorTest/xcode/ShaderPreprocessorTest.xcodeproj/project.pbxproj
+++ b/test/_opengl/ShaderPreprocessorTest/xcode/ShaderPreprocessorTest.xcodeproj/project.pbxproj
@@ -7,13 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0034BC361BF25DEB00DE9922 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0034BC351BF25DEB00DE9922 /* IOKit.framework */; };
 		0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0091D8F80E81B9330029341E /* OpenGL.framework */; };
 		00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784AF0FF439BC000DE1D7 /* Accelerate.framework */; };
 		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
-		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		B0245F5519BEDC7600BC878D /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0245F5419BEDC7600BC878D /* AVFoundation.framework */; };
 		B0245F5719BEDC7D00BC878D /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0245F5619BEDC7D00BC878D /* CoreMedia.framework */; };
@@ -21,6 +21,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0034BC351BF25DEB00DE9922 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		0034BC371BF25E1500DE9922 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../assets; sourceTree = "<group>"; };
 		0091D8F80E81B9330029341E /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
 		00B784AF0FF439BC000DE1D7 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
@@ -45,12 +47,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0034BC361BF25DEB00DE9922 /* IOKit.framework in Frameworks */,
 				B0245F5719BEDC7D00BC878D /* CoreMedia.framework in Frameworks */,
 				B0245F5519BEDC7600BC878D /* AVFoundation.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */,
 				5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */,
-				5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */,
 				00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */,
 				00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */,
 				00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */,
@@ -104,6 +106,7 @@
 		29B97314FDCFA39411CA2CEA /* ShaderPreprocessorTest */ = {
 			isa = PBXGroup;
 			children = (
+				0034BC371BF25E1500DE9922 /* assets */,
 				29B97315FDCFA39411CA2CEA /* Headers */,
 				080E96DDFE201D6D7F000001 /* Source */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
@@ -133,6 +136,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0034BC351BF25DEB00DE9922 /* IOKit.framework */,
 				B0245F5619BEDC7D00BC878D /* CoreMedia.framework */,
 				B0245F5419BEDC7600BC878D /* AVFoundation.framework */,
 				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,


### PR DESCRIPTION
Replaces regex's we've been using for preprocessing `#version` and `#include` directives in GLSL with handwritten equivalents. The primary motivation is to remove our dependency on std::regex to simplify Linux + GCC ports. A secondary benefit is improved performance, on MSW in particular. These changes benchmark as 5.5x perf in Debug and 3.7x perf in Release for me.