### PR TITLE
Osc and Tuio updates

### DIFF
--- a/blocks/OSC/src/Osc.h
+++ b/blocks/OSC/src/Osc.h
@@ -278,6 +278,9 @@ class Message {
 	bool			operator==( const Message &other ) const;
 	//! Evaluates the inequality of this with \a other
 	bool			operator!=( const Message &other ) const;
+	//! Returns a const reference of the Sender's (originator) Ip Address. Note: Will only
+	//! be set by the receiver when the message is received.
+	const asio::ip::address& getSenderIpAddress() const { return mSenderIpAddress; }
 	
   private:
 	//! Helper to calculate how many zeros to buffer to create a 4 byte
@@ -329,6 +332,7 @@ class Message {
 	std::vector<Argument>	mDataViews;
 	mutable bool			mIsCached;
 	mutable ByteBufferRef	mCache;
+	asio::ip::address		mSenderIpAddress;
 	
 	//! Create the OSC message and store it in cache.
 	void createCache() const;
@@ -663,7 +667,7 @@ public:
 	
 	//! Decodes and routes messages from the networking layer stream. Dispatches all messages with an address that
 	//! has an associated listener.
-	void dispatchMethods( uint8_t *data, uint32_t size );
+	void dispatchMethods( uint8_t *data, uint32_t size, const asio::ip::address &senderIpAddress );
 	//! Decodes a complete OSC Packet into it's individual parts. \a timetag is ignored within the below implementations.
 	bool decodeData( uint8_t *data, uint32_t size, std::vector<Message> &messages, uint64_t timetag = 0 ) const;
 	//! Decodes an individual message. \a timetag is ignored within the below implementations.

--- a/blocks/OSC/test/Test/src/TestApp.cpp
+++ b/blocks/OSC/test/Test/src/TestApp.cpp
@@ -61,6 +61,7 @@ TestApp::TestApp()
 	mReceiver.setListener( "/app/?",
 	[]( const osc::Message &message ){
 		cout << "Integer: " << message[0].int32() << endl;
+		cout << "Received From: " << message.getSenderIpAddress() << endl;
 	} );
 	mReceiver.setListener( "/app/?",
 	[]( const osc::Message &message ) {

--- a/blocks/OSC/test/Test/src/TestApp.cpp
+++ b/blocks/OSC/test/Test/src/TestApp.cpp
@@ -30,6 +30,7 @@ class TestApp : public App {
 	osc::SenderUdp		mSender;
 #else
 	void sendMessageTcp( const osc::Message &message );
+	void cleanup() override;
 	
 	osc::PacketFramingRef mPacketFraming;
 	
@@ -53,7 +54,8 @@ TestApp::TestApp()
 #endif
 	mReceiver( 10000, mPacketFraming ), mSender( 12345, "127.0.0.1", 10000, mPacketFraming )
 #endif
-{	
+{
+	log::manager()->makeLogger<log::LoggerBreakpoint>();
 	mReceiver.bind();
 	mReceiver.listen();
 	mReceiver.setListener( "/app/?",
@@ -178,20 +180,28 @@ void TestApp::update()
 		message.append( true );
 		
 		mSender.send( message );
-		
 		mMessage = std::move( message );
 //		cout << mMessage << endl;
-        
+		
         {
 			const char* something = "Something";
 			mMessage2 = osc::Message( "/message2" ) << 3 << 4 << 2.0 << 3.0f << "string literal" << something;
-			cout << "As constructed: " << mMessage2 << endl;
+//			cout << "As constructed: " << mMessage2 << endl;
             mSender.send(mMessage2);
         }
 	}
 	
 	gl::clear();
 }
+
+#if ! TEST_UDP
+void TestApp::cleanup()
+{
+	mSender.shutdown();
+	mReceiver.close();
+	mSender.close();
+}
+#endif
 
 #if defined( CINDER_MSW )
 CINDER_APP(TestApp, RendererGl, [](App::Settings *settings) { settings->setConsoleWindowEnabled(); })


### PR DESCRIPTION
- Fixed edge case in Tuio. In the spec, the source message is optional and in production this was breaking Tuio. Added an address to Osc Messages and use that address as a "source" in Tuio.
- Also implemented socket shutdown for Osc, which fixes a problem people were having with opening a socket soon after closing it. However, there are still edge cases, which can be seen [here](http://stackoverflow.com/questions/35365826/asio-address-already-in-use-on-bind-yet-i-can-still-connect/35394556#35394556).