### PR TITLE
Fixing vc2013 handling of std::atomic

### DIFF
--- a/blocks/OSC/src/Osc.h
+++ b/blocks/OSC/src/Osc.h
@@ -617,7 +617,7 @@ class SenderTcp : public SenderBase {
 	asio::ip::tcp::endpoint mLocalEndpoint, mRemoteEndpoint;
 	OnConnectFn				mOnConnectFn;
 	std::mutex				mOnConnectFnMutex;
-	std::atomic_bool		mIsConnected;
+	std::atomic<bool>		mIsConnected;
 	
   public:
 	//! Non-copyable.
@@ -833,7 +833,7 @@ class ReceiverTcp : public ReceiverBase {
 		TcpSocketRef			mSocket;
 		ReceiverTcp*			mReceiver;
 		asio::streambuf			mBuffer;
-		std::atomic_bool		mIsConnected;
+		std::atomic<bool>		mIsConnected;
 		
 		const uint64_t			mIdentifier;
 		
@@ -879,7 +879,7 @@ class ReceiverTcp : public ReceiverBase {
 	using UniqueConnection = std::unique_ptr<Connection>;
 	std::vector<UniqueConnection>		mConnections;
 	uint64_t							mConnectionIdentifiers;
-	std::atomic_bool					mIsShuttingDown;
+	std::atomic<bool>					mIsShuttingDown;
 
 	friend struct Connection;
   public:


### PR DESCRIPTION
This fixes a problem with the way vc2013 handles atomic types. Solution found [here](http://stackoverflow.com/questions/15750917/initializing-stdatomic-bool). Fixes #1405