### PR TITLE
detect CMYK files and throw more detailed exception.

### DIFF
--- a/src/cinder/ImageSourceFileWic.cpp
+++ b/src/cinder/ImageSourceFileWic.cpp
@@ -206,6 +206,9 @@ bool ImageSourceFileWic::processFormat( const ::GUID &guid, ::GUID *convertGUID 
 	else if( guid == GUID_WICPixelFormat32bppGrayFloat ) {
 		setChannelOrder( ImageIo::Y ); setColorModel( ImageIo::CM_GRAY ); setDataType( ImageIo::FLOAT32 );
 	}
+	else if( guid == GUID_WICPixelFormat32bppCMYK || guid == GUID_WICPixelFormat64bppCMYK || guid == GUID_WICPixelFormat40bppCMYKAlpha || guid == GUID_WICPixelFormat80bppCMYKAlpha ) {
+		throw ImageIoExceptionIllegalColorModel( "CMYK pixel format not supported." );
+	}
 	else
 		throw ImageIoException( "Unsupported format." );
 


### PR DESCRIPTION
I ran into some client-provided jpeg's that were encoded in CMYK format, was getting the `ImageIoException` that explains its an 'unsupported format' but didn't know why at first. This'll make it clear that we don't support cmyk color model..