### PR TITLE
Updated Fbo::attachAttachments to modern opengl on desktop

### DIFF
--- a/src/cinder/gl/Fbo.cpp
+++ b/src/cinder/gl/Fbo.cpp
@@ -358,10 +358,14 @@ void Fbo::attachAttachments()
 	
 	// attach Textures
 	for( auto &textureAttachment : mAttachmentsTexture ) {
+#if ! defined( CINDER_GL_ES )
+		glFramebufferTexture( GL_FRAMEBUFFER, textureAttachment.first, textureAttachment.second->getId(), 0 );
+#else
 		auto textureTarget = textureAttachment.second->getTarget();
 		if( textureTarget == GL_TEXTURE_CUBE_MAP )
 			textureTarget = GL_TEXTURE_CUBE_MAP_POSITIVE_X;
 		glFramebufferTexture2D( GL_FRAMEBUFFER, textureAttachment.first, textureTarget, textureAttachment.second->getId(), 0 );
+#endif
 	}	
 }
 
@@ -656,6 +660,9 @@ bool Fbo::checkStatus( FboExceptionInvalidSpecification *resultExc )
 		case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
 			*resultExc = FboExceptionInvalidSpecification( "Framebuffer incomplete: incomplete multisample" );
 		break;
+		case GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS:
+			*resultExc = FboExceptionInvalidSpecification( "Framebuffer incomplete: not all attached images are layered" );
+		return false;
 #else
 		case GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS:
 			*resultExc = FboExceptionInvalidSpecification( "Framebuffer incomplete: not all attached images have the same number of samples" );


### PR DESCRIPTION
And also added an extra case in the checkStatus method to deal with incomplete layered fbo.

See discussion https://github.com/cinder/Cinder/issues/1191