### PR TITLE
Fix geom::Constant float constructor.

### DIFF
--- a/include/cinder/GeomIo.h
+++ b/include/cinder/GeomIo.h
@@ -1268,7 +1268,7 @@ class ColorFromAttrib : public Modifier {
 //! Sets an attribute of a geom::Source to be a constant value for every vertex. Determines dimension from constructor (vec4 -> 4, for example)
 class Constant : public Modifier {
   public:
-	Constant( geom::Attrib attrib, float &v )
+	Constant( geom::Attrib attrib, float v )
 		: mAttrib( attrib ), mValue( v, 0, 0, 0 ), mDims( 1 ) {}
 	Constant( geom::Attrib attrib, const vec2 &v )
 		: mAttrib( attrib ), mValue( v, 0, 0 ), mDims( 2 ) {}


### PR DESCRIPTION
The constructor should just accept a float, but it was asking for a non-const float reference.

Now allows for the very reasonable usage:
```c++
auto thing = geom::Sphere() >> geom::Constant(geom::Attrib::CUSTOM_0, 1.0f);
```

Before, required the somewhat absurd:
```c++
auto one = 1.0f;
auto thing = geom::Sphere() >> geom::Constant(geom::Attrib::CUSTOM_0, one);
```