### PR TITLE
Fixed gl::Sync Position in Flickr Multi-threaded Sample

### DIFF
--- a/samples/FlickrTestMultithreaded/src/FlickrTestMultithreadedApp.cpp
+++ b/samples/FlickrTestMultithreaded/src/FlickrTestMultithreadedApp.cpp
@@ -68,11 +68,14 @@ void FlickrTestMTApp::loadImagesThreadFn( gl::ContextRef context )
 	// load images as Textures into our ConcurrentCircularBuffer
 	while( ( ! mShouldQuit ) && ( ! urls.empty() ) ) {
 		try {
+			auto urlSource = loadUrl( urls.back() );
+			auto imageSource = loadImage( urlSource );
+			auto tex = gl::Texture::create( imageSource );
+			
 			// we need to wait on a fence before alerting the primary thread that the Texture is ready
 			auto fence = gl::Sync::create();
-			auto tex = gl::Texture::create( loadImage( loadUrl( urls.back() ) ) );
-			// wait on the fence
 			fence->clientWaitSync();
+			
 			mImages->pushFront( tex );
 			urls.pop_back();
 		}


### PR DESCRIPTION
Fixed a bug in the Flickr Multi-threaded sample. 

In its previous form, the fence ensured that only the gl commands sent _before_ texture::create() were completed. This can lead to incomplete textures after the fence, specifically with the following call to gl::texture::create().

Quick fix that pushes gl::Sync::create() and clientWaitSync next to each other. This will properly block until all work, including gl::texture::create(), is complete.