### PR TITLE
Backport docs changes to release_v0.9.0 branch

### DIFF
--- a/docs/generateDocs.py
+++ b/docs/generateDocs.py
@@ -1626,23 +1626,30 @@ def replace_code_chunks(bs4):
     :param bs4:
     :return:
     """
+
     # find all the code chunks
     code_chunks = bs4.find_all("div", "programlisting")
+    code_chunks += bs4.find_all("span", "programlisting")
+
     for chunk in code_chunks:
         pre_tag = bs4.new_tag("pre")
         code_tag = bs4.new_tag("code")
         add_class_to_tag(code_tag, "language-cpp")
 
         # for each code line, add a line of that text to the new div
-        for line in chunk.find("div", "codeline"):
-            line_text = ""
-            for c in line.contents:
-                if type(c) is Tag:
-                    line_text += c.text
-                else:
-                    line_text += c
-            code_tag.append(line_text + "\n")
-        pre_tag.append(code_tag)
+        codeline = chunk.find_all("div", "codeline")
+        codeline += chunk.find_all("span", "codeline")
+
+        if codeline:
+            for line in codeline:
+                line_text = ""
+                for c in line.contents:
+                    if type(c) is Tag:
+                        line_text += c.text
+                    else:
+                        line_text += c
+                code_tag.append(line_text + "\n")
+            pre_tag.append(code_tag)
 
         # replace content in code chunks
         chunk.clear()

--- a/docs/htmlsrc/_assets/css/style.css
+++ b/docs/htmlsrc/_assets/css/style.css
@@ -574,7 +574,7 @@ body.classes img.header-icon {
 #container .reference-lists section > ul > li:nth-child(odd) {
   background: #f8f8f8;
 }
-#container .reference-lists section > ul > li:nth-child(odd).expandable:hover {
+#container .reference-lists section > ul > li:nth-child(odd).expandable:not(.hidden):hover {
   -webkit-animation: fade-odd 1.5s;
   -moz-animation: fade-odd 1.5s;
   -o-animation: fade-odd 1.5s;

--- a/docs/htmlsrc/_assets/css/style.css
+++ b/docs/htmlsrc/_assets/css/style.css
@@ -1379,7 +1379,6 @@ code,
 .code {
   font-family: Inconsolata, monospace !important;
   font-size: 1em;
-  padding: 2px 4px;
   background: #fafafa;
   color: #666;
 }

--- a/docs/htmlsrc/_assets/js/cinder.js
+++ b/docs/htmlsrc/_assets/js/cinder.js
@@ -5,7 +5,6 @@ $(document).ready(function() {
 	var rootDir = window.location.pathname.substr(0, window.location.pathname.lastIndexOf( window.docsRoot + '/' ) + ( window.docsRoot.length + 1 ) );
 	var windowHeight = window.innerHeight;
 	var input = document.querySelector( '#search-input' );
-	var clicked = false;
 
 	var cinderJs = {
 
@@ -13,17 +12,7 @@ $(document).ready(function() {
 			this.selectNamspace( window.selectedNamespace );
  			this.showContent( hash );
  			this.adjustClassInfoLinks();
-
- 			// focus on search input on keydown if no clicking has happened yet
- 			$( window ).keydown( function(){
- 				if( ! clicked ){
- 					$( input ).focus();	
- 				}
- 			} );
-
- 			$( window ).one( "click", function(){
- 				clicked = true;
- 			} );
+			$( input ).focus();	
 		},
 		
 	 	/*

--- a/docs/htmlsrc/_assets/js/cinder.js
+++ b/docs/htmlsrc/_assets/js/cinder.js
@@ -5,6 +5,7 @@ $(document).ready(function() {
 	var rootDir = window.location.pathname.substr(0, window.location.pathname.lastIndexOf( window.docsRoot + '/' ) + ( window.docsRoot.length + 1 ) );
 	var windowHeight = window.innerHeight;
 	var input = document.querySelector( '#search-input' );
+	var clicked = false;
 
 	var cinderJs = {
 
@@ -13,9 +14,15 @@ $(document).ready(function() {
  			this.showContent( hash );
  			this.adjustClassInfoLinks();
 
- 			// focus on search input on keydown
- 			$( window ).keydown( function( ){
- 				$( input ).focus();
+ 			// focus on search input on keydown if no clicking has happened yet
+ 			$( window ).keydown( function(){
+ 				if( ! clicked ){
+ 					$( input ).focus();	
+ 				}
+ 			} );
+
+ 			$( window ).one( "click", function(){
+ 				clicked = true;
  			} );
 		},
 		

--- a/docs/htmlsrc/_docs/log/Logger.html
+++ b/docs/htmlsrc/_docs/log/Logger.html
@@ -8,22 +8,30 @@
 	<!-- 
 	cinder::ChannelT prefix 
 	-->
-    
-    <ci prefix dox="cinder::log::LoggerFile">
-	<br>
-    <br>
-    <code>LoggerFile( const fs::path &amp;filePath = fs::path(), bool appendToExisting = true );</code><br><br>
-    <code>filePath</code> defines the target logfile.  For example, <code>/tmp/cinder.log</code>.  If this parameter is left blank, LoggerFile will target a file named <code>cinder.log</code> that will sit next to the application binary.<br><br>
-    <code>appendToExisting</code> configures file appending.  This parameter defaults to <code>true</code>.
+	
+	<ci prefix dox="cinder::log::LoggerFile">
+	<!-- space from the docs in code -->
+	<br><br>
+	<p>
+		<code>LoggerFile( const fs::path &amp;filePath = fs::path(), bool appendToExisting = true );</code>
+		<ul>
+			<li><code>filePath</code> defines the target logfile.  For example, <code>/tmp/cinder.log</code>.  If this parameter is left blank, LoggerFile will target a file named <code>cinder.log</code> that will sit next to the application binary.</li>
+			<li><code>appendToExisting</code> configures file appending.  This parameter defaults to <code>true</code>.</li>
+		</ul>
+	</p>
 	</ci>
 
-    <ci prefix dox="cinder::log::LoggerFileRotating">
-    <br>
-    <br>
-	<code>LoggerFileRotating( const fs::path &amp;folder, const std::string &amp;formatStr, bool appendToExisting = true );</code><br><br>
-	<code>folder</code> defines the root folder that will contain the logfile.  If a blank string is provided, the folder will default to the folder that contains the application binary.<br><br>
-    <code>formatStr</code> is the string that will be evaluated by <a href="http://www.cplusplus.com/reference/ctime/strftime/" target="_blank">strftime</a> and turned into the logfile name.  For example, the string <code>cinder.%Y.%m.%d.log</code> could evaluate to <code>cinder.2015.08.28.log</code>.  Note that, since the log name is only re-evaluated once daily, using a format that includes minutes or seconds may not produce the results you're expecting.  If a blank format string is provided, an assertion will be thrown.<br><br>
-    <code>appendToExisting</code> configures file appending.  This parameter defaults to <code>true</code>.
+	<ci prefix dox="cinder::log::LoggerFileRotating">
+	<!-- space from the docs in code -->
+	<br><br>
+	<p>
+		<code>LoggerFileRotating( const fs::path &amp;folder, const std::string &amp;formatStr, bool appendToExisting = true );</code>
+		<ul>
+			<li><code>folder</code> defines the root folder that will contain the logfile.  If a blank string is provided, the folder will default to the folder that contains the application binary.</li>
+			<li><code>formatStr</code> is the string that will be evaluated by <a href="http://www.cplusplus.com/reference/ctime/strftime/" target="_blank">strftime</a> and turned into the logfile name.  For example, the string <code>cinder.%Y.%m.%d.log</code> could evaluate to <code>cinder.2015.08.28.log</code>.  Note that, since the log name is only re-evaluated once daily, using a format that includes minutes or seconds may not produce the results you're expecting.  If a blank format string is provided, an assertion will be thrown.</li>
+			<li><code>appendToExisting</code> configures file appending.  This parameter defaults to <code>true</code>.</li>
+		</ul>
+	</p>
 	</ci>
 
 </body>

--- a/docs/htmlsrc/_docs/log/Logger.html
+++ b/docs/htmlsrc/_docs/log/Logger.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+	
+</head>
+<body>
+	<!-- 
+	cinder::ChannelT prefix 
+	-->
+    
+    <ci prefix dox="cinder::log::LoggerFile">
+	<br>
+    <br>
+    <code>LoggerFile( const fs::path &amp;filePath = fs::path(), bool appendToExisting = true );</code><br><br>
+    <code>filePath</code> defines the target logfile.  For example, <code>/tmp/cinder.log</code>.  If this parameter is left blank, LoggerFile will target a file named <code>cinder.log</code> that will sit next to the application binary.<br><br>
+    <code>appendToExisting</code> configures file appending.  This parameter defaults to <code>true</code>.
+	</ci>
+
+    <ci prefix dox="cinder::log::LoggerFileRotating">
+    <br>
+    <br>
+	<code>LoggerFileRotating( const fs::path &amp;folder, const std::string &amp;formatStr, bool appendToExisting = true );</code><br><br>
+	<code>folder</code> defines the root folder that will contain the logfile.  If a blank string is provided, the folder will default to the folder that contains the application binary.<br><br>
+    <code>formatStr</code> is the string that will be evaluated by <a href="http://www.cplusplus.com/reference/ctime/strftime/" target="_blank">strftime</a> and turned into the logfile name.  For example, the string <code>cinder.%Y.%m.%d.log</code> could evaluate to <code>cinder.2015.08.28.log</code>.  Note that, since the log name is only re-evaluated once daily, using a format that includes minutes or seconds may not produce the results you're expecting.  If a blank format string is provided, an assertion will be thrown.<br><br>
+    <code>appendToExisting</code> configures file appending.  This parameter defaults to <code>true</code>.
+	</ci>
+
+</body>
+</html>

--- a/docs/htmlsrc/guides/audio/index.html
+++ b/docs/htmlsrc/guides/audio/index.html
@@ -599,18 +599,6 @@ mVoice->getOutputNode() >> mMonitor >> audio::master()->getOutput();
             <li>Windows: test/_audio/Audio2Test.msw/Audio2Test.sln</li>
          </ul>
          <p>These are meant to be more for feature and regression testing than anything else, but they may also be a useful way to see the entire breadth of the available functionality. </p>
-         
-<pre><code class="lang-cpp">
-gl::clear( Color( 0, 0, 0 ) );
-gl::setMatricesWindowPersp( getWindowSize() );
-gl::enableDepthRead();
-gl::enableDepthWrite();
-
-gl::ScopedGlslProg render( mRenderProg );
-gl::ScopedVao vao( mAttributes[mSourceIndex] );
-gl::context()->setDefaultShaderVars();
-gl::drawArrays( GL_POINTS, 0, NUM_PARTICLES );
-</code></pre>
       </section>
 
       <!-- END CONTENT -->

--- a/docs/htmlsrc/guides/cinder-blocks/index.html
+++ b/docs/htmlsrc/guides/cinder-blocks/index.html
@@ -47,7 +47,7 @@
   </div>
 
   <div>
-    To learn more about using CinderBlocks from TinderBox, checkout <a href="cinderblocks.html">its documentation</a>.
+    To learn more about using CinderBlocks from TinderBox, checkout <a href="../tinderbox/index.html">its documentation</a>.
   </div>
 
  <br />

--- a/docs/htmlsrc/guides/docs/building_docs.html
+++ b/docs/htmlsrc/guides/docs/building_docs.html
@@ -27,7 +27,7 @@
 
 		<h1>Building Cinder Docs</h1>
 		
-		<p>The bundled Cinder source files includes documentation that you can view locally. You can find the <a href="libcinder.org/docs">online version here</a>. If you are cloning the Cinder GitHub repo, the docs will need to be generated in your cloned local repo. This is a 2-step process.</p>
+		<p>The bundled Cinder source files includes documentation that you can view locally. You can find the <a href="https://libcinder.org/docs">online version here</a>. If you are cloning the Cinder GitHub repo, the docs will need to be generated in your cloned local repo. This is a 2-step process.</p>
 
 		<section>
 			<h2>Step 1: Doxygen Export</h2>

--- a/docs/htmlsrc/guides/index.html
+++ b/docs/htmlsrc/guides/index.html
@@ -51,8 +51,8 @@
 	            <label>Cinder APIs</label>
 				<li><a href="audio/index.html">Audio in Cinder</a></li>
 				<li><a href="path2d/part1.html">Path2d</a></li>
-	            <li><a href="xml-tree/index.html">XML in Cinder</a></li>
-                <li><a href="logging/index.html">Logging in Cinder</a></li>
+				<li><a href="xml-tree/index.html">XML in Cinder</a></li>
+				<li><a href="logging/index.html">Logging in Cinder</a></li>
 				<li><a href="movie-writer/index.html">QuickTime MovieWriter (Out of date)</a></li>
 				
 			</ul>

--- a/docs/htmlsrc/guides/index.html
+++ b/docs/htmlsrc/guides/index.html
@@ -52,6 +52,7 @@
 				<li><a href="audio/index.html">Audio in Cinder</a></li>
 				<li><a href="path2d/part1.html">Path2d</a></li>
 	            <li><a href="xml-tree/index.html">XML in Cinder</a></li>
+                <li><a href="logging/index.html">Logging in Cinder</a></li>
 				<li><a href="movie-writer/index.html">QuickTime MovieWriter (Out of date)</a></li>
 				
 			</ul>

--- a/docs/htmlsrc/guides/logging/index.html
+++ b/docs/htmlsrc/guides/logging/index.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html>
+	<head>
+			<title>Logging in Cinder</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, logging, logs, log, trace, debugging">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+      	<ci seealso dox="cinder::log" label="Logging in Cinder"></ci>
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+		
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+		<h1>Logging in Cinder</h1>
+        
+        <p>
+        	This document provides an overview of the logging capabilities in Cinder.  You can use this, along with the sample in <em><a href="https://github.com/cinder/Cinder/tree/master/samples/Logging" target="_blank">samples/Logging</a></em>, to quickly begin utilizing Cinder's built in logging capabilities.
+        </p>
+        <a name="overview"></a>
+        <h2>Overview</h2>
+        Cinder logging resides in the <ci>ci::log</ci> namespace, and provides a set of tools for straight forward, and relatively flexible logging.  The purpose of Cinder logging is not to circumvent advanced logging packages, but rather to provide Cinder users with basic, integrated functionality that will cover most practical use cases.<br>
+        <br>
+        All Cinder apps start with the default <ci dox="ci::log::LoggerConsole">LoggerConsole</ci> enabled, meaning any Cinder logging calls will appear in the application console window.  You can confirm this by making a logging call in a new Cinder app.  The example code:
+        <pre><code class="language-cpp">CI_LOG_D( "Hello world!" );</code></pre>
+        Would produce the following trace in the application console:
+        <pre><code class="language-cpp">|debug  | virtual void TestApp::setup()[40] Hello world!</code></pre>        
+        Using concise, but flexible calls, a user can enable any number of additional loggers.  Below is an example of how you would log to a file by adding an instance of <ci dox="ci::log::LoggerFile">LoggerFile</ci> to your Cinder project:
+        <pre><code class="language-cpp">log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/cinder/cinder.log" );</code></pre>
+        Before getting deeper into the features in <ci>ci::log</ci>, let's review some high level information.<br>
+        <br>
+        <a name="levels"></a>
+        <h2>Log Levels</h2>
+        <ci>ci::log::Level</ci> defines standard logging levels.  Opinions vary on the exact use of each logging level, so this is left up to the developer.  What is important to understand is that <code>LEVEL_VERBOSE</code> is considered the lowest logging level, and <code>LEVEL_FATAL</code> the highest.  This is important when understanding how to configure logging levels in Cinder.  The supported logging levels and their corresonding functions are below:<br><br>
+        <table>
+        <tr><td><b>Level</b></td><td><b>Function</b></td><td><b>Enum Value</b></td><td><b>Comment</b></td></tr> 
+        <tr><td>LEVEL_VERBOSE</td><td>CI_LOG_V</td><td>0</td><td>(lowest logging level)</td></tr> 
+        <tr><td>LEVEL_DEBUG</td><td>CI_LOG_D</td><td>1</td><td></td></tr> 
+        <tr><td>LEVEL_INFO</td><td>CI_LOG_I</td><td>2</td><td></td></tr> 
+        <tr><td>LEVEL_WARNING</td><td>CI_LOG_W</td><td>3</td><td></td></tr> 
+        <tr><td>LEVEL_ERROR</td><td>CI_LOG_E</td><td>4</td><td></td></tr> 
+        <tr><td>LEVEL_FATAL</td><td>CI_LOG_F</td><td>5</td><td>(highest logging level)</td></tr> 
+        </table>
+		<br>
+		<a name="types"></a>
+        <h2>Logger Types</h2>
+
+        <h3>Logger</h3>
+        <ci>ci::log::Logger</ci> is the base class for all loggers.  This class is never directly used.<br>
+		<br>
+        <h3>LoggerConsole</h3>
+        <ci>ci::log::LoggerConsole</ci> directs log messages into the application console window.  This logger is enabled by default.  This logger takes no parameters.<br>
+		<br>
+        <h3>LoggerFile</h3>
+        <ci>ci::log::LoggerFile</ci> directs log messages to a specified file.<br>
+        <br>
+        <h3>LoggerFileRotating</h3>
+        <ci>ci::log::LoggerFileRotating</ci> directs log messages to a specified file.  The name of that file is evaluated at the first logging call after application startup, and re-evaluated at the first logging call after midnight.<br>
+        <br>
+	    <h3>LoggerSystem</h3>
+        <ci>ci::log::LoggerSystem</ci> will write log messages to the platform specific system log.  This currently means the system log on OS X <code>/var/log/system.log</code> and the Event Log on Windows with MSW applications.  WinRT system logging is still being developed.<br>
+        <br>
+        <h4>Minimum System Logging Level</h4>
+        The minimum system logging level can be controlled by calling <ci dox="ci::log::LoggerSystem::setLoggingLevel">LoggerSystem::setLoggingLevel()</ci>.  This level can be controlled independently of the Cinder minimum logging level, but the system logging level can never be lower than the Cinder minimum logging level.  For more information on this, see the section on <a href="#optimization">Compile Time Settings & Optimization.</a><br>
+        <br>
+        <h4>OS Specific Notes</h4>
+        <b>OS X:</b> By default, logging messages that are lower than LOG_NOTICE do not show up in the system log.  This can be adjusted by configuring the <code>/etc/syslog.conf</code> file, but in order for OS X system logging to work out of the box, Cinder logging levels are never mapped to a logging level lower than LOG_NOTICE.  The full mapping is shown below.  The log messages themselves will contain the Cinder logging level.
+        <table>
+        <tr><td><b>Cinder Level</b></td><td><b>Event Log Level</b></td></tr> 
+        <tr><td>LEVEL_VERBOSE</td><td>LOG_NOTICE</td></tr> 
+        <tr><td>LEVEL_DEBUG</td><td>LOG_NOTICE</td></tr> 
+        <tr><td>LEVEL_INFO</td><td>LOG_NOTICE</td></tr> 
+        <tr><td>LEVEL_WARNING</td><td>LOG_WARNING</td></tr> 
+        <tr><td>LEVEL_ERROR</td><td>LOG_ERR</td></tr> 
+        <tr><td>LEVEL_FATAL</td><td>LOG_CRIT</td></tr> 
+        </table>
+        <b>Windows:</b> On Windows, there is no direct conversion of Cinder logging levels to Event Log logging levels.  Event levels are mapped as follows.  The log messages themselves will contain the Cinder logging level.<br>
+        <table>
+        <tr><td><b>Cinder Level</b></td><td><b>Event Log Level</b></td></tr> 
+        <tr><td>LEVEL_VERBOSE</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
+        <tr><td>LEVEL_DEBUG</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
+        <tr><td>LEVEL_INFO</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
+        <tr><td>LEVEL_WARNING</td><td>EVENTLOG_WARNING_TYPE</td></tr> 
+        <tr><td>LEVEL_ERROR</td><td>EVENTLOG_ERROR_TYPE</td></tr> 
+        <tr><td>LEVEL_FATAL</td><td>EVENTLOG_ERROR_TYPE</td></tr> 
+        </table>
+        <b>Windows:</b> For deployments on Windows systems, you may find that you need to create and register an application manifest file.  We are exploring how this may be integrated into the Cinder workflow, but in the mean time, please reference issue <a href="https://github.com/cinder/Cinder/issues/1109" target="_blank">#1109</a> for information.<br>
+		<br>
+        <h3>LoggerBreakpoint</h3>
+        <ci>ci::log::LoggerBreakpoint</ci> doesn't actually log messages, but triggers a breakpoint on log events above a specified threshold.
+        <code>triggerLevel</code> defines the minimum logging level that will break execution.<br>
+        The trigger level can be controlled by calling <ci dox="ci::log::LoggerBreakpoint::setTriggerLevel">LoggerBreakpoint::setTriggerLevel()</ci>.<br>
+        <br>
+        <a name="management"></a>
+        <h2>Logger Management</h2>
+        Multiple logger types aren't much use if you can't easily create, enable, and disable loggers.  The <ci>ci::log::LogManager</ci> manages a stack of all active loggers, and provides functions to aid in the management of loggers.<br><br>
+        <h3>Usage</h3>
+        The LogManager allows you to add individual logs to the stack of active loggers.  You can either keep track of loggers after you've added them to the stack, or you can search for the logger at a later point in time.<br><br>
+        <b>Example 1: Adding and forgetting a LoggerFile:</b>
+        <pre><code class="language-cpp">log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/logging/cinder.log", true );</code></pre>
+        This causes a <ci>ci::log::LoggerFile</ci> to be created and added to the logger stack.<br><br>
+        <b>Example 2: Adding and keeping a <ci>ci::log::LoggerRef</ci>:</b>
+        <pre><code class="language-cpp">log::LoggerRef logger = log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/logging/cinder.log", true );
+... log some things to the console and file
+// remove the logger
+log::manager()->removeLogger( logger );
+... log some things to the console only</code></pre>
+        <b>Example 3: Getting an active logger:</b><br>
+        <pre><code class="language-cpp">// gets the active LoggerSystem and sets the minimum level to LEVEL_ERROR
+log::manager()->getLoggers&lt;log::LoggerSystem&gt;()[0]->setLoggingLevel( log::LEVEL_ERROR );</code></pre><br>
+        <a name="optimization"></a>
+       	<h2>Compile Time Settings &amp; Optimization</h2>
+        The <code>CI_MIN_LOG_LEVEL</code> directive allows you to configure the minimum logging level that is enabled.  For example, if you you included the following code in your main application:
+        <pre><code class="language-cpp">#define CI_MIN_LOG_LEVEL 4
+#include "cinder/Log.h"</code></pre>
+        Then the lowest enabled logging level would be <code>LEVEL_ERROR</code>.  Calls to lower logging levels, such as <code>CI_LOG_D</code> would incur no runtime costs because the method is optimized away at compile time.<br><br>
+        By default, when compiling your application in debug mode, all logging levels are supported.<br><br>
+        By default, when compiling your application in release mode, all levels including and above <code>LEVEL_INFO</code> are supported.<br><br>
+        When you set <code>CI_MIN_LOG_LEVEL</code> these default settings are overwritten.<br>
+        <b>note:</b> this is why the minimum system logging level can never be lower than the currently enabled Cinder logging level.<br><br>
+         
+        <a name="advanced"></a>
+        <h2>Advanced Usage</h2>
+        Sticking with the Cinder mantra "make easy things easy, and hard things possible", Cinder allows for the insertion of custom loggers.  For example, if I felt like creating a logger that prepended text to my logging string, I could use the following code:
+        <pre><code class="language-cpp">class SpecialLogger: public log::LoggerConsole
+{
+    virtual void write( const log::Metadata &meta, const std::string &text ) override
+    {
+        LoggerConsole::write( meta, "Special: " + text );
+    }
+};
+...
+log::makeLogger&lt;SpecialLogger&gt;();
+CI_LOG_D( "nothing special.");</code></pre>
+        Which would print the following to the console output:
+        <pre><code class="language-cpp">|debug  | virtual void LoggingApp::setup()[51] Special: nothing special.</code></pre>
+        <br>
+		<a name="limitations"></a>      
+        <h2>Limitations</h2>
+        <h3>Message Formatting</h3>
+        Currently you can not change the message format.
+        <br><br>
+        <h3>File Rotating Interval</h3>
+        Currently the <ci>ci::log::LoggerFileRotating</ci> will only rotate log files during the first logging event after midnight.  This is not configurable to a different interval period.
+        <br><br>
+        <a name="examples"></a>
+       	<h2>Example Projects</h2>
+        <a href="https://github.com/lucasvickers/Cinder/tree/master/samples/Logging" target="_blank">samples/Logging</a><br>
+        <a href="https://github.com/lucasvickers/Cinder/tree/master/test/DebugTest" target="_blank">test/DebugTest</a>
+        
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html> 

--- a/docs/htmlsrc/guides/logging/index.html
+++ b/docs/htmlsrc/guides/logging/index.html
@@ -30,20 +30,32 @@
         	This document provides an overview of the logging capabilities in Cinder.  You can use this, along with the sample in <em><a href="https://github.com/cinder/Cinder/tree/master/samples/Logging" target="_blank">samples/Logging</a></em>, to quickly begin utilizing Cinder's built in logging capabilities.
         </p>
         <a name="overview"></a>
+        <section>
         <h2>Overview</h2>
-        Cinder logging resides in the <ci>ci::log</ci> namespace, and provides a set of tools for straight forward, and relatively flexible logging.  The purpose of Cinder logging is not to circumvent advanced logging packages, but rather to provide Cinder users with basic, integrated functionality that will cover most practical use cases.<br>
-        <br>
-        All Cinder apps start with the default <ci dox="ci::log::LoggerConsole">LoggerConsole</ci> enabled, meaning any Cinder logging calls will appear in the application console window.  You can confirm this by making a logging call in a new Cinder app.  The example code:
-        <pre><code class="language-cpp">CI_LOG_D( "Hello world!" );</code></pre>
-        Would produce the following trace in the application console:
-        <pre><code class="language-cpp">|debug  | virtual void TestApp::setup()[40] Hello world!</code></pre>        
-        Using concise, but flexible calls, a user can enable any number of additional loggers.  Below is an example of how you would log to a file by adding an instance of <ci dox="ci::log::LoggerFile">LoggerFile</ci> to your Cinder project:
-        <pre><code class="language-cpp">log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/cinder/cinder.log" );</code></pre>
-        Before getting deeper into the features in <ci>ci::log</ci>, let's review some high level information.<br>
-        <br>
+        <p>
+            Cinder logging resides in the <ci>ci::log</ci> namespace, and provides a set of tools for straight forward, and relatively flexible logging.  The purpose of Cinder logging is not to circumvent advanced logging packages, but rather to provide Cinder users with basic, integrated functionality that will cover most practical use cases.
+        </p>
+        <p>
+            All Cinder apps start with the default <ci dox="ci::log::LoggerConsole">LoggerConsole</ci> enabled, meaning any Cinder logging calls will appear in the application console window.  You can confirm this by making a logging call in a new Cinder app.  The example code:
+            <pre><code class="language-cpp">CI_LOG_D( "Hello world!" );</code></pre>
+            Would produce the following trace in the application console:
+            <pre><code class="language-cpp">|debug  | virtual void TestApp::setup()[40] Hello world!</code></pre>
+        </p>
+        <p>
+            Using concise, but flexible calls, a user can enable any number of additional loggers.  Below is an example of how you would log to a file by adding an instance of <ci dox="ci::log::LoggerFile">LoggerFile</ci> to your Cinder project:
+            <pre><code class="language-cpp">log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/cinder/cinder.log" );</code></pre>
+        </p>
+        <p>
+        Before getting deeper into the features in <ci>ci::log</ci>, let's review some high level information.
+        </p>
+        </section>
+
         <a name="levels"></a>
+        <section>
         <h2>Log Levels</h2>
-        <ci>ci::log::Level</ci> defines standard logging levels.  Opinions vary on the exact use of each logging level, so this is left up to the developer.  What is important to understand is that <code>LEVEL_VERBOSE</code> is considered the lowest logging level, and <code>LEVEL_FATAL</code> the highest.  This is important when understanding how to configure logging levels in Cinder.  The supported logging levels and their corresonding functions are below:<br><br>
+        <p>
+            <ci>ci::log::Level</ci> defines standard logging levels.  Opinions vary on the exact use of each logging level, so this is left up to the developer.  What is important to understand is that <code>LEVEL_VERBOSE</code> is considered the lowest logging level, and <code>LEVEL_FATAL</code> the highest.  This is important when understanding how to configure logging levels in Cinder.  The supported logging levels and their corresonding functions are below:
+        </p>
         <table>
         <tr><td><b>Level</b></td><td><b>Function</b></td><td><b>Enum Value</b></td><td><b>Comment</b></td></tr> 
         <tr><td>LEVEL_VERBOSE</td><td>CI_LOG_V</td><td>0</td><td>(lowest logging level)</td></tr> 
@@ -53,88 +65,115 @@
         <tr><td>LEVEL_ERROR</td><td>CI_LOG_E</td><td>4</td><td></td></tr> 
         <tr><td>LEVEL_FATAL</td><td>CI_LOG_F</td><td>5</td><td>(highest logging level)</td></tr> 
         </table>
-		<br>
-		<a name="types"></a>
-        <h2>Logger Types</h2>
+		</section>
 
-        <h3>Logger</h3>
-        <ci>ci::log::Logger</ci> is the base class for all loggers.  This class is never directly used.<br>
-		<br>
-        <h3>LoggerConsole</h3>
-        <ci>ci::log::LoggerConsole</ci> directs log messages into the application console window.  This logger is enabled by default.  This logger takes no parameters.<br>
-		<br>
-        <h3>LoggerFile</h3>
-        <ci>ci::log::LoggerFile</ci> directs log messages to a specified file.<br>
-        <br>
-        <h3>LoggerFileRotating</h3>
-        <ci>ci::log::LoggerFileRotating</ci> directs log messages to a specified file.  The name of that file is evaluated at the first logging call after application startup, and re-evaluated at the first logging call after midnight.<br>
-        <br>
-	    <h3>LoggerSystem</h3>
-        <ci>ci::log::LoggerSystem</ci> will write log messages to the platform specific system log.  This currently means the system log on OS X <code>/var/log/system.log</code> and the Event Log on Windows with MSW applications.  WinRT system logging is still being developed.<br>
-        <br>
+		<a name="types"></a>
+        <section>
+        <h2>Logger Types</h2>
+        <ul>
+            <li><ci dox="ci::log::Logger">Logger</ci> is the base class for all loggers.  This class is never directly used.</li>
+            <li><ci dox="ci::log::LoggerConsole">LoggerConsole</ci> directs log messages into the application console window.  This logger is enabled by default.  This logger takes no parameters.</li>
+            <li><ci dox="ci::log::LoggerFile">LoggerFile</ci> directs log messages to a specified file.</li>
+            <li><ci dox="ci::log::LoggerFileRotating">LoggerFileRotating</ci> directs log messages to a specified file.  The name of that file is evaluated at the first logging call after application startup, and re-evaluated at the first logging call after midnight.</li>
+            <li>
+                <ci dox="ci::log::LoggerBreakpoint">LoggerBreakpoint</ci> doesn't actually log messages, but triggers a breakpoint on log events above a specified threshold.  <code>triggerLevel</code> defines the minimum logging level that will break execution.
+                <br>The trigger level can be controlled by calling <ci dox="ci::log::LoggerBreakpoint::setTriggerLevel">LoggerBreakpoint::setTriggerLevel()</ci>.
+            </li>
+            <li><ci dox="ci::log::LoggerSystem">LoggerSystem</ci> will write log messages to the platform specific system log.  This currently means the system log on OS X <code>/var/log/system.log</code> and the Event Log on Windows with MSW applications.  WinRT system logging is still being developed.</li>
+        </ul>
+        <h3>LoggerSystem Notes</h3>
         <h4>Minimum System Logging Level</h4>
-        The minimum system logging level can be controlled by calling <ci dox="ci::log::LoggerSystem::setLoggingLevel">LoggerSystem::setLoggingLevel()</ci>.  This level can be controlled independently of the Cinder minimum logging level, but the system logging level can never be lower than the Cinder minimum logging level.  For more information on this, see the section on <a href="#optimization">Compile Time Settings & Optimization.</a><br>
-        <br>
-        <h4>OS Specific Notes</h4>
-        <b>OS X:</b> By default, logging messages that are lower than LOG_NOTICE do not show up in the system log.  This can be adjusted by configuring the <code>/etc/syslog.conf</code> file, but in order for OS X system logging to work out of the box, Cinder logging levels are never mapped to a logging level lower than LOG_NOTICE.  The full mapping is shown below.  The log messages themselves will contain the Cinder logging level.
-        <table>
-        <tr><td><b>Cinder Level</b></td><td><b>Event Log Level</b></td></tr> 
-        <tr><td>LEVEL_VERBOSE</td><td>LOG_NOTICE</td></tr> 
-        <tr><td>LEVEL_DEBUG</td><td>LOG_NOTICE</td></tr> 
-        <tr><td>LEVEL_INFO</td><td>LOG_NOTICE</td></tr> 
-        <tr><td>LEVEL_WARNING</td><td>LOG_WARNING</td></tr> 
-        <tr><td>LEVEL_ERROR</td><td>LOG_ERR</td></tr> 
-        <tr><td>LEVEL_FATAL</td><td>LOG_CRIT</td></tr> 
-        </table>
-        <b>Windows:</b> On Windows, there is no direct conversion of Cinder logging levels to Event Log logging levels.  Event levels are mapped as follows.  The log messages themselves will contain the Cinder logging level.<br>
-        <table>
-        <tr><td><b>Cinder Level</b></td><td><b>Event Log Level</b></td></tr> 
-        <tr><td>LEVEL_VERBOSE</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
-        <tr><td>LEVEL_DEBUG</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
-        <tr><td>LEVEL_INFO</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
-        <tr><td>LEVEL_WARNING</td><td>EVENTLOG_WARNING_TYPE</td></tr> 
-        <tr><td>LEVEL_ERROR</td><td>EVENTLOG_ERROR_TYPE</td></tr> 
-        <tr><td>LEVEL_FATAL</td><td>EVENTLOG_ERROR_TYPE</td></tr> 
-        </table>
-        <b>Windows:</b> For deployments on Windows systems, you may find that you need to create and register an application manifest file.  We are exploring how this may be integrated into the Cinder workflow, but in the mean time, please reference issue <a href="https://github.com/cinder/Cinder/issues/1109" target="_blank">#1109</a> for information.<br>
-		<br>
-        <h3>LoggerBreakpoint</h3>
-        <ci>ci::log::LoggerBreakpoint</ci> doesn't actually log messages, but triggers a breakpoint on log events above a specified threshold.
-        <code>triggerLevel</code> defines the minimum logging level that will break execution.<br>
-        The trigger level can be controlled by calling <ci dox="ci::log::LoggerBreakpoint::setTriggerLevel">LoggerBreakpoint::setTriggerLevel()</ci>.<br>
-        <br>
+        <p>
+            The minimum system logging level can be controlled by calling <ci dox="ci::log::LoggerSystem::setLoggingLevel">LoggerSystem::setLoggingLevel()</ci>.  This level can be controlled independently of the Cinder minimum logging level, but the system logging level can never be lower than the Cinder minimum logging level.  For more information on this, see the section on <a href="#optimization">Compile Time Settings & Optimization.</a>
+        </p>
+        <h4>OS X Specific Notes</h4>
+        <p>
+            <b>Note:</b> By default, logging messages that are lower than LOG_NOTICE do not show up in the system log.  This can be adjusted by configuring the <code>/etc/syslog.conf</code> file, but in order for OS X system logging to work out of the box, Cinder logging levels are never mapped to a logging level lower than LOG_NOTICE.  The full mapping is shown below.  The log messages themselves will contain the Cinder logging level.
+            <table>
+            <tr><td><b>Cinder Level</b></td><td><b>Event Log Level</b></td></tr> 
+            <tr><td>LEVEL_VERBOSE</td><td>LOG_NOTICE</td></tr> 
+            <tr><td>LEVEL_DEBUG</td><td>LOG_NOTICE</td></tr> 
+            <tr><td>LEVEL_INFO</td><td>LOG_NOTICE</td></tr> 
+            <tr><td>LEVEL_WARNING</td><td>LOG_WARNING</td></tr> 
+            <tr><td>LEVEL_ERROR</td><td>LOG_ERR</td></tr> 
+            <tr><td>LEVEL_FATAL</td><td>LOG_CRIT</td></tr> 
+            </table>
+        </p>
+        <h4>Windows Specific Notes</h4>
+        <p>
+            <b>Note:</b> On Windows, there is no direct conversion of Cinder logging levels to Event Log logging levels.  Event levels are mapped as follows.  The log messages themselves will contain the Cinder logging level.
+            <table>
+            <tr><td><b>Cinder Level</b></td><td><b>Event Log Level</b></td></tr> 
+            <tr><td>LEVEL_VERBOSE</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
+            <tr><td>LEVEL_DEBUG</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
+            <tr><td>LEVEL_INFO</td><td>EVENTLOG_INFORMATION_TYPE</td></tr> 
+            <tr><td>LEVEL_WARNING</td><td>EVENTLOG_WARNING_TYPE</td></tr> 
+            <tr><td>LEVEL_ERROR</td><td>EVENTLOG_ERROR_TYPE</td></tr> 
+            <tr><td>LEVEL_FATAL</td><td>EVENTLOG_ERROR_TYPE</td></tr> 
+            </table>
+        </p>
+        <p>
+            <b>Note:</b> For deployments on Windows systems, you may find that you need to create and register an application manifest file.  We are exploring how this may be integrated into the Cinder workflow, but in the mean time, please reference issue <a href="https://github.com/cinder/Cinder/issues/1109" target="_blank">#1109</a> for information.
+        </p>
+        </section>
+
         <a name="management"></a>
+        <section>
         <h2>Logger Management</h2>
-        Multiple logger types aren't much use if you can't easily create, enable, and disable loggers.  The <ci>ci::log::LogManager</ci> manages a stack of all active loggers, and provides functions to aid in the management of loggers.<br><br>
+        <p>
+            Multiple logger types aren't much use if you can't easily create, enable, and disable loggers.  The <ci>ci::log::LogManager</ci> manages a stack of all active loggers, and provides functions to aid in the management of loggers.
+        </p>
         <h3>Usage</h3>
-        The LogManager allows you to add individual logs to the stack of active loggers.  You can either keep track of loggers after you've added them to the stack, or you can search for the logger at a later point in time.<br><br>
-        <b>Example 1: Adding and forgetting a LoggerFile:</b>
-        <pre><code class="language-cpp">log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/logging/cinder.log", true );</code></pre>
-        This causes a <ci>ci::log::LoggerFile</ci> to be created and added to the logger stack.<br><br>
-        <b>Example 2: Adding and keeping a <ci>ci::log::LoggerRef</ci>:</b>
-        <pre><code class="language-cpp">log::LoggerRef logger = log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/logging/cinder.log", true );
+        <p>
+            The LogManager allows you to add individual logs to the stack of active loggers.  You can either keep track of loggers after you've added them to the stack, or you can search for the logger at a later point in time.
+        </p>
+        <p>
+            <b>Example 1: Adding and forgetting a LoggerFile:</b><br>
+            <pre><code class="language-cpp">log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/logging/cinder.log", true );</code></pre>
+            This causes a <ci>ci::log::LoggerFile</ci> to be created and added to the logger stack.
+        </p>
+        <p>
+            <b>Example 2: Adding and keeping a <ci>ci::log::LoggerRef</ci>:</b><br>
+            <pre><code class="language-cpp">log::LoggerRef logger = log::makeLogger&lt;log::LoggerFile&gt;( "/tmp/logging/cinder.log", true );
 ... log some things to the console and file
 // remove the logger
 log::manager()->removeLogger( logger );
 ... log some things to the console only</code></pre>
-        <b>Example 3: Getting an active logger:</b><br>
-        <pre><code class="language-cpp">// gets the active LoggerSystem and sets the minimum level to LEVEL_ERROR
-log::manager()->getLoggers&lt;log::LoggerSystem&gt;()[0]->setLoggingLevel( log::LEVEL_ERROR );</code></pre><br>
+        </p>
+        <p>
+            <b>Example 3: Getting an active logger:</b><br>
+            <pre><code class="language-cpp">// gets the active LoggerSystem and sets the minimum level to LEVEL_ERROR
+log::manager()->getLoggers&lt;log::LoggerSystem&gt;()[0]->setLoggingLevel( log::LEVEL_ERROR );</code></pre>
+        </p>
+        </section>
+
         <a name="optimization"></a>
-       	<h2>Compile Time Settings &amp; Optimization</h2>
-        The <code>CI_MIN_LOG_LEVEL</code> directive allows you to configure the minimum logging level that is enabled.  For example, if you you included the following code in your main application:
-        <pre><code class="language-cpp">#define CI_MIN_LOG_LEVEL 4
+       	<section>
+        <h2>Compile Time Settings &amp; Optimization</h2>
+        <p>
+            The <code>CI_MIN_LOG_LEVEL</code> directive allows you to configure the minimum logging level that is enabled.  For example, if you you included the following code in your main application:
+            <pre><code class="language-cpp">#define CI_MIN_LOG_LEVEL 4
 #include "cinder/Log.h"</code></pre>
-        Then the lowest enabled logging level would be <code>LEVEL_ERROR</code>.  Calls to lower logging levels, such as <code>CI_LOG_D</code> would incur no runtime costs because the method is optimized away at compile time.<br><br>
-        By default, when compiling your application in debug mode, all logging levels are supported.<br><br>
-        By default, when compiling your application in release mode, all levels including and above <code>LEVEL_INFO</code> are supported.<br><br>
-        When you set <code>CI_MIN_LOG_LEVEL</code> these default settings are overwritten.<br>
-        <b>note:</b> this is why the minimum system logging level can never be lower than the currently enabled Cinder logging level.<br><br>
+            Then the lowest enabled logging level would be <code>LEVEL_ERROR</code>.  Calls to lower logging levels, such as <code>CI_LOG_D</code> would incur no runtime costs because the method is optimized away at compile time.
+        </p>
+        <p>
+            By default, when compiling your application in debug mode, all logging levels are supported.
+        </p>
+        <p>
+            By default, when compiling your application in release mode, all levels including and above <code>LEVEL_INFO</code> are supported.
+        </p>
+        <p>
+            When you set <code>CI_MIN_LOG_LEVEL</code> these default settings are overwritten.<br>
+            <b>Note:</b> this is why the minimum system logging level can never be lower than the currently enabled Cinder logging level.
+        </p>
+        </section>
          
         <a name="advanced"></a>
+        <section>
         <h2>Advanced Usage</h2>
-        Sticking with the Cinder mantra "make easy things easy, and hard things possible", Cinder allows for the insertion of custom loggers.  For example, if I felt like creating a logger that prepended text to my logging string, I could use the following code:
-        <pre><code class="language-cpp">class SpecialLogger: public log::LoggerConsole
+        <p>
+            Sticking with the Cinder mantra "make easy things easy, and hard things possible", Cinder allows for the insertion of custom loggers.  For example, if I felt like creating a logger that prepended text to my logging string, I could use the following code:
+            <pre><code class="language-cpp">class SpecialLogger: public log::LoggerConsole
 {
     virtual void write( const log::Metadata &meta, const std::string &text ) override
     {
@@ -144,22 +183,33 @@ log::manager()->getLoggers&lt;log::LoggerSystem&gt;()[0]->setLoggingLevel( log::
 ...
 log::makeLogger&lt;SpecialLogger&gt;();
 CI_LOG_D( "nothing special.");</code></pre>
-        Which would print the following to the console output:
-        <pre><code class="language-cpp">|debug  | virtual void LoggingApp::setup()[51] Special: nothing special.</code></pre>
-        <br>
+            Which would print the following to the console output:
+            <pre><code class="language-cpp">|debug  | virtual void LoggingApp::setup()[51] Special: nothing special.</code></pre>
+        </p>
+        </section>
+
 		<a name="limitations"></a>      
+        <section>
         <h2>Limitations</h2>
-        <h3>Message Formatting</h3>
-        Currently you can not change the message format.
-        <br><br>
-        <h3>File Rotating Interval</h3>
-        Currently the <ci>ci::log::LoggerFileRotating</ci> will only rotate log files during the first logging event after midnight.  This is not configurable to a different interval period.
-        <br><br>
+        <p>
+            <h3>Message Formatting</h3>
+            Currently you can not change the message format.
+        </p>
+        <p>
+            <h3>File Rotating Interval</h3>
+            Currently the <ci>ci::log::LoggerFileRotating</ci> will only rotate log files during the first logging event after midnight.  This is not configurable to a different interval period.
+        </p>
+        </section>
+
         <a name="examples"></a>
-       	<h2>Example Projects</h2>
-        <a href="https://github.com/lucasvickers/Cinder/tree/master/samples/Logging" target="_blank">samples/Logging</a><br>
-        <a href="https://github.com/lucasvickers/Cinder/tree/master/test/DebugTest" target="_blank">test/DebugTest</a>
-        
+        <section>
+        <p>
+           	<h2>Example Projects</h2>
+            <a href="https://github.com/Cinder/Cinder/tree/master/samples/Logging" target="_blank">samples/Logging</a><br>
+            <a href="https://github.com/Cinder/Cinder/tree/master/test/DebugTest" target="_blank">test/DebugTest</a>
+        </p>
+        </section>
+
 		<!-- END CONTENT -->
 
 		<!-- Scripts -->

--- a/docs/htmlsrc/guides/mac-setup/index.html
+++ b/docs/htmlsrc/guides/mac-setup/index.html
@@ -19,7 +19,7 @@
 		<h1>OS X Setup</h1>
 		<p>This short guide will walk you through getting Cinder running on your OS X machine. You'll need Xcode 5.1.1 or later. In general this is best installed through the App Store, and is <a href="https://itunes.apple.com/us/app/xcode/id497799835?mt=12">available here</a>.</p>
 
-		<p>If you are using one of our <a href="http://libcinder.org/download/">packaged releases</a>, you already have everything you need. If you're working from GitHub you'll want to follow the build instructions in our <a href="../git/index.html">Cinder + Git</a> guide.</p>
+		<p>If you are using one of our <a href="https://libcinder.org/download">packaged releases</a>, you already have everything you need. If you're working from GitHub you'll want to follow the build instructions in our <a href="../git/index.html">Cinder + Git</a> guide.</p>
 
 		<p>To test your installation, we'll build one of the samples. From the Finder, navigate to the <em>samples/_opengl/CubeMapping</em> folder and open <em>xcode/CubeMapping.xcodeproj</em> by double-clicking it. From the <strong>Product</strong> menu select the <strong>Run</strong> item. Xcode will take a few seconds to build the sample and then it should launch and look similar to the screenshot below.</p>
 

--- a/docs/htmlsrc/guides/tour/hello_cinder.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder.html
@@ -36,7 +36,7 @@
                <br />
                In Section Two, I will tweak the particle engine from Section One and use it as a basis for a flocking simulation. Over five chapters, I will show how to create and control a 3D camera system and show how to set up a graphical interface for controlling variables in runtime. Then I will explain and implement four rules for a robust flocking simulation. By the end of Section Two, you will have a fully functioning 3D flocking simulation complete with predators and collision avoidance.<br />
                <br />
-               Below you will find some brief chapter descriptions. Each chapter has a corresponding project, which you can find in the <em>cinder/tour</em> directory. If you don't already have the Hello Cinder tour, you can download it <a href="http://libcinder.org/docs/hello_cinder/tour.zip">here</a>.<br />
+               Below you will find some brief chapter descriptions. Each chapter has a corresponding project, which you can find in the <em>cinder/tour</em> directory. If you don't already have the Hello Cinder tour, you can download it <a href="https://libcinder.org/docs/hello_cinder/tour.zip">here</a>.<br />
                <br />
             </p>
             <div class="image">

--- a/docs/htmlsrc/guides/windows-setup/index.html
+++ b/docs/htmlsrc/guides/windows-setup/index.html
@@ -25,7 +25,7 @@
 
         <!-- CONTENT STARTS HERE -->
         <h1>Windows Setup</h1>
-        <p>This guide will help you get started using Cinder on Windows. Start by downloading Cinder itself from the site's <a href="http://libcinder.org/download/">Download Page</a> if you haven't already. Choose the Visual C++ 2013 version if you don't already have Visual C++ installed.</p>
+        <p>This guide will help you get started using Cinder on Windows. Start by downloading Cinder itself from the site's <a href="https://libcinder.org/download">Download Page</a> if you haven't already. Choose the Visual C++ 2013 version if you don't already have Visual C++ installed.</p>
            
 
         <section> 
@@ -36,7 +36,7 @@
             <p>The first step is to install Visual C++ itself - click the <em>Download Community Free</em> button on the <a href="https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx">Visual Studio download page</a>. Next, launch the installer. Make sure that the Visual C++ option is selected under <em>Programming Languages</em> and press the <em>Install</em> button.
             </p>
 
-            <p>If you are using one of our <a href="http://libcinder.org/download/">packaged releases</a>, you should be all set. If you're working from GitHub you'll want to follow the build instructions in our <a href="GitSetup.html">Cinder + Git</a> guide.</p>
+            <p>If you are using one of our <a href="https://libcinder.org/download">packaged releases</a>, you should be all set. If you're working from GitHub you'll want to follow the build instructions in our <a href="GitSetup.html">Cinder + Git</a> guide.</p>
             
             <p>To verify your installation, try opening and building one of the samples. From Windows Explorer, navigate to the <em>cinder\samples\_opengl\CubeMapping\vc2013</em> folder and open <em>CubeMapping.sln</em>.</p>
             

--- a/docs/htmlsrc/index.html
+++ b/docs/htmlsrc/index.html
@@ -11,8 +11,8 @@
 		        <!-- cinder docs version links -->
 		        <div id="downloads" class="columns medium-4 large-3 hide-for-small">
 		            <ul>
-		                <li data-ci-version="0.9.0"><a href="http://libcinder.org/docs/release/v0.9.0/">Latest Release (v0.9.0)</a></li>
-		                <li data-ci-version="0.9.1dev"><a href="http://libcinder.org/docs/branch/master/">Master (v0.9.1dev)</a></li>
+		                <li data-ci-version="0.9.0"><a href="https://libcinder.org/docs/release/v0.9.0/">Latest Release (v0.9.0)</a></li>
+		                <li data-ci-version="0.9.1dev"><a href="https://libcinder.org/docs/branch/master/">Master (v0.9.1dev)</a></li>
 		            </ul>
 		        </div>
 

--- a/docs/htmlsrc/index.html
+++ b/docs/htmlsrc/index.html
@@ -11,8 +11,8 @@
 		        <!-- cinder docs version links -->
 		        <div id="downloads" class="columns medium-4 large-3 hide-for-small">
 		            <ul>
-		                <li data-ci-version="0.9.0"><a href="http://libcinder.org/docs/release/0.9.0/">Latest Release (v0.9.0)</a></li>
-		                <li data-ci-version="0.9.1.dev"><a href="http://libcinder.org/docs/branch/master/">Master (v0.9.1.dev)</a></li>
+		                <li data-ci-version="0.9.0"><a href="http://libcinder.org/docs/release/v0.9.0/">Latest Release (v0.9.0)</a></li>
+		                <li data-ci-version="0.9.1dev"><a href="http://libcinder.org/docs/branch/master/">Master (v0.9.1dev)</a></li>
 		            </ul>
 		        </div>
 

--- a/docs/htmlsrc/index.html
+++ b/docs/htmlsrc/index.html
@@ -12,7 +12,7 @@
 		        <div id="downloads" class="columns medium-4 large-3 hide-for-small">
 		            <ul>
 		                <li data-ci-version="0.9.0"><a href="https://libcinder.org/docs/release/v0.9.0/">Latest Release (v0.9.0)</a></li>
-		                <li data-ci-version="0.9.1dev"><a href="https://libcinder.org/docs/branch/master/">Master (v0.9.1dev)</a></li>
+		                <li data-ci-version="0.9.1.dev"><a href="https://libcinder.org/docs/branch/master/">Master (v0.9.1.dev)</a></li>
 		            </ul>
 		        </div>
 

--- a/docs/stylesrc/stylus/cinder_docs.styl
+++ b/docs/stylesrc/stylus/cinder_docs.styl
@@ -479,7 +479,7 @@ body.classes
 				&:nth-child(odd)
 					background: #f8f8f8	
 					
-					&.expandable:hover
+					&.expandable:not(.hidden):hover
 						animation: fade-odd 1.5s
 					
 				&.expandable

--- a/include/cinder/audio/InputNode.h
+++ b/include/cinder/audio/InputNode.h
@@ -35,7 +35,7 @@ typedef std::shared_ptr<class CallbackProcessorNode>	CallbackProcessorNodeRef;
 
 //! \brief InputNode is the base class for Node's that produce audio. It cannot have any inputs.
 //!
-//! By default, you must call start() before a InputNode will process audio. \see Node::Format::autoEnable()
+//! By default, you must call enable() before a InputNode will process audio. \see Node::Format::autoEnable()
 //! The default ChannelMode is set to Node::ChannelMode::MATCHES_OUTPUT, though subclasses may override this to use SPECIFIED instead.
 class InputNode : public Node {
   public:


### PR DESCRIPTION
Rebased the various docs commits mentioned in https://github.com/cinder/Cinder/issues/1213 onto the release_v0.9.0 branch so we can update the website. 

Fixes #1135 & #1245.

Here's the `git rebase -i origin/release_v0.9.0` commands I used:
* * *  
#1148 Updated git guide. Fixed outdated/broken links.
pick f0c04ba49cfbe91a224132e4af184ca4d552dab3 Updated index docs links
#pick f1b930f432582c01846651d379251ec3de15a8c6 Merge to resolve conflicts

#1149 Added logging guide
pick 6d1220fdb9e5281c174557a2d5469901900eccbf Added logging guide
pick 5c3eb4212a2b6147b06e52dd1a07e586cb504b6e Formatting updates based on feedback

#1150 Added supplementary html for LoggerFile and LoggerFileRotating 
pick 0bab421cbc4484dbcd9d8639a3a9380a2f507701 Added supplementary html for LoggerFile and LoggerFileRotating
pick 8968427740f131d445a7742a2b2b8366f4f422b4 small formatting changes.

#1155 Dox next fixes
pick 2820edbb23a60e95fceeb684a59dd73c18474928 No more overriding key events after click occurs.
#pick 1f0eeead8ef15dca7784e27ad523dfbe974588d2 Merge to resolve conflicts
#pick 71feb3ed6819c114f81c56a5fb9d3590f2aa6b1c Empty without merge resolution

#1177 Fixed the keyboard input bug for all pages 
pick c388e3233acb567f469a0c0a922beb5cf45df369 Removed input focus on key input.

#1183 Fix download links and migrate links to https
pick a1b89a9f0517057952c4e03b3a06eb677f83a60e fix download links and migrate links to https

#1155 Dox next fixes
pick a75048b Tweaked label for 0.9.1.dev link

#1197 Update TinderBox link
pick f1a0fdf65d35bff0e268ae675f703f9b38a8b3f3 Update TinderBox link

#1203 Fixed code syntax within function descriptions 
pick 6be9188b1aaf88a20eb1c726d3e368b440ffdd72 Fixed code syntax within funciton descriptions.

#1216 Added logging guide to main guide page. 
pick d49732f67f5fbb5b6c3f3220a6c31d0ca57af0d9 Added logging guide to main guide page.
pick c4e55c8f023e7781a019c48e616f93c4363b31f4 Spaces to tabs for consistency

#1233 Audio doc cleanup
pick e8e9e50edef1b3c49dc36460032bb547de4a6996 remove stray code section in audio guide
pick 9bc804418cd337a25adc231cb43d88ae643065ac fix doc for updated function name

* * *
There were a couple small tweaks I had to make to resolve conflicts... I think it's what the battling merge commits were trying to do.