### PR TITLE
Fix normal packing with z-aligned normals in DeferredShadingAdvanced

### DIFF
--- a/samples/_opengl/DeferredShadingAdvanced/assets/common/unpack.glsl
+++ b/samples/_opengl/DeferredShadingAdvanced/assets/common/unpack.glsl
@@ -4,11 +4,11 @@ uniform sampler2D	uSamplerDepth;
 
 vec3 unpackNormal( in vec2 uv )
 {
-    vec2 fenc   = uv * 4.0 - 2.0;
-    float f     = dot( fenc, fenc );
-    float g     = sqrt( 1.0 - f / 4.0 );
+	vec2 fenc   = uv * 4.0 - 2.0;
+	float f     = dot( fenc, fenc );
+	float g     = sqrt( 1.0 - f / 4.0 );
 
-    return vec3( fenc * g, 1.0 - f / 2.0 );
+	return vec3( fenc * g, 1.0 - f / 2.0 );
 }
 
 vec4 unpackPosition( in vec2 uv )

--- a/samples/_opengl/DeferredShadingAdvanced/assets/common/unpack.glsl
+++ b/samples/_opengl/DeferredShadingAdvanced/assets/common/unpack.glsl
@@ -4,13 +4,13 @@ uniform sampler2D	uSamplerDepth;
 
 vec3 unpackNormal( in vec2 uv )
 {
-	vec4 n				= vec4( uv.xy, 0.0, 0.0 ) * vec4( 2.0, 2.0, 0.0, 0.0 ) + vec4( -1.0, -1.0, 1.0, -1.0 );
-	float l				= dot( n.xyz, -n.xyw );
-	n.z					= l;
-	n.xy				*= sqrt( l );
-	return n.xyz * 2.0 + vec3( 0.0, 0.0, -1.0 );
+    vec2 fenc   = uv * 4.0 - 2.0;
+    float f     = dot( fenc, fenc );
+    float g     = sqrt( 1.0 - f / 4.0 );
+
+    return vec3( fenc * g, 1.0 - f / 2.0 );
 }
- 
+
 vec4 unpackPosition( in vec2 uv )
 {
 	float depth			= texture( uSamplerDepth, uv ).x;

--- a/samples/_opengl/DeferredShadingAdvanced/assets/deferred/gbuffer.frag
+++ b/samples/_opengl/DeferredShadingAdvanced/assets/deferred/gbuffer.frag
@@ -12,8 +12,8 @@ layout (location = 2) out vec4	oNormal;
 
 vec2 pack( vec3 v )
 {
-    float f = sqrt( 8.0 * v.z + 8.0 );
-    return v.xy / f + 0.5;
+	float f = sqrt( 8.0 * v.z + 8.0 );
+	return v.xy / f + 0.5;
 }
 
 void main( void )

--- a/samples/_opengl/DeferredShadingAdvanced/assets/deferred/gbuffer.frag
+++ b/samples/_opengl/DeferredShadingAdvanced/assets/deferred/gbuffer.frag
@@ -12,9 +12,8 @@ layout (location = 2) out vec4	oNormal;
 
 vec2 pack( vec3 v )
 {
-    vec2 n	= normalize( v.xy ) * ( sqrt( -v.z * 0.5 + 0.5 ) );
-    n		= n * 0.5 + 0.5;
-    return n;
+    float f = sqrt( 8.0 * v.z + 8.0 );
+    return v.xy / f + 0.5;
 }
 
 void main( void )


### PR DESCRIPTION
I was seeing an issue on certain hardware (Windows 10, Nvidia GTX 970) where z-aligned normals would have their signs flipped, causing faces to disappear. Looking at the existing normal packing method, it normalized a zero-vector which I believe could have implementation-specific behavior.

[Per](https://forum.libcinder.org/topic/deferred-shading-normal-packing) @paulhoux, referring to [this article](http://aras-p.info/texts/CompactNormalStorage.html) on normal packing, I implemented the Lambert Azimuthal Equal-Area projection approach to the Spheremap Transform method, which should be equivalent to the existing method but fixed the issue I was seeing. I've attached before and after screenshots from the DeferredShadingAdvanced sample that show pretty similar results with the two approaches. These screenshots were taken on a MacBook Pro, but I saw similar results on the Windows 10 machine.

<img width="1280" alt="before" src="https://cloud.githubusercontent.com/assets/72790/12056956/3ea0b782-aef1-11e5-87c5-8ea5cbf1b886.png">
<img width="1280" alt="after" src="https://cloud.githubusercontent.com/assets/72790/12056957/3ea3f37a-aef1-11e5-9238-6254a69af634.png">
