### PR TITLE
Fix for CameraPersp::generateRay

### DIFF
--- a/include/cinder/Camera.h
+++ b/include/cinder/Camera.h
@@ -148,6 +148,8 @@ class Camera {
 	virtual void	calcInverseView() const;
 	virtual void	calcProjection() const = 0;
 
+	virtual Ray		calcRay( float u, float v, float imagePlaneAspectRatio ) const;
+
 	vec3	mEyePoint;
 	vec3	mViewDirection;
 	quat	mOrientation;
@@ -213,7 +215,7 @@ class CameraPersp : public Camera {
 		A vertical lens shift of 1 (-1) will shift the view up (down) by half the height of the viewport. */
 	void	setLensShiftVertical( float vertical ) { setLensShift( mLensShift.x, vertical ); }
 	
-	virtual bool	isPersp() const { return true; }
+	bool	isPersp() const override { return true; }
 
 	//! Returns a Camera whose eyePoint is positioned to exactly frame \a worldSpaceSphere but is equivalent in other parameters (including orientation). Sets the result's pivotDistance to be the distance to \a worldSpaceSphere's center.
 	CameraPersp		calcFraming( const Sphere &worldSpaceSphere ) const;
@@ -221,7 +223,8 @@ class CameraPersp : public Camera {
   protected:
 	vec2	mLensShift;
 
-	virtual void	calcProjection() const;
+	void	calcProjection() const override;
+	Ray		calcRay( float u, float v, float imagePlaneAspectRatio ) const override;
 };
 
 //! An orthographic Camera.
@@ -230,12 +233,12 @@ class CameraOrtho : public Camera {
 	CameraOrtho();
 	CameraOrtho( float left, float right, float bottom, float top, float nearPlane, float farPlane );
 
-	void setOrtho( float left, float right, float bottom, float top, float nearPlane, float farPlane );
+	void	setOrtho( float left, float right, float bottom, float top, float nearPlane, float farPlane );
 
-	virtual bool	isPersp() const { return false; }
+	bool	isPersp() const override { return false; }
 	
   protected:
-	virtual void	calcProjection() const;
+	void	calcProjection() const override;
 };
 
 //! A Camera used for stereoscopic displays.

--- a/include/cinder/Camera.h
+++ b/include/cinder/Camera.h
@@ -114,9 +114,9 @@ class Camera {
 	virtual const mat4&	getInverseViewMatrix() const { if( ! mInverseModelViewCached ) calcInverseView(); return mInverseModelViewMatrix; }
 
 	//! Returns a Ray that passes through the image plane coordinates (\a u, \a v) (expressed in the range [0,1]) on an image plane of aspect ratio \a imagePlaneAspectRatio
-	Ray		generateRay( float u, float v, float imagePlaneAspectRatio ) const;
+	Ray		generateRay( float u, float v, float imagePlaneAspectRatio ) const { return calcRay( u, v, imagePlaneAspectRatio ); }
 	//! Returns a Ray that passes through the pixels coordinates \a posPixels on an image of size \a imageSizePixels
-	Ray		generateRay( const vec2 &posPixels, const vec2 &imageSizePixels ) const;
+	Ray		generateRay( const vec2 &posPixels, const vec2 &imageSizePixels ) const { return calcRay( posPixels.x / imageSizePixels.x, ( imageSizePixels.y - posPixels.y ) / imageSizePixels.y, imageSizePixels.x / imageSizePixels.y ); }
 	//! Returns the \a right and \a up vectors suitable for billboarding relative to the Camera
 	void	getBillboardVectors( vec3 *right, vec3 *up ) const;
 

--- a/src/cinder/Camera.cpp
+++ b/src/cinder/Camera.cpp
@@ -137,16 +137,6 @@ void Camera::getFrustum( float *left, float *top, float *right, float *bottom, f
 	*far = mFarClip;
 }
 
-Ray Camera::generateRay( float uPos, float vPos, float imagePlaneApectRatio ) const
-{	
-	return calcRay( uPos, vPos, imagePlaneApectRatio );
-}
-
-Ray Camera::generateRay( const vec2 &posPixels, const vec2 &imageSizePixels ) const
-{
-	return calcRay( posPixels.x / imageSizePixels.x, ( imageSizePixels.y - posPixels.y ) / imageSizePixels.y, imageSizePixels.x / imageSizePixels.y );
-}
-
 void Camera::getBillboardVectors( vec3 *right, vec3 *up ) const
 {
 	*right = glm::vec3( glm::row( getViewMatrix(), 0 ) );

--- a/src/cinder/Camera.cpp
+++ b/src/cinder/Camera.cpp
@@ -139,17 +139,12 @@ void Camera::getFrustum( float *left, float *top, float *right, float *bottom, f
 
 Ray Camera::generateRay( float uPos, float vPos, float imagePlaneApectRatio ) const
 {	
-	calcMatrices();
-
-	float s = ( uPos - 0.5f ) * imagePlaneApectRatio;
-	float t = ( vPos - 0.5f );
-	float viewDistance = imagePlaneApectRatio / math<float>::abs( mFrustumRight - mFrustumLeft ) * mNearClip;
-	return Ray( mEyePoint, normalize( mU * s + mV * t - ( mW * viewDistance ) ) );
+	return calcRay( uPos, vPos, imagePlaneApectRatio );
 }
 
 Ray Camera::generateRay( const vec2 &posPixels, const vec2 &imageSizePixels ) const
 {
-	return generateRay( posPixels.x / imageSizePixels.x, ( imageSizePixels.y - posPixels.y ) / imageSizePixels.y, imageSizePixels.x / imageSizePixels.y );
+	return calcRay( posPixels.x / imageSizePixels.x, ( imageSizePixels.y - posPixels.y ) / imageSizePixels.y, imageSizePixels.x / imageSizePixels.y );
 }
 
 void Camera::getBillboardVectors( vec3 *right, vec3 *up ) const
@@ -255,6 +250,16 @@ void Camera::calcInverseView() const
 	mInverseModelViewCached = true;
 }
 
+Ray Camera::calcRay( float uPos, float vPos, float imagePlaneApectRatio ) const
+{
+	calcMatrices();
+
+	float s = ( uPos - 0.5f ) * imagePlaneApectRatio;
+	float t = ( vPos - 0.5f );
+	float viewDistance = imagePlaneApectRatio / math<float>::abs( mFrustumRight - mFrustumLeft ) * mNearClip;
+	return Ray( mEyePoint, normalize( mU * s + mV * t - ( mW * viewDistance ) ) );
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // CameraPersp
 // Creates a default camera resembling Maya Persp
@@ -305,6 +310,16 @@ void CameraPersp::setPerspective( float verticalFovDegrees, float aspectRatio, f
 	mFarClip		= farPlane;
 
 	mProjectionCached = false;
+}
+
+Ray CameraPersp::calcRay( float uPos, float vPos, float imagePlaneApectRatio ) const
+{
+	calcMatrices();
+
+	float s = ( uPos - 0.5f + 0.5f * mLensShift.x ) * imagePlaneApectRatio;
+	float t = ( vPos - 0.5f + 0.5f * mLensShift.y );
+	float viewDistance = imagePlaneApectRatio / math<float>::abs( mFrustumRight - mFrustumLeft ) * mNearClip;
+	return Ray( mEyePoint, normalize( mU * s + mV * t - ( mW * viewDistance ) ) );
 }
 
 void CameraPersp::calcProjection() const


### PR DESCRIPTION
Lens shift was not taken into account. Also added 'override' keyword to virtual functions in derived classes. Use the CameraPersp sample if you want to check the implementation: the red line is the generated Ray, but it is not correct when lens shift is applied. This code will fix that. See also issue #1239 .