### PR TITLE
Fix Linux version of getDefaultExecutablePath to return parent dir path of the exe.

### DIFF
--- a/src/cinder/app/linux/PlatformLinux.cpp
+++ b/src/cinder/app/linux/PlatformLinux.cpp
@@ -406,7 +406,7 @@ fs::path PlatformLinux::getDefaultExecutablePath() const
     if( ( -1 != len ) && ( len < buf.size() ) ) {
       buf[len] = '\0';
     }
- 	return fs::path( std::string( &(buf[0]), len ) );
+ 	return fs::path( std::string( &(buf[0]), len ) ).parent_path();
 }
 
 void PlatformLinux::sleep( float milliseconds ) 


### PR DESCRIPTION
As is [currently](https://github.com/cinder/Cinder/blob/android_linux/src/cinder/app/linux/PlatformLinux.cpp#L409) `getDefaultExecutablePath` will return the full symlink path to the exe including the exe itself. This fixes it by returning the parent dir of the exe as it happens on the other platforms too.