### PR TITLE
Added a GlslProg::create() method for transform feedback shaders.

### DIFF
--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -351,6 +351,9 @@ class GlslProg {
 	static GlslProgRef create( DataSourceRef vertexShader, DataSourceRef fragmentShader = DataSourceRef() );
 	static GlslProgRef create( const std::string &vertexShader, const std::string &fragmentShader = std::string() );
 #endif
+#if defined( CINDER_GL_HAS_TRANSFORM_FEEDBACK )
+	static GlslProgRef create( DataSourceRef vertexShader, const std::vector<std::string>& varyings, GLenum format = GL_INTERLEAVED_ATTRIBS );
+#endif
 	~GlslProg();
 	
 	void			bind() const;

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -433,6 +433,12 @@ GlslProgRef GlslProg::create( const string &vertexShader, const string &fragment
 }
 	
 #endif
+#if defined( CINDER_GL_HAS_TRANSFORM_FEEDBACK )
+GlslProgRef GlslProg::create( DataSourceRef vertexShader, const std::vector<std::string>& varyings, GLenum format )
+{
+	return GlslProgRef( new GlslProg( GlslProg::Format().vertex( vertexShader ).feedbackVaryings( varyings ).feedbackFormat( format ) ) );
+}
+#endif
 	
 GlslProg::~GlslProg()
 {


### PR DESCRIPTION
This allows you to quickly create the transform feedback shader by just supplying a file, a list of varyings and optionally a transform feedback format. Attributes don't need to be specified, because GlslProg already is able to query them from the source files. Thanks to this addition, I was able to add support for transform feedback shaders to a caching system, which would otherwise have been harder.