### PR TITLE
Updating the Source on a FilePlayerNode or Buffer on a BufferPlayerNo…

### DIFF
--- a/include/cinder/audio/SamplePlayerNode.h
+++ b/include/cinder/audio/SamplePlayerNode.h
@@ -111,9 +111,9 @@ class BufferPlayerNode : public SamplePlayerNode {
 
 	void seek( size_t readPositionFrames ) override;
 
-	//! Loads and stores a reference to a Buffer created from the entire contents of \a sourceFile.
+	//! Loads and stores a reference to a Buffer created from the entire contents of \a sourceFile. Resets the loop points to 0:getNumFrames()).
 	void loadBuffer( const SourceFileRef &sourceFile );
-	//! Sets the current Buffer. Safe to do while enabled.
+	//! Sets the current Buffer. Safe to do while enabled. Resets the loop points to 0:getNumFrames()).
 	void setBuffer( const BufferRef &buffer );
 	//! returns a shared_ptr to the current Buffer.
 	const BufferRef& getBuffer() const	{ return mBuffer; }
@@ -140,7 +140,7 @@ class FilePlayerNode : public SamplePlayerNode {
 	//! Returns whether reading occurs asynchronously (default is false). If true, file reading is done from an internal thread, if false it is done directly on the audio thread.
 	bool isReadAsync() const	{ return mIsReadAsync; }
 
-	//! \note \a sourceFile's samplerate is forced to match this Node's Context.
+	//! \note \a sourceFile's samplerate is forced to match this Node's Context. Resets the loop points to 0:getNumFrames()).
 	void setSourceFile( const SourceFileRef &sourceFile );
 	const SourceFileRef& getSourceFile() const	{ return mSourceFile; }
 

--- a/src/cinder/audio/SamplePlayerNode.cpp
+++ b/src/cinder/audio/SamplePlayerNode.cpp
@@ -163,8 +163,9 @@ void BufferPlayerNode::setBuffer( const BufferRef &buffer )
 
 	mBuffer = buffer;
 
-	if( ! mLoopEnd || mLoopEnd > mNumFrames )
-		mLoopEnd = mNumFrames;
+	// reset loop markers
+	mLoopBegin = 0;
+	mLoopEnd = mNumFrames;
 }
 
 void BufferPlayerNode::loadBuffer( const SourceFileRef &sourceFile )
@@ -336,15 +337,15 @@ void FilePlayerNode::setSourceFile( const SourceFileRef &sourceFile )
 	else
 		mSourceFile = sourceFile->cloneWithSampleRate( sampleRate );
 
+	// reset num frames and loop markers
 	mNumFrames = mSourceFile->getNumFrames();
+	mLoopBegin = 0;
+	mLoopEnd = mNumFrames;
 
 	if( getNumChannels() != mSourceFile->getNumChannels() ) {
 		setNumChannels( mSourceFile->getNumChannels() );
 		configureConnections();
 	}
-
-	if( ! mLoopEnd  || mLoopEnd > mNumFrames )
-		mLoopEnd = mNumFrames;
 
 	if( wasEnabled )
 		enable();

--- a/test/_audio/SampleTest/src/SampleTestApp.cpp
+++ b/test/_audio/SampleTest/src/SampleTestApp.cpp
@@ -194,6 +194,8 @@ void SamplePlayerNodeTestApp::setupBufferRecorderNode()
 void SamplePlayerNodeTestApp::setSourceFile( const DataSourceRef &dataSource )
 {
 	mSourceFile = audio::load( dataSource, audio::master()->getSampleRate() );
+	mLoopEndSlider.mMax = (float)mSourceFile->getNumSeconds();
+	mLoopBeginSlider.set( (float)mSourceFile->getNumSeconds() );
 
 	getWindow()->setTitle( dataSource->getFilePath().filename().string() );
 


### PR DESCRIPTION
…de will reset the loop points, so that they go from zero to the length of the new source / buffer. Otherwise switching to a longer file kept the old loopEnd intact, which was confusing.

Address the problem in the following forum post:
https://forum.libcinder.org/topic/audio-setting-a-new-file-source-on-fileplayernode-keeps-previous-file-source-frame-count