### PR TITLE
VertBatch cleanup

### DIFF
--- a/include/cinder/gl/Batch.h
+++ b/include/cinder/gl/Batch.h
@@ -47,7 +47,7 @@ class Batch {
 	static BatchRef		create( const VboMeshRef &vboMesh, const gl::GlslProgRef &glsl, const AttributeMapping &attributeMapping = AttributeMapping() );
 	//! Builds a Batch from a geom::Source and a GlslProg. Attributes defined in \a attributeMapping override the default mapping
 	static BatchRef		create( const geom::Source &source, const gl::GlslProgRef &glsl, const AttributeMapping &attributeMapping = AttributeMapping() );
-	
+
 	//! Draws the Batch. Optionally specify a \a first vertex/element and a \a count. Otherwise the entire geometry will be drawn.
 	void			draw( GLint first = 0, GLsizei count = -1 );
 #if defined( CINDER_GL_HAS_DRAW_INSTANCED )
@@ -83,12 +83,12 @@ class Batch {
 
 	void	init( const geom::Source &source, const gl::GlslProgRef &glsl );
 	void	initVao( const AttributeMapping &attributeMapping = AttributeMapping() );
-		
+
 	VboMeshRef				mVboMesh;
 	VaoRef					mVao;
 	GlslProgRef				mGlsl;
 	AttributeMapping		mAttribMapping;
-	
+
 	friend class BatchGeomTarget;
 };
 
@@ -161,16 +161,16 @@ class VertBatch : public geom::Source {
 	void	begin( GLenum type );
 	//! No-op. Present for parity with legacy immediate mode.
 	void	end() {}
-	
+
 	//! Clears all vertices recorded by the VertBatch
 	void	clear();
 
 	//! Returns \c true if no vertices have been added to the VertBatch.
 	bool	empty() const { return mVertices.empty(); }
-	
+
 	//! Draws the VertBatch using the gl::Context's currently active shader. For multiple draws consider constructing a gl::Batch using the VertBatch instead.
 	void	draw();
-	
+
   protected:
 	void	addVertex( const vec4 &v );
 	void	setupBuffers();
@@ -185,17 +185,18 @@ class VertBatch : public geom::Source {
 	VertBatch*		clone() const override { return new VertBatch( *this ); }
 
 	geom::AttribSet	getAvailableAttribs() const override;
-	
+
 
 	GLenum					mPrimType;
 
 	std::vector<vec4>		mVertices;
-	
+
 	std::vector<vec3>		mNormals;
 	std::vector<ColorAf>	mColors;
 	std::vector<vec4>		mTexCoords0, mTexCoords1;
-	
+
 	bool					mOwnsBuffers;
+	bool					mForceUpdate;
 	Vao*					mVao;
 	VaoRef					mVaoStorage;
 	VboRef					mVbo;

--- a/src/cinder/gl/Batch.cpp
+++ b/src/cinder/gl/Batch.cpp
@@ -74,15 +74,15 @@ void Batch::initVao( const AttributeMapping &attributeMapping )
 
 	mVao = Vao::create();
 	ctx->pushVao( mVao );
-	
+
 	mVboMesh->buildVao( mGlsl, attributeMapping );
-	
+
 	ctx->popVao();
 	ctx->popBufferBinding( GL_ARRAY_BUFFER );
-	
+
 	if( ! mVao->getLayout().isVertexAttribArrayEnabled( 0 ) )
 		CI_LOG_W("VertexAttribArray at location 0 not enabled, this has performance implications.");
-	
+
 	mAttribMapping = attributeMapping;
 }
 
@@ -101,7 +101,7 @@ void Batch::replaceVboMesh( const VboMeshRef &vboMesh )
 void Batch::draw( GLint first, GLsizei count )
 {
 	auto ctx = gl::context();
-	
+
 	gl::ScopedGlslProg ScopedGlslProg( mGlsl );
 	gl::ScopedVao ScopedVao( mVao );
 	ctx->setDefaultShaderVars();
@@ -113,7 +113,7 @@ void Batch::draw( GLint first, GLsizei count )
 void Batch::drawInstanced( GLsizei instanceCount )
 {
 	auto ctx = gl::context();
-	
+
 	gl::ScopedGlslProg ScopedGlslProg( mGlsl );
 	gl::ScopedVao ScopedVao( mVao );
 	ctx->setDefaultShaderVars();
@@ -136,7 +136,7 @@ void Batch::reassignContext( Context *context )
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // VertBatch
 VertBatch::VertBatch( GLenum primType, bool useContextDefaultBuffers )
-	: mPrimType( primType )
+	: mPrimType( primType ), mForceUpdate( false )
 {
 	if( useContextDefaultBuffers ) {
 		auto ctx = gl::context();
@@ -144,13 +144,17 @@ VertBatch::VertBatch( GLenum primType, bool useContextDefaultBuffers )
 		mVbo = ctx->getDefaultArrayVbo();
 		mOwnsBuffers = false;
 	}
-	else
+	else {
+		mVaoStorage = gl::Vao::create();
+		mVao = mVaoStorage.get();
+		mVbo = gl::Vbo::create( GL_ARRAY_BUFFER, 0 );
 		mOwnsBuffers = true;
+	}
 }
 
 VertBatchRef VertBatch::create( GLenum primType, bool useContextDefaultBuffers )
 {
-	return VertBatchRef( new VertBatch( primType, useContextDefaultBuffers ) ); 
+	return VertBatchRef( new VertBatch( primType, useContextDefaultBuffers ) );
 }
 
 void VertBatch::setType( GLenum primType )
@@ -196,16 +200,17 @@ void VertBatch::vertex( const vec4 &v, const ColorAf &c )
 
 void VertBatch::addVertex( const vec4 &v )
 {
+	mForceUpdate = true;
 	mVertices.push_back( v );
 
 	if( ! mNormals.empty() ) {
 		while( mNormals.size() < mVertices.size() )
 			mNormals.push_back( mNormals.back() );
 	}
-	
+
 	if( ! mColors.empty() ) {
 		while( mColors.size() < mVertices.size() )
-			mColors.push_back( mColors.back() );	
+			mColors.push_back( mColors.back() );
 	}
 
 	if( ! mTexCoords0.empty() ) {
@@ -232,26 +237,22 @@ void VertBatch::clear()
 	mColors.clear();
 	mTexCoords0.clear();
 	mTexCoords1.clear();
-	mVbo.reset();
-	mVao = nullptr;
 }
 
 void VertBatch::draw()
 {
-	// this pushes the VAO, which needs to be popped
+	ScopedVao scopedVao( mVao );
 	setupBuffers();
-	ScopedVao vao( mVao );
-	
+
 	auto ctx = context();
 	ctx->setDefaultShaderVars();
 	ctx->drawArrays( mPrimType, 0, (GLsizei)mVertices.size() );
 }
 
-// Leaves mVAO bound
 void VertBatch::setupBuffers()
 {
 	auto ctx = gl::context();
-	
+
 	auto glslProg = ctx->getGlslProg();
 	if( ! glslProg )
 		return;
@@ -263,24 +264,19 @@ void VertBatch::setupBuffers()
 	const size_t texCoords1SizeBytes = mTexCoords1.size() * sizeof(vec4);
 	size_t totalSizeBytes = verticesSizeBytes + normalsSizeBytes + colorsSizeBytes + texCoords0SizeBytes + texCoords1SizeBytes;
 
-	// allocate the VBO if we don't have one yet (which implies we're not using the context defaults)
-	bool forceUpload = false;
-	if( ! mVbo ) {
-		// allocate the VBO and upload the data
-		mVbo = gl::Vbo::create( GL_ARRAY_BUFFER, totalSizeBytes );
-		forceUpload = true;
-	}
-	
-	ScopedBuffer ScopedBuffer( mVbo );
+	ScopedBuffer scopedVbo( mVbo );
+
 	// if this VBO was freshly made, or we don't own the buffer because we use the context defaults
-	if( ( forceUpload || ( ! mOwnsBuffers ) ) && ( ! mVertices.empty() ) ) {
+	if( ( ! mVertices.empty() ) && ( mForceUpdate || ( ! mOwnsBuffers ) ) ) {
+
+		mForceUpdate = false;
 		mVbo->ensureMinimumSize( totalSizeBytes );
-		
+
 		// upload positions
 		GLintptr offset = 0;
 		mVbo->bufferSubData( offset, verticesSizeBytes, &mVertices[0] );
 		offset += verticesSizeBytes;
-		
+
 		// upload normals
 		if( ! mNormals.empty() ) {
 			mVbo->bufferSubData( offset, normalsSizeBytes, &mNormals[0] );
@@ -306,17 +302,8 @@ void VertBatch::setupBuffers()
 		}
 	}
 
-	// Setup the VAO
-	ctx->pushVao(); // this will be popped by draw()
-	if( ! mOwnsBuffers )
-		mVao->replacementBindBegin();
-	else {
-		mVaoStorage = gl::Vao::create();
-		mVao = mVaoStorage.get();
-		mVao->bind();
-	}
+	mVao->replacementBindBegin();
 
-	gl::ScopedBuffer vboScope( mVbo );
 	size_t offset = 0;
 	if( glslProg->hasAttribSemantic( geom::Attrib::POSITION ) ) {
 		int loc = glslProg->getAttribSemanticLocation( geom::Attrib::POSITION );
@@ -351,10 +338,8 @@ void VertBatch::setupBuffers()
 		ctx->enableVertexAttribArray( loc );
 		ctx->vertexAttribPointer( loc, 4, GL_FLOAT, false, 0, (const GLvoid*)offset );
 	}
-	
-	if( ! mOwnsBuffers )
-		mVao->replacementBindEnd();
-	ctx->popVao();
+
+	mVao->replacementBindEnd();
 }
 
 size_t VertBatch::getNumVertices() const
@@ -408,7 +393,7 @@ geom::AttribSet	VertBatch::getAvailableAttribs() const
 {
 	geom::AttribSet attribs;
 	attribs.insert( geom::Attrib::POSITION );
-	
+
 	if( ! mNormals.empty() )
 		attribs.insert( geom::Attrib::NORMAL );
 	if( ! mColors.empty() )
@@ -417,7 +402,7 @@ geom::AttribSet	VertBatch::getAvailableAttribs() const
 		attribs.insert( geom::Attrib::TEX_COORD_0 );
 	if( ! mTexCoords1.empty() )
 		attribs.insert( geom::Attrib::TEX_COORD_1 );
-	
+
 	return attribs;
 }
 


### PR DESCRIPTION
Cleans up the VertBatch code and fixes the error on RPI2 mentioned [here](https://forum.libcinder.org/topic/params-won-t-compile-on-pi#23286000002630003)  by @chaoticbob 
Also fixes a problem where the Vao pointer is set to nullptr on clear when using default buffers.

This example fails on current master:
```c++
// setup
mBatch = gl::VertBatch::create( GL_POINTS, true );

// draw
mBatch->begin( GL_LINE_STRIP );
for( const vec2 &point : mPoints ) {
	mBatch->vertex( vec4( point, 0, 1 ), Color( 1.0f, 0.5f, 0.25f ) );
}
mBatch->draw();
```

Also fixed whitespace issues