### PR TITLE
Add vec2 overload of RectT::scaledCentered()

### DIFF
--- a/include/cinder/Rect.h
+++ b/include/cinder/Rect.h
@@ -69,6 +69,7 @@ class RectT {
 	//! Translates the rectangle so that its center is at \a center
 	void		offsetCenterTo( const Vec2T &center ) { offset( center - getCenter() ); }
 	void		scaleCentered( const Vec2T &scale );
+	RectT		scaledCentered( const Vec2T &scale ) const;
 	void		scaleCentered( T scale );
 	RectT		scaledCentered( T scale ) const;
 	void		scale( T scale );

--- a/src/cinder/Rect.cpp
+++ b/src/cinder/Rect.cpp
@@ -179,6 +179,15 @@ void RectT<T>::scaleCentered( T scale )
 }
 
 template<typename T>
+RectT<T> RectT<T>::scaledCentered( const Vec2T &scale ) const
+{
+	const T halfWidth = getWidth() * scale.x / 2;
+	const T halfHeight = getHeight() * scale.y / 2;
+	const auto center = getCenter();
+	return RectT<T>( center.x - halfWidth, center.y - halfHeight, center.x + halfWidth, center.y + halfHeight );
+}
+
+template<typename T>
 RectT<T> RectT<T>::scaledCentered( T scale ) const
 {
 	const T halfWidth = getWidth() * scale / 2;


### PR DESCRIPTION
Rectifies (har har) one case where the copying (past tense) methods don't match the in-place.