### PR TITLE
Fix velocity buffer motion blur sample.

### DIFF
--- a/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
+++ b/samples/_opengl/MotionBlurVelocityBuffer/src/MotionBlurVelocityBufferApp.cpp
@@ -287,6 +287,7 @@ void MotionBlurVelocityBufferApp::draw()
 	gl::ScopedMatrices matrices;
 	gl::setMatricesWindowPersp( getWindowSize(), 60.0f, 1.0f, 5000.0f );
 	gl::ScopedViewport viewport( vec2(0), getWindowSize() );
+	gl::ScopedBlend blend(false);
 
 	gl::draw( mBackground, getWindowBounds() );
 


### PR DESCRIPTION
Now-default alpha blending broke the velocity buffer rendering.
Simply disabled the alpha blending.

Closes #1055 (at least on OSX)