### PR TITLE
ignore the .VC.opendb files created by VS 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ lib/winrt/x64/cinder*.lib
 *.suo
 *.ncb
 *.sdf
+*.VC.opendb
 *.opensdf
 Debug/
 Release/


### PR DESCRIPTION
They were showing up as untracked content whenever I ran a sample.