### PR TITLE
RectT::moveULTo(), getMoveULTo()

### DIFF
--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -56,12 +56,14 @@ class RectT {
 	void		clipBy( const RectT &clip );
 	RectT		getClipBy( const RectT &clip ) const;
 	Area		getInteriorArea() const;
+	//! Translates the RectT by \a off
 	void		offset( const Vec2T &offset );
-	RectT		getOffset( const Vec2T &off ) const { RectT result( *this ); result.offset( off ); return result; }
+	//! Returns a copy of the RectT translated by \a off
+	RectT		getOffset( const Vec2T &off ) const;
 	//! Translates the RectT so that its upper-left corner is \a newUL
-	void		moveULTo( const vec2 &newUL );
+	void		moveULTo( const Vec2T &newUL );
 	//! Returns a copy of the RectT translated so that its upper-left corner is \a newUL
-	RectT		getMoveULTo( const Vec2T &newUL ) const	{ RectT result( *this ); result.moveULTo( newUL ); return result; }
+	RectT		getMoveULTo( const Vec2T &newUL ) const;
 	void		inflate( const Vec2T &amount );
 	RectT		inflated( const Vec2T &amount ) const;
 	//! Translates the rectangle so that its center is at \a center

--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -58,6 +58,10 @@ class RectT {
 	Area		getInteriorArea() const;
 	void		offset( const Vec2T &offset );
 	RectT		getOffset( const Vec2T &off ) const { RectT result( *this ); result.offset( off ); return result; }
+	//! Translates the RectT so that its upper-left corner is \a newUL
+	void		moveULTo( const vec2 &newUL );
+	//! Returns a copy of the RectT translated so that its upper-left corner is \a newUL
+	RectT		getMoveULTo( const Vec2T &newUL ) const	{ RectT result( *this ); result.moveULTo( newUL ); return result; }
 	void		inflate( const Vec2T &amount );
 	RectT		inflated( const Vec2T &amount ) const;
 	//! Translates the rectangle so that its center is at \a center

--- a/src/cinder/Rect.cpp
+++ b/src/cinder/Rect.cpp
@@ -118,6 +118,12 @@ void RectT<T>::offset( const Vec2T &offset )
 }
 
 template<typename T>
+void RectT<T>::moveULTo( const vec2 &newUL )
+{
+	set( newUL.x, newUL.y, newUL.x + getWidth(), newUL.y + getHeight() );
+}
+
+template<typename T>
 void RectT<T>::inflate( const Vec2T &amount )
 {
 	x1 -= amount.x;

--- a/src/cinder/Rect.cpp
+++ b/src/cinder/Rect.cpp
@@ -118,9 +118,23 @@ void RectT<T>::offset( const Vec2T &offset )
 }
 
 template<typename T>
-void RectT<T>::moveULTo( const vec2 &newUL )
+RectT<T> RectT<T>::getOffset( const Vec2T &off ) const
+{
+	RectT result( *this ); result.offset( off ); return result;
+}
+
+template<typename T>
+void RectT<T>::moveULTo( const Vec2T &newUL )
 {
 	set( newUL.x, newUL.y, newUL.x + getWidth(), newUL.y + getHeight() );
+}
+
+template<typename T>
+RectT<T> RectT<T>::getMoveULTo( const Vec2T &newUL ) const
+{
+	RectT result( *this );
+	result.moveULTo( newUL );
+	return result;
 }
 
 template<typename T>


### PR DESCRIPTION
For parity with Area, which has the same methods.