### PR TITLE
include sdkddkver.h in Cinder.h

### DIFF
--- a/include/cinder/Cinder.h
+++ b/include/cinder/Cinder.h
@@ -65,6 +65,7 @@ using std::uint64_t;
 		#endif
 	#else
 		#define CINDER_MSW
+		#include <sdkddkver.h>
 	#endif
 #elif defined(linux) || defined(__linux) || defined(__linux__)
 	#define CINDER_LINUX


### PR DESCRIPTION
I'm using Paul's upcoming video stuff  in a project and I was able to just drop into into my project except for [this change](https://github.com/cinder/Cinder/compare/cinder:7182b3a...paulhoux:8392693#diff-d952cf3677246763cc7566adede21863). He's using the macros defined within that windows header throughout his code base to make sure MF isn't used before vista.

Also we're already including similar headers for Mac (TargetConditionals.h, AvailabilityMacros.h), and I do think it is nice to use the macro names like `#if( _WIN32_WINNT >= _WIN32_WINNT_VISTA )` rather than 0x600 or whatever. This header doesn't #include any other windows headers so it is pretty lightweight.