### PR TITLE
Linux fix DialogHelper(Zenity) newline ending.

### DIFF
--- a/src/cinder/app/linux/PlatformLinux.cpp
+++ b/src/cinder/app/linux/PlatformLinux.cpp
@@ -171,16 +171,16 @@ struct DialogHelper {
 						value += static_cast<const char *>( buffer.data() );
 					}
 				}
-                if( ! value.empty() ) {
-                    // Zenity seems to add a new line character at the end of the path, so remove it if present.
-                    const auto newLineCharacterPos = std::strcspn( value.c_str(), "\n" );
+				if( ! value.empty() ) {
+					// Zenity seems to add a new line character at the end of the path, so remove it if present.
+					const auto newLineCharacterPos = std::strcspn( value.c_str(), "\n" );
 
-                    if( newLineCharacterPos !=  value.size() ) {
-                        value[ newLineCharacterPos ] = 0;
-                    }
+					if( newLineCharacterPos !=  value.size() ) {
+						value[ newLineCharacterPos ] = 0;
+					}
 
 					result = value;
-                }
+				}
 			}
 			pclose(pipe);			
 		}

--- a/src/cinder/app/linux/PlatformLinux.cpp
+++ b/src/cinder/app/linux/PlatformLinux.cpp
@@ -171,9 +171,16 @@ struct DialogHelper {
 						value += static_cast<const char *>( buffer.data() );
 					}
 				}
-				if( ! value.empty() ) {
+                if( ! value.empty() ) {
+                    // Zenity seems to add a new line character at the end of the path, so remove it if present.
+                    const auto newLineCharacterPos = std::strcspn( value.c_str(), "\n" );
+
+                    if( newLineCharacterPos !=  value.size() ) {
+                        value[ newLineCharacterPos ] = 0;
+                    }
+
 					result = value;
-				}
+                }
 			}
 			pclose(pipe);			
 		}


### PR DESCRIPTION
It seems that paths coming from Zenity contain a newline character at the end. This messes up filenames that then appear with this character ending. Use the ObjLoader sample as a test case to reproduce. The fix should not affect other DialogHelpers.