### PR TITLE
Use glfwSetWindowShouldClose for signalling quit. Fixes exit crash.

### DIFF
--- a/src/cinder/app/linux/AppImplLinuxGlfw.cpp
+++ b/src/cinder/app/linux/AppImplLinuxGlfw.cpp
@@ -359,7 +359,9 @@ WindowRef AppImplLinux::createWindow( Window::Format format )
 
 void AppImplLinux::quit()
 {
-	::glfwTerminate();
+	for( auto &window : mWindows ) {
+		::glfwSetWindowShouldClose( window->getNative(), true );	
+	}
 }
 
 float AppImplLinux::getFrameRate() const 


### PR DESCRIPTION
This fixes a crash on exit that happens currently when you quit the app through `ci::app::quit` . The reason is that currently `ci::app::quit` calls `::glfwTerminate` which invalidates and destroys all windows immediately but since this can happen from callbacks there is no guaranty that [`::glfwPollEvents`](https://github.com/PetrosKataras/Cinder/blob/6ddaa339551b32ee2638f0ca42a9019453a1a2e7/src/cinder/app/linux/AppImplLinuxGlfw.cpp#L310) will not be called from the run loop after all windows are destroyed which leads to a crash internally on X.

With this PR windows are flagged as ready to close inside `ci::app::quit` and are actually closed inside the run loop after `::glfwPollEvents` has finished, keeping the exit order sane.

