### PR TITLE
Fixed issue with FboCubeMap from previous PR

### DIFF
--- a/src/cinder/gl/Fbo.cpp
+++ b/src/cinder/gl/Fbo.cpp
@@ -358,10 +358,16 @@ void Fbo::attachAttachments()
 	
 	// attach Textures
 	for( auto &textureAttachment : mAttachmentsTexture ) {
-#if ! defined( CINDER_GL_ES )
-		glFramebufferTexture( GL_FRAMEBUFFER, textureAttachment.first, textureAttachment.second->getId(), 0 );
-#else
 		auto textureTarget = textureAttachment.second->getTarget();
+#if ! defined( CINDER_GL_ES )
+		if( textureTarget == GL_TEXTURE_CUBE_MAP ) {
+			textureTarget = GL_TEXTURE_CUBE_MAP_POSITIVE_X;
+			glFramebufferTexture2D( GL_FRAMEBUFFER, textureAttachment.first, textureTarget, textureAttachment.second->getId(), 0 );
+		}
+		else {
+			glFramebufferTexture( GL_FRAMEBUFFER, textureAttachment.first, textureAttachment.second->getId(), 0 );
+		}
+#else
 		if( textureTarget == GL_TEXTURE_CUBE_MAP )
 			textureTarget = GL_TEXTURE_CUBE_MAP_POSITIVE_X;
 		glFramebufferTexture2D( GL_FRAMEBUFFER, textureAttachment.first, textureTarget, textureAttachment.second->getId(), 0 );


### PR DESCRIPTION
***Really sorry about this!***

My last changes have broken our dear FboCubeMap class! I'm not sure how, but it seems like I missed this in the tests I've done for my last PR.

I'll start working on a better solution, but for now this fix the issue.

What was happening is that using ```glFrameBufferTexture``` with a cubemap texture (instead of ```glFrameBufferTexture2D```) makes the Framebuffer expect a depth attachement of the same target (and therefore a cubemap depth attachement / 6 faces depth attachement). Ideally this should be dealt with when creating the depth buffer, checking for the format there, but this involves other changes and it's probably better to make that happen with a few other changes that we recently discussed.

Sorry again!