### PR TITLE
CameraUi events

### DIFF
--- a/include/cinder/CameraUi.h
+++ b/include/cinder/CameraUi.h
@@ -44,6 +44,8 @@ class CameraUi {
 	void connect( const app::WindowRef &window, int signalPriority = 0 );
 	//! Disconnects all signal handlers
 	void disconnect();
+	//! Returns whether the CameraUi is connected to mouse and window signal handlers
+	bool isConnected() const;
 	//! Sets whether the CameraUi will modify its CameraPersp either through its Window signals or through the various mouse*() member functions. Does not prevent resize handling.
 	void enable( bool enable = true )	{ mEnabled = enable; }
 	//! Prevents the CameraUi from modifying its CameraPersp either through its Window signals or through the various mouse*() member functions. Does not prevent resize handling.

--- a/src/cinder/CameraUi.cpp
+++ b/src/cinder/CameraUi.cpp
@@ -105,6 +105,11 @@ void CameraUi::disconnect()
 	mWindow.reset();
 }
 
+bool CameraUi::isConnected() const
+{
+	return mWindow != nullptr;
+}
+
 signals::Signal<void()>& CameraUi::getSignalCameraChange()
 {
 	return mSignalCameraChange;

--- a/src/cinder/CameraUi.cpp
+++ b/src/cinder/CameraUi.cpp
@@ -112,18 +112,27 @@ signals::Signal<void()>& CameraUi::getSignalCameraChange()
 
 void CameraUi::mouseDown( app::MouseEvent &event )
 {
+	if( ! mEnabled )
+		return;
+
 	mouseDown( event.getPos() );
 	event.setHandled();
 }
 
 void CameraUi::mouseUp( app::MouseEvent &event )
 {
+	if( ! mEnabled )
+		return;
+
 	mouseUp( event.getPos() );
 	event.setHandled();
 }
 
 void CameraUi::mouseWheel( app::MouseEvent &event )
 {
+	if( ! mEnabled )
+		return;
+
 	mouseWheel( event.getWheelIncrement() );
 	event.setHandled();
 }
@@ -146,6 +155,9 @@ void CameraUi::mouseDown( const vec2 &mousePos )
 
 void CameraUi::mouseDrag( app::MouseEvent &event )
 {
+	if( ! mEnabled )
+		return;
+
 	bool isLeftDown = event.isLeftDown();
 	bool isMiddleDown = event.isMiddleDown() || event.isAltDown();
 	bool isRightDown = event.isRightDown() || event.isControlDown();


### PR DESCRIPTION
Fixing CameraUi not testing for enabled in signal handlers, and adding isConnected() method. Addressing #1283.