### PR TITLE
Add Base64.cpp to the Android build

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -639,6 +639,7 @@ set( CINDER_CXX_SRC_FILES
     ${CINDER_SRC_DIR}/cinder/svg/Svg.cpp
 
     ${CINDER_SRC_DIR}/cinder/Area.cpp
+    ${CINDER_SRC_DIR}/cinder/Base64.cpp
     ${CINDER_SRC_DIR}/cinder/BSpline.cpp
     ${CINDER_SRC_DIR}/cinder/BSplineFit.cpp
     ${CINDER_SRC_DIR}/cinder/Buffer.cpp


### PR DESCRIPTION
This was addressed by [chaoticbob/Cinder/pull/77](https://github.com/chaoticbob/Cinder/pull/77) but was lost in the android_linux handover shuffle.