### PR TITLE
Allow Surfaces larger than 2GiB

### DIFF
--- a/blocks/Cairo/include/cinder/cairo/Cairo.h
+++ b/blocks/Cairo/include/cinder/cairo/Cairo.h
@@ -788,7 +788,7 @@ namespace cinder {
 class SurfaceConstraintsCairo : public cinder::SurfaceConstraints {
  public:
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const;
-	virtual int32_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const;
+	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const;
 };
 
 } // namespace cinder

--- a/blocks/Cairo/include/cinder/cairo/Cairo.h
+++ b/blocks/Cairo/include/cinder/cairo/Cairo.h
@@ -788,7 +788,7 @@ namespace cinder {
 class SurfaceConstraintsCairo : public cinder::SurfaceConstraints {
  public:
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const;
-	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const;
+	virtual ptrdiff_t			getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const;
 };
 
 } // namespace cinder

--- a/blocks/Cairo/src/Cairo.cpp
+++ b/blocks/Cairo/src/Cairo.cpp
@@ -53,7 +53,7 @@ SurfaceChannelOrder SurfaceConstraintsCairo::getChannelOrder( bool alpha ) const
 	return ( alpha ) ? SurfaceChannelOrder::BGRA : SurfaceChannelOrder::BGRX;
 }
 
-size_t	SurfaceConstraintsCairo::getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const {
+ptrdiff_t SurfaceConstraintsCairo::getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const {
 	return cairo_format_stride_for_width( sco.hasAlpha() ? CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_RGB24, requestedWidth );
 }
 

--- a/blocks/Cairo/src/Cairo.cpp
+++ b/blocks/Cairo/src/Cairo.cpp
@@ -53,7 +53,7 @@ SurfaceChannelOrder SurfaceConstraintsCairo::getChannelOrder( bool alpha ) const
 	return ( alpha ) ? SurfaceChannelOrder::BGRA : SurfaceChannelOrder::BGRX;
 }
 
-int32_t	SurfaceConstraintsCairo::getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const {
+size_t	SurfaceConstraintsCairo::getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const {
 	return cairo_format_stride_for_width( sco.hasAlpha() ? CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_RGB24, requestedWidth );
 }
 

--- a/include/cinder/Channel.h
+++ b/include/cinder/Channel.h
@@ -43,9 +43,9 @@ class ChannelT {
 	//! Allocates and owns a contiguous block of memory that is sizeof(T) * width * height
 	ChannelT( int32_t width, int32_t height );
 	//! Does not allocate or own memory pointed to by \a data
-	ChannelT( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data );
+	ChannelT( int32_t width, int32_t height, ptrdiff_t rowBytes, uint8_t increment, T *data );
 	//! Does not allocate memory pointed to by \a data but holds a reference to \a dataStore
-	ChannelT( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data, const std::shared_ptr<T> &dataStore );
+	ChannelT( int32_t width, int32_t height, ptrdiff_t rowBytes, uint8_t increment, T *data, const std::shared_ptr<T> &dataStore );
 	//! Creates a clone of \a rhs. Data is always stored planar regardless of the increment of \a rhs.
 	ChannelT( const ChannelT &rhs );
 	//! Move constructor. Receives data store of \a rhs.
@@ -62,11 +62,11 @@ class ChannelT {
 	{ return std::make_shared<ChannelT<T>>( width, height ); }
 	
 	//! Does not allocate or own memory pointed to by \a data
-	static std::shared_ptr<ChannelT<T>> create( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data )
+	static std::shared_ptr<ChannelT<T>> create( int32_t width, int32_t height, ptrdiff_t rowBytes, uint8_t increment, T *data )
 	{ return std::make_shared<ChannelT<T>>( width, height, rowBytes, increment, data ); }
 	
 	//! Does not allocate memory pointed to by \a data but holds a reference to \a dataStore
-	static std::shared_ptr<ChannelT<T>> create( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data, const std::shared_ptr<T> &dataStore )
+	static std::shared_ptr<ChannelT<T>> create( int32_t width, int32_t height, ptrdiff_t rowBytes, uint8_t increment, T *data, const std::shared_ptr<T> &dataStore )
 	{ return std::make_shared<ChannelT<T>>( width, height, rowBytes, increment, data, dataStore ); }
 	
 	//! Creates a clone of \a rhs. Data is always stored planar regardless of the increment of \a rhs.
@@ -94,9 +94,9 @@ class ChannelT {
 	//! Returns the bounding Area of the Channel in pixels: [0,0]-(width,height)
 	Area		getBounds() const { return Area( 0, 0, mWidth, mHeight ); }
 	//! Returns the width of a row of the Channel measured in bytes, which is not necessarily getWidth() * getPixelInc()
-	size_t		getRowBytes() const { return mRowBytes; }
+	ptrdiff_t	getRowBytes() const { return mRowBytes; }
 	//! Returns the amount to increment a T* to increment by a pixel. For a planar channel this is \c 1, but for a Channel of a Surface this might be \c 3 or \c 4
-	size_t		getIncrement() const { return mIncrement; }
+	uint8_t		getIncrement() const { return mIncrement; }
 	//! Returns whether the Channel represents a tightly packed array of values. This will be \c false if the Channel is a member of a Surface. Analogous to <tt>getIncrement() == 1</tt>
 	bool		isPlanar() const { return mIncrement == 1; }
 
@@ -187,7 +187,8 @@ class ChannelT {
 		int32_t		getHeight() { return mHeight; }
 
 		/// \cond
-		size_t				mInc, mRowInc;
+		uint8_t				mInc;
+		ptrdiff_t			mRowInc;
 		uint8_t				*mLinePtr;
 		T					*mPtr;
 		int32_t				mWidth, mHeight;
@@ -255,7 +256,8 @@ class ChannelT {
 		int32_t		getHeight() { return mHeight; }
 
 		/// \cond
-		size_t				mInc, mRowInc;
+		uint8_t				mInc;
+		ptrdiff_t			mRowInc;
 		const uint8_t		*mLinePtr;
 		const T				*mPtr;
 		int32_t				mWidth, mHeight;
@@ -271,10 +273,11 @@ class ChannelT {
 	ConstIter	getIter() const { return ConstIter( *this, this->getBounds() ); }
 	//! Returns a ConstIter which iterates the Area \a area.
 	ConstIter	getIter( const Area &area ) const { return ConstIter( *this, area ); }
-	
+
   protected:
 	int32_t						mWidth, mHeight;
-	size_t						mRowBytes, mIncrement;
+	uint8_t						mIncrement;
+	ptrdiff_t					mRowBytes;
 	T							*mData;
 	std::shared_ptr<T>			mDataStore;
 };

--- a/include/cinder/Channel.h
+++ b/include/cinder/Channel.h
@@ -43,9 +43,9 @@ class ChannelT {
 	//! Allocates and owns a contiguous block of memory that is sizeof(T) * width * height
 	ChannelT( int32_t width, int32_t height );
 	//! Does not allocate or own memory pointed to by \a data
-	ChannelT( int32_t width, int32_t height, int32_t rowBytes, uint8_t increment, T *data );
+	ChannelT( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data );
 	//! Does not allocate memory pointed to by \a data but holds a reference to \a dataStore
-	ChannelT( int32_t width, int32_t height, int32_t rowBytes, uint8_t increment, T *data, const std::shared_ptr<T> &dataStore );
+	ChannelT( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data, const std::shared_ptr<T> &dataStore );
 	//! Creates a clone of \a rhs. Data is always stored planar regardless of the increment of \a rhs.
 	ChannelT( const ChannelT &rhs );
 	//! Move constructor. Receives data store of \a rhs.
@@ -62,11 +62,11 @@ class ChannelT {
 	{ return std::make_shared<ChannelT<T>>( width, height ); }
 	
 	//! Does not allocate or own memory pointed to by \a data
-	static std::shared_ptr<ChannelT<T>> create( int32_t width, int32_t height, int32_t rowBytes, uint8_t increment, T *data )
+	static std::shared_ptr<ChannelT<T>> create( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data )
 	{ return std::make_shared<ChannelT<T>>( width, height, rowBytes, increment, data ); }
 	
 	//! Does not allocate memory pointed to by \a data but holds a reference to \a dataStore
-	static std::shared_ptr<ChannelT<T>> create( int32_t width, int32_t height, int32_t rowBytes, uint8_t increment, T *data, const std::shared_ptr<T> &dataStore )
+	static std::shared_ptr<ChannelT<T>> create( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data, const std::shared_ptr<T> &dataStore )
 	{ return std::make_shared<ChannelT<T>>( width, height, rowBytes, increment, data, dataStore ); }
 	
 	//! Creates a clone of \a rhs. Data is always stored planar regardless of the increment of \a rhs.
@@ -94,9 +94,9 @@ class ChannelT {
 	//! Returns the bounding Area of the Channel in pixels: [0,0]-(width,height)
 	Area		getBounds() const { return Area( 0, 0, mWidth, mHeight ); }
 	//! Returns the width of a row of the Channel measured in bytes, which is not necessarily getWidth() * getPixelInc()
-	int32_t		getRowBytes() const { return mRowBytes; }
+	size_t		getRowBytes() const { return mRowBytes; }
 	//! Returns the amount to increment a T* to increment by a pixel. For a planar channel this is \c 1, but for a Channel of a Surface this might be \c 3 or \c 4
-	uint8_t		getIncrement() const { return mIncrement; }
+	size_t		getIncrement() const { return mIncrement; }
 	//! Returns whether the Channel represents a tightly packed array of values. This will be \c false if the Channel is a member of a Surface. Analogous to <tt>getIncrement() == 1</tt>
 	bool		isPlanar() const { return mIncrement == 1; }
 
@@ -187,10 +187,10 @@ class ChannelT {
 		int32_t		getHeight() { return mHeight; }
 
 		/// \cond
-		uint8_t				mInc;
+		size_t				mInc, mRowInc;
 		uint8_t				*mLinePtr;
 		T					*mPtr;
-		int32_t				mRowInc, mWidth, mHeight;
+		int32_t				mWidth, mHeight;
 		int32_t				mX, mY, mStartX, mStartY, mEndX, mEndY;
 		/// \endcond
 	};
@@ -255,10 +255,10 @@ class ChannelT {
 		int32_t		getHeight() { return mHeight; }
 
 		/// \cond
-		uint8_t				mInc;
+		size_t				mInc, mRowInc;
 		const uint8_t		*mLinePtr;
 		const T				*mPtr;
-		int32_t				mRowInc, mWidth, mHeight;
+		int32_t				mWidth, mHeight;
 		int32_t				mX, mY, mStartX, mStartY, mEndX, mEndY;
 		/// \endcond
 	};
@@ -273,8 +273,8 @@ class ChannelT {
 	ConstIter	getIter( const Area &area ) const { return ConstIter( *this, area ); }
 	
   protected:
-	int32_t						mWidth, mHeight, mRowBytes;
-	uint8_t						mIncrement;
+	int32_t						mWidth, mHeight;
+	size_t						mRowBytes, mIncrement;
 	T							*mData;
 	std::shared_ptr<T>			mDataStore;
 };

--- a/include/cinder/Surface.h
+++ b/include/cinder/Surface.h
@@ -59,41 +59,41 @@ class SurfaceChannelOrder {
 	SurfaceChannelOrder() : mCode( UNSPECIFIED ), mRed( INVALID ), mGreen( INVALID ), mBlue( INVALID ), mAlpha( INVALID ), mPixelInc( INVALID ) {}
 	SurfaceChannelOrder( int aCode );
 	SurfaceChannelOrder( const SurfaceChannelOrder &aOrder );
-		
+
 //	static ChannelOrder	GetPlatformNativeChannelOrder( bool includeAlpha );
-	
+
 	uint8_t		getRedOffset() const { return mRed; }
 	uint8_t		getGreenOffset() const { return mGreen; }
 	uint8_t		getBlueOffset() const { return mBlue; }
 	uint8_t		getAlphaOffset() const { return mAlpha; }
 	bool		hasAlpha() const { return ( mAlpha != INVALID ) ? true : false; }
-	uint8_t		getPixelInc() const { return mPixelInc; }
+	size_t		getPixelInc() const { return mPixelInc; }
 	int			getCode() const { return mCode; }
 
-	bool operator==( const SurfaceChannelOrder& sco ) const 
+	bool operator==( const SurfaceChannelOrder& sco ) const
 	{
 		return mCode == sco.mCode;
 	}
 
-	enum { CHAN_RED, CHAN_GREEN, CHAN_BLUE, CHAN_ALPHA, INVALID = 255 };	
+	enum { CHAN_RED, CHAN_GREEN, CHAN_BLUE, CHAN_ALPHA, INVALID = 255 };
 	enum { RGBA, BGRA, ARGB, ABGR, RGBX, BGRX, XRGB, XBGR, RGB, BGR, UNSPECIFIED }; // Codes
 
 	int			getImageIoChannelOrder() const;
 
   private:
-	void		set( uint8_t aRed, uint8_t aGreen, uint8_t aBlue, uint8_t aAlpha, uint8_t aPixelInc );
-	int			mCode; // the enum 
-	uint8_t		mRed, mGreen, mBlue, mAlpha, mPixelInc;
-	
+	void		set( uint8_t aRed, uint8_t aGreen, uint8_t aBlue, uint8_t aAlpha, size_t aPixelInc );
+	int			mCode; // the enum
+	uint8_t		mRed, mGreen, mBlue, mAlpha;
+	size_t		mPixelInc;
 };
 
 //! Base class for defining the properties of a Surface necessary to be interoperable with different APIs
 class SurfaceConstraints {
  public:
 	virtual ~SurfaceConstraints() {}
- 
+
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const { return ( alpha ) ? SurfaceChannelOrder::RGBA : SurfaceChannelOrder::RGB; }
-	virtual int32_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { return requestedWidth * elementSize * sco.getPixelInc(); }
+	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { return requestedWidth * elementSize * sco.getPixelInc(); }
 };
 
 class SurfaceConstraintsDefault : public SurfaceConstraints {
@@ -113,7 +113,7 @@ class SurfaceT {
 	//! Allocates a Surface of size \a width X \a height, with an optional \a alpha channel. \a constraints allows specification of channel order and rowBytes constraints as a function of width.
 	SurfaceT( int32_t width, int32_t height, bool alpha, const SurfaceConstraints &constraints );
 	//! Constructs a surface from the memory pointed to by \a data. Does not assume ownership of the memory in \a data, which consequently should not be freed while the Surface is still in use.
-	SurfaceT( T *data, int32_t width, int32_t height, int32_t rowBytes, SurfaceChannelOrder channelOrder );
+	SurfaceT( T *data, int32_t width, int32_t height, size_t rowBytes, SurfaceChannelOrder channelOrder );
 	//! Constructs a Surface from an \a imageSource and optional \a constraints. Default value for \a alpha chooses one based on the contents of the ImageSource.
 	SurfaceT( ImageSourceRef imageSource, const SurfaceConstraints &constraints = SurfaceConstraintsDefault(), boost::tribool alpha = boost::logic::indeterminate );
 
@@ -125,15 +125,15 @@ class SurfaceT {
 	//! Creates a SurfaceRef of size \a width X \a height, with an optional \a alpha channel. The default value for \a channelOrder selects a platform default.
 	static std::shared_ptr<SurfaceT<T>>	create( int32_t width, int32_t height, bool alpha, SurfaceChannelOrder channelOrder = SurfaceChannelOrder::UNSPECIFIED )
 	{ return std::make_shared<SurfaceT<T>>( width, height, alpha, channelOrder ); }
-	
+
 	//! Creates a SurfaceRef of size \a width X \a height, with an optional \a alpha channel. \a constraints allows specification of channel order and rowBytes constraints as a function of width.
 	static std::shared_ptr<SurfaceT<T>>	create( int32_t width, int32_t height, bool alpha, const SurfaceConstraints &constraints )
 	{ return std::make_shared<SurfaceT<T>>( width, height, alpha, constraints ); }
-	
+
 	//! Creates a SurfaceRef from the memory pointed to by \a data. Does not assume ownership of the memory in \a data, which consequently should not be freed while the Surface is still in use.
-	static std::shared_ptr<SurfaceT<T>>	create( T *data, int32_t width, int32_t height, int32_t rowBytes, SurfaceChannelOrder channelOrder )
+	static std::shared_ptr<SurfaceT<T>>	create( T *data, int32_t width, int32_t height, size_t rowBytes, SurfaceChannelOrder channelOrder )
 	{ return std::make_shared<SurfaceT<T>>( data, width, height, rowBytes, channelOrder ); }
-	
+
 	//! Creates a SurfaceRef from an \a imageSource and optional \a constraints. Default value for \a alpha chooses one based on the contents of the ImageSource.
 	static std::shared_ptr<SurfaceT<T>>	create( ImageSourceRef imageSource, const SurfaceConstraints &constraints = SurfaceConstraintsDefault(), boost::tribool alpha = boost::logic::indeterminate )
 	{ return std::make_shared<SurfaceT<T>>( imageSource, constraints, alpha ); }
@@ -172,11 +172,11 @@ class SurfaceT {
 	//! Sets whether the Surface color data should be interpreted as being premultiplied by its alpha channel or not
 	void			setPremultiplied( bool premult = true ) { mPremultiplied = premult; }
 	//! Returns the width of a row of the Surface measured in bytes, which is not necessarily getWidth() * getPixelInc()
-	int32_t			getRowBytes() const { return mRowBytes; }
+	size_t			getRowBytes() const { return mRowBytes; }
 	//! Returns the amount to increment a T* to increment by a pixel. Analogous to the number of channels, which is either 3 or 4
-	uint8_t			getPixelInc() const { return mChannelOrder.getPixelInc(); }
+	size_t			getPixelInc() const { return mChannelOrder.getPixelInc(); }
 	//! Returns the number of bytes to increment by a pixel. Analogous to the number of channels, (which is either 3 or 4) * sizeof(T)
-	uint8_t			getPixelBytes() const { return mChannelOrder.getPixelInc() * sizeof(T); }
+	size_t			getPixelBytes() const { return mChannelOrder.getPixelInc() * sizeof(T); }
 
 	//! Returns a new Surface which is a duplicate. If \a copyPixels the pixel values are copied, otherwise the clone's pixels remain uninitialized
 	SurfaceT			clone( bool copyPixels = true ) const;
@@ -262,7 +262,8 @@ class SurfaceT {
 
 	void	initChannels();
 
-	int32_t						mWidth, mHeight, mRowBytes;
+	int32_t						mWidth, mHeight;
+	size_t						mRowBytes;
 	bool						mPremultiplied;
 	T							*mData;
 	std::shared_ptr<T>			mDataStore; // shared rather than unique because member Channels (r/g/b/a) share the same data store and may need to outlive their parent Surface
@@ -351,17 +352,18 @@ class SurfaceT {
 			mX = mStartX - 1;
 			return mY < mEndY;
 		}
-		
+
 		//! Returns the width of the Area the Iter iterates
 		int32_t		getWidth() const { return mWidth; }
 		//! Returns the height of the Area the Iter iterates
 		int32_t		getHeight() const { return mHeight; }
 
 		/// \cond
-		uint8_t				mRedOff, mGreenOff, mBlueOff, mAlphaOff, mInc;
+		uint8_t				mRedOff, mGreenOff, mBlueOff, mAlphaOff;
 		uint8_t				*mLinePtr;
 		T					*mPtr;
-		int32_t				mRowInc, mWidth, mHeight;
+		size_t				mInc, mRowInc;
+		int32_t				mWidth, mHeight;
 		int32_t				mX, mY, mStartX, mStartY, mEndX, mEndY;
 		/// \endcond
 	};
@@ -466,17 +468,18 @@ class SurfaceT {
 			mX = mStartX - 1;
 			return mY < mEndY;
 		}
-		
+
 		//! Returns the width of the Area the Iter iterates
 		int32_t		getWidth() const { return mWidth; }
 		//! Returns the height of the Area the Iter iterates
 		int32_t		getHeight() const { return mHeight; }
 
 		/// \cond
-		uint8_t				mRedOff, mGreenOff, mBlueOff, mAlphaOff, mInc;
+		uint8_t				mRedOff, mGreenOff, mBlueOff, mAlphaOff;
 		const uint8_t		*mLinePtr;
 		const T				*mPtr;
-		int32_t				mRowInc, mWidth, mHeight;
+		size_t				mInc, mRowInc;
+		int32_t				mWidth, mHeight;
 		int32_t				mX, mY, mStartX, mStartY, mEndX, mEndY;
 		/// \endcond
 	};

--- a/include/cinder/cocoa/CinderCocoa.h
+++ b/include/cinder/cocoa/CinderCocoa.h
@@ -233,7 +233,7 @@ namespace cinder {
 class SurfaceConstraintsCgBitmapContext : public cinder::SurfaceConstraints {
  public:
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const;
-	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const;
+	virtual ptrdiff_t			getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const;
 };
 //! \endcond
 

--- a/include/cinder/cocoa/CinderCocoa.h
+++ b/include/cinder/cocoa/CinderCocoa.h
@@ -233,7 +233,7 @@ namespace cinder {
 class SurfaceConstraintsCgBitmapContext : public cinder::SurfaceConstraints {
  public:
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const;
-	virtual int32_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const;
+	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const;
 };
 //! \endcond
 

--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -128,7 +128,7 @@ class TextureBase {
 
 	//! Returns whether a Surface of \a width, \a rowBytes and \a surfaceChannelOrder would require an intermediate Surface in order to be copied into a GL Texture.
 	template<typename T>
-	static bool		surfaceRequiresIntermediate( int32_t width, size_t pixelBytes, size_t rowBytes, SurfaceChannelOrder surfaceChannelOrder );
+	static bool		surfaceRequiresIntermediate( int32_t width, uint8_t pixelBytes, ptrdiff_t rowBytes, SurfaceChannelOrder surfaceChannelOrder );
 	//! Converts a SurfaceChannelOrder into an appropriate OpenGL dataFormat and type
 	template<typename T>
 	static void		SurfaceChannelOrderToDataFormatAndType( const SurfaceChannelOrder &sco, GLint *dataFormat, GLenum *type );
@@ -796,7 +796,7 @@ class Texture2dCache : public std::enable_shared_from_this<Texture2dCache>
 class SurfaceConstraintsGLTexture : public SurfaceConstraints {
   public:
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const { return ( alpha ) ? SurfaceChannelOrder::BGRA : SurfaceChannelOrder::BGR; }
-	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { return requestedWidth * elementSize * sco.getPixelInc(); }
+	virtual ptrdiff_t			getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { return requestedWidth * elementSize * sco.getPixelInc(); }
 };
 
 class KtxParseExc : public Exception {

--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -128,7 +128,7 @@ class TextureBase {
 
 	//! Returns whether a Surface of \a width, \a rowBytes and \a surfaceChannelOrder would require an intermediate Surface in order to be copied into a GL Texture.
 	template<typename T>
-	static bool		surfaceRequiresIntermediate( int32_t width, uint8_t pixelBytes, int32_t rowBytes, SurfaceChannelOrder surfaceChannelOrder );
+	static bool		surfaceRequiresIntermediate( int32_t width, size_t pixelBytes, size_t rowBytes, SurfaceChannelOrder surfaceChannelOrder );
 	//! Converts a SurfaceChannelOrder into an appropriate OpenGL dataFormat and type
 	template<typename T>
 	static void		SurfaceChannelOrderToDataFormatAndType( const SurfaceChannelOrder &sco, GLint *dataFormat, GLenum *type );
@@ -796,7 +796,7 @@ class Texture2dCache : public std::enable_shared_from_this<Texture2dCache>
 class SurfaceConstraintsGLTexture : public SurfaceConstraints {
   public:
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const { return ( alpha ) ? SurfaceChannelOrder::BGRA : SurfaceChannelOrder::BGR; }
-	virtual int32_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { return requestedWidth * elementSize * sco.getPixelInc(); }
+	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { return requestedWidth * elementSize * sco.getPixelInc(); }
 };
 
 class KtxParseExc : public Exception {

--- a/include/cinder/ip/Threshold.h
+++ b/include/cinder/ip/Threshold.h
@@ -72,7 +72,7 @@ class AdaptiveThresholdT {
 	const ChannelT<T>*	mChannel;
 	int32_t				mImageWidth;
 	int32_t				mImageHeight;
-	int8_t				mIncrement;
+	size_t				mIncrement;
 	std::vector<SUMT>	mIntegralImage;
 };
 

--- a/include/cinder/ip/Threshold.h
+++ b/include/cinder/ip/Threshold.h
@@ -72,7 +72,7 @@ class AdaptiveThresholdT {
 	const ChannelT<T>*	mChannel;
 	int32_t				mImageWidth;
 	int32_t				mImageHeight;
-	size_t				mIncrement;
+	uint8_t				mIncrement;
 	std::vector<SUMT>	mIntegralImage;
 };
 

--- a/include/cinder/msw/CinderMswGdiPlus.h
+++ b/include/cinder/msw/CinderMswGdiPlus.h
@@ -52,7 +52,7 @@ namespace cinder {
 
 class SurfaceConstraintsGdiPlus : public SurfaceConstraints {
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const { return ( alpha ) ? SurfaceChannelOrder::BGRA : SurfaceChannelOrder::BGR; }
-	virtual int32_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { int32_t result = requestedWidth * elementSize * sco.getPixelInc(); result += ( result & 3 ) ? ( 4 - (result&3) ) : 0; return result; }
+	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { size_t result = requestedWidth * elementSize * sco.getPixelInc(); result += ( result & 3 ) ? ( 4 - (result&3) ) : 0; return result; }
 };
 
 } // namespace cinder

--- a/include/cinder/msw/CinderMswGdiPlus.h
+++ b/include/cinder/msw/CinderMswGdiPlus.h
@@ -52,7 +52,7 @@ namespace cinder {
 
 class SurfaceConstraintsGdiPlus : public SurfaceConstraints {
 	virtual SurfaceChannelOrder getChannelOrder( bool alpha ) const { return ( alpha ) ? SurfaceChannelOrder::BGRA : SurfaceChannelOrder::BGR; }
-	virtual size_t				getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { size_t result = requestedWidth * elementSize * sco.getPixelInc(); result += ( result & 3 ) ? ( 4 - (result&3) ) : 0; return result; }
+	virtual ptrdiff_t			getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const { size_t result = requestedWidth * elementSize * sco.getPixelInc(); result += ( result & 3 ) ? ( 4 - (result&3) ) : 0; return result; }
 };
 
 } // namespace cinder

--- a/src/cinder/Channel.cpp
+++ b/src/cinder/Channel.cpp
@@ -101,7 +101,7 @@ class ImageSourceChannel : public ImageSource {
 	// this is used to register a reference to the channel we were constructed with
 	shared_ptr<void>	mDataStore;
 	const uint8_t		*mData;
-	size_t				mRowBytes;
+	ptrdiff_t			mRowBytes;
 };
 
 template<typename T>
@@ -122,14 +122,14 @@ ChannelT<T>::ChannelT( int32_t width, int32_t height )
 }
 
 template<typename T>
-ChannelT<T>::ChannelT( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data )
+ChannelT<T>::ChannelT( int32_t width, int32_t height, ptrdiff_t rowBytes, uint8_t increment, T *data )
 	: mWidth( width ), mHeight( height ), mRowBytes( rowBytes ), mIncrement( increment ), mData( data )
 {
 	mDataStore = nullptr;
 }
 
 template<typename T>
-ChannelT<T>::ChannelT( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data, const std::shared_ptr<T> &dataStore )
+ChannelT<T>::ChannelT( int32_t width, int32_t height, ptrdiff_t rowBytes, uint8_t increment, T *data, const std::shared_ptr<T> &dataStore )
 	: mWidth( width ), mHeight( height ), mRowBytes( rowBytes ), mIncrement( increment ), mData( data ), mDataStore( dataStore )
 {
 }
@@ -229,9 +229,9 @@ void ChannelT<T>::copyFrom( const ChannelT<T> &srcChannel, const Area &srcArea, 
 {
 	std::pair<Area,ivec2> srcDst = clippedSrcDst( srcChannel.getBounds(), srcArea, getBounds(), srcArea.getUL() + relativeOffset );
 	
-	size_t srcRowBytes = srcChannel.getRowBytes();
-	size_t srcIncrement = srcChannel.getIncrement();
-	size_t increment = mIncrement;
+	ptrdiff_t srcRowBytes = srcChannel.getRowBytes();
+	uint8_t srcIncrement = srcChannel.getIncrement();
+	uint8_t increment = mIncrement;
 	
 	int32_t width = srcDst.first.getWidth();
 	
@@ -255,8 +255,8 @@ T ChannelT<T>::areaAverage( const Area &area ) const
 	if( ( clipped.getWidth() <= 0 ) || ( clipped.getHeight() <= 0 ) )
 		return 0;
 
-	size_t increment = mIncrement;
-	size_t rowBytes = mRowBytes;
+	uint8_t increment = mIncrement;
+	ptrdiff_t rowBytes = mRowBytes;
 	
 	const T *line = reinterpret_cast<const T*>( reinterpret_cast<const uint8_t*>( mData + clipped.x1 * mIncrement ) + clipped.y1 * mRowBytes );
 	for( int32_t y = clipped.y1; y < clipped.y2; ++y ) {

--- a/src/cinder/Channel.cpp
+++ b/src/cinder/Channel.cpp
@@ -101,7 +101,7 @@ class ImageSourceChannel : public ImageSource {
 	// this is used to register a reference to the channel we were constructed with
 	shared_ptr<void>	mDataStore;
 	const uint8_t		*mData;
-	int32_t				mRowBytes;
+	size_t				mRowBytes;
 };
 
 template<typename T>
@@ -122,14 +122,14 @@ ChannelT<T>::ChannelT( int32_t width, int32_t height )
 }
 
 template<typename T>
-ChannelT<T>::ChannelT( int32_t width, int32_t height, int32_t rowBytes, uint8_t increment, T *data )
+ChannelT<T>::ChannelT( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data )
 	: mWidth( width ), mHeight( height ), mRowBytes( rowBytes ), mIncrement( increment ), mData( data )
 {
 	mDataStore = nullptr;
 }
 
 template<typename T>
-ChannelT<T>::ChannelT( int32_t width, int32_t height, int32_t rowBytes, uint8_t increment, T *data, const std::shared_ptr<T> &dataStore )
+ChannelT<T>::ChannelT( int32_t width, int32_t height, size_t rowBytes, size_t increment, T *data, const std::shared_ptr<T> &dataStore )
 	: mWidth( width ), mHeight( height ), mRowBytes( rowBytes ), mIncrement( increment ), mData( data ), mDataStore( dataStore )
 {
 }
@@ -229,9 +229,9 @@ void ChannelT<T>::copyFrom( const ChannelT<T> &srcChannel, const Area &srcArea, 
 {
 	std::pair<Area,ivec2> srcDst = clippedSrcDst( srcChannel.getBounds(), srcArea, getBounds(), srcArea.getUL() + relativeOffset );
 	
-	int32_t srcRowBytes = srcChannel.getRowBytes();
-	uint8_t srcIncrement = srcChannel.getIncrement();
-	uint8_t increment = mIncrement;
+	size_t srcRowBytes = srcChannel.getRowBytes();
+	size_t srcIncrement = srcChannel.getIncrement();
+	size_t increment = mIncrement;
 	
 	int32_t width = srcDst.first.getWidth();
 	
@@ -255,8 +255,8 @@ T ChannelT<T>::areaAverage( const Area &area ) const
 	if( ( clipped.getWidth() <= 0 ) || ( clipped.getHeight() <= 0 ) )
 		return 0;
 
-	uint8_t increment = mIncrement;
-	int32_t rowBytes = mRowBytes;
+	size_t increment = mIncrement;
+	size_t rowBytes = mRowBytes;
 	
 	const T *line = reinterpret_cast<const T*>( reinterpret_cast<const uint8_t*>( mData + clipped.x1 * mIncrement ) + clipped.y1 * mRowBytes );
 	for( int32_t y = clipped.y1; y < clipped.y2; ++y ) {

--- a/src/cinder/Surface.cpp
+++ b/src/cinder/Surface.cpp
@@ -102,7 +102,7 @@ class ImageSourceSurface : public ImageSource {
 
 	// not ideal, but these are used to register a reference to the surface we were constructed with
 	const uint8_t			*mData;
-	size_t					mRowBytes;
+	ptrdiff_t				mRowBytes;
 	std::shared_ptr<void>	mDataStoreRef;
 };
 
@@ -155,7 +155,7 @@ SurfaceChannelOrder::SurfaceChannelOrder( const SurfaceChannelOrder &aOrder )
 {
 }
 
-void SurfaceChannelOrder::set( uint8_t aRed, uint8_t aGreen, uint8_t aBlue, uint8_t aAlpha, size_t aPixelInc )
+void SurfaceChannelOrder::set( uint8_t aRed, uint8_t aGreen, uint8_t aBlue, uint8_t aAlpha, uint8_t aPixelInc )
 {
 	mRed = aRed;
 	mGreen = aGreen;
@@ -256,7 +256,7 @@ SurfaceT<T>::SurfaceT( int32_t width, int32_t height, bool alpha, const SurfaceC
 }
 
 template<typename T>
-SurfaceT<T>::SurfaceT( T *data, int32_t width, int32_t height, size_t rowBytes, SurfaceChannelOrder channelOrder )
+SurfaceT<T>::SurfaceT( T *data, int32_t width, int32_t height, ptrdiff_t rowBytes, SurfaceChannelOrder channelOrder )
 	: mData( data ), mWidth( width ), mHeight( height ), mRowBytes( rowBytes ), mChannelOrder( channelOrder )
 {
 	mPremultiplied = false;
@@ -418,9 +418,9 @@ void SurfaceT<T>::copyFrom( const SurfaceT<T> &srcSurface, const Area &srcArea, 
 template<typename T>
 void SurfaceT<T>::copyRawSameChannelOrder( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &absoluteOffset )
 {
-	size_t srcRowBytes = srcSurface.getRowBytes();
-	size_t srcPixelInc = srcSurface.getPixelInc();
-	size_t dstPixelInc = getPixelInc();
+	ptrdiff_t srcRowBytes = srcSurface.getRowBytes();
+	uint8_t srcPixelInc = srcSurface.getPixelInc();
+	uint8_t dstPixelInc = getPixelInc();
 	size_t copyBytes = srcArea.getWidth() * srcPixelInc * sizeof(T);
 	for( int32_t y = 0; y < srcArea.getHeight(); ++y ) {
 		const T *srcPtr = reinterpret_cast<const T*>( reinterpret_cast<const uint8_t*>( srcSurface.getData() + srcArea.x1 * srcPixelInc ) + ( srcArea.y1 + y ) * srcRowBytes );
@@ -432,7 +432,7 @@ void SurfaceT<T>::copyRawSameChannelOrder( const SurfaceT<T> &srcSurface, const 
 template<typename T>
 void SurfaceT<T>::copyRawRgba( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &absoluteOffset )
 {
-	const size_t srcRowBytes = srcSurface.getRowBytes();
+	const ptrdiff_t srcRowBytes = srcSurface.getRowBytes();
 	uint8_t srcRed = srcSurface.getChannelOrder().getRedOffset();
 	uint8_t srcGreen = srcSurface.getChannelOrder().getGreenOffset();
 	uint8_t srcBlue = srcSurface.getChannelOrder().getBlueOffset();
@@ -462,8 +462,8 @@ void SurfaceT<T>::copyRawRgba( const SurfaceT<T> &srcSurface, const Area &srcAre
 template<typename T>
 void SurfaceT<T>::copyRawRgbFullAlpha( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &absoluteOffset )
 {
-	const size_t srcRowBytes = srcSurface.getRowBytes();
-	const size_t srcPixelInc = srcSurface.getPixelInc();
+	const ptrdiff_t srcRowBytes = srcSurface.getRowBytes();
+	const uint8_t srcPixelInc = srcSurface.getPixelInc();
 	uint8_t srcRed = srcSurface.getChannelOrder().getRedOffset();
 	uint8_t srcGreen = srcSurface.getChannelOrder().getGreenOffset();
 	uint8_t srcBlue = srcSurface.getChannelOrder().getBlueOffset();
@@ -493,8 +493,8 @@ void SurfaceT<T>::copyRawRgbFullAlpha( const SurfaceT<T> &srcSurface, const Area
 template<typename T>
 void SurfaceT<T>::copyRawRgb( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &absoluteOffset )
 {
-	const size_t srcRowBytes = srcSurface.getRowBytes();
-	const size_t srcPixelInc = srcSurface.getPixelInc();
+	const ptrdiff_t srcRowBytes = srcSurface.getRowBytes();
+	const uint8_t srcPixelInc = srcSurface.getPixelInc();
 	const uint8_t srcRed = srcSurface.getChannelOrder().getRedOffset();
 	const uint8_t srcGreen = srcSurface.getChannelOrder().getGreenOffset();
 	const uint8_t srcBlue = srcSurface.getChannelOrder().getBlueOffset();
@@ -529,7 +529,7 @@ ColorT<T> SurfaceT<T>::areaAverage( const Area &area ) const
 		return ColorT<T>( 0, 0, 0 );
 
 	uint8_t red = getRedOffset(), green = getGreenOffset(), blue = getBlueOffset();
-	size_t inc = getPixelInc();
+	uint8_t inc = getPixelInc();
 	const T *line = getData( clipped.getUL() );
 	for( int32_t y = clipped.y1; y < clipped.y2; ++y ) {
 		const T *d = line;

--- a/src/cinder/Surface.cpp
+++ b/src/cinder/Surface.cpp
@@ -92,17 +92,17 @@ class ImageSourceSurface : public ImageSource {
 	void load( ImageTargetRef target ) {
 		// get a pointer to the ImageSource function appropriate for handling our data configuration
 		ImageSource::RowFunc func = setupRowFunc( target );
-		
+
 		const uint8_t *data = mData;
 		for( int32_t row = 0; row < mHeight; ++row ) {
 			((*this).*func)( target, row, data );
 			data += mRowBytes;
 		}
 	}
-	
+
 	// not ideal, but these are used to register a reference to the surface we were constructed with
 	const uint8_t			*mData;
-	int32_t					mRowBytes;
+	size_t					mRowBytes;
 	std::shared_ptr<void>	mDataStoreRef;
 };
 
@@ -155,7 +155,7 @@ SurfaceChannelOrder::SurfaceChannelOrder( const SurfaceChannelOrder &aOrder )
 {
 }
 
-void SurfaceChannelOrder::set( uint8_t aRed, uint8_t aGreen, uint8_t aBlue, uint8_t aAlpha, uint8_t aPixelInc )
+void SurfaceChannelOrder::set( uint8_t aRed, uint8_t aGreen, uint8_t aBlue, uint8_t aAlpha, size_t aPixelInc )
 {
 	mRed = aRed;
 	mGreen = aGreen;
@@ -256,7 +256,7 @@ SurfaceT<T>::SurfaceT( int32_t width, int32_t height, bool alpha, const SurfaceC
 }
 
 template<typename T>
-SurfaceT<T>::SurfaceT( T *data, int32_t width, int32_t height, int32_t rowBytes, SurfaceChannelOrder channelOrder )
+SurfaceT<T>::SurfaceT( T *data, int32_t width, int32_t height, size_t rowBytes, SurfaceChannelOrder channelOrder )
 	: mData( data ), mWidth( width ), mHeight( height ), mRowBytes( rowBytes ), mChannelOrder( channelOrder )
 {
 	mPremultiplied = false;
@@ -418,9 +418,9 @@ void SurfaceT<T>::copyFrom( const SurfaceT<T> &srcSurface, const Area &srcArea, 
 template<typename T>
 void SurfaceT<T>::copyRawSameChannelOrder( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &absoluteOffset )
 {
-	int32_t srcRowBytes = srcSurface.getRowBytes();
-	int32_t srcPixelInc = srcSurface.getPixelInc();
-	int32_t dstPixelInc = getPixelInc();
+	size_t srcRowBytes = srcSurface.getRowBytes();
+	size_t srcPixelInc = srcSurface.getPixelInc();
+	size_t dstPixelInc = getPixelInc();
 	size_t copyBytes = srcArea.getWidth() * srcPixelInc * sizeof(T);
 	for( int32_t y = 0; y < srcArea.getHeight(); ++y ) {
 		const T *srcPtr = reinterpret_cast<const T*>( reinterpret_cast<const uint8_t*>( srcSurface.getData() + srcArea.x1 * srcPixelInc ) + ( srcArea.y1 + y ) * srcRowBytes );
@@ -432,19 +432,19 @@ void SurfaceT<T>::copyRawSameChannelOrder( const SurfaceT<T> &srcSurface, const 
 template<typename T>
 void SurfaceT<T>::copyRawRgba( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &absoluteOffset )
 {
-	const int32_t srcRowBytes = srcSurface.getRowBytes();
+	const size_t srcRowBytes = srcSurface.getRowBytes();
 	uint8_t srcRed = srcSurface.getChannelOrder().getRedOffset();
 	uint8_t srcGreen = srcSurface.getChannelOrder().getGreenOffset();
 	uint8_t srcBlue = srcSurface.getChannelOrder().getBlueOffset();
 	uint8_t srcAlpha = srcSurface.getChannelOrder().getAlphaOffset();
-	
+
 	uint8_t dstRed = getChannelOrder().getRedOffset();
 	uint8_t dstGreen = getChannelOrder().getGreenOffset();
 	uint8_t dstBlue = getChannelOrder().getBlueOffset();
 	uint8_t dstAlpha = getChannelOrder().getAlphaOffset();
-	
+
 	int32_t width = srcArea.getWidth();
-	
+
 	for( int32_t y = 0; y < srcArea.getHeight(); ++y ) {
 		const T *src = reinterpret_cast<const T*>( reinterpret_cast<const uint8_t*>( srcSurface.getData() + srcArea.x1 * 4 ) + ( srcArea.y1 + y ) * srcRowBytes );
 		T *dst = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( getData() + absoluteOffset.x * 4 ) + ( y + absoluteOffset.y ) * getRowBytes() );
@@ -462,20 +462,20 @@ void SurfaceT<T>::copyRawRgba( const SurfaceT<T> &srcSurface, const Area &srcAre
 template<typename T>
 void SurfaceT<T>::copyRawRgbFullAlpha( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &absoluteOffset )
 {
-	const int32_t srcRowBytes = srcSurface.getRowBytes();
-	const int8_t srcPixelInc = srcSurface.getPixelInc();
+	const size_t srcRowBytes = srcSurface.getRowBytes();
+	const size_t srcPixelInc = srcSurface.getPixelInc();
 	uint8_t srcRed = srcSurface.getChannelOrder().getRedOffset();
 	uint8_t srcGreen = srcSurface.getChannelOrder().getGreenOffset();
 	uint8_t srcBlue = srcSurface.getChannelOrder().getBlueOffset();
 	const T fullAlpha = CHANTRAIT<T>::max();
-	
+
 	uint8_t dstRed = getChannelOrder().getRedOffset();
 	uint8_t dstGreen = getChannelOrder().getGreenOffset();
 	uint8_t dstBlue = getChannelOrder().getBlueOffset();
 	uint8_t dstAlpha = getChannelOrder().getAlphaOffset();
-	
+
 	int32_t width = srcArea.getWidth();
-	
+
 	for( int32_t y = 0; y < srcArea.getHeight(); ++y ) {
 		const T *src = reinterpret_cast<const T*>( reinterpret_cast<const uint8_t*>( srcSurface.getData() + srcArea.x1 * 4 ) + ( srcArea.y1 + y ) * srcRowBytes );
 		T *dst = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( getData() + absoluteOffset.x * 4 ) + ( y + absoluteOffset.y ) * getRowBytes() );
@@ -493,19 +493,19 @@ void SurfaceT<T>::copyRawRgbFullAlpha( const SurfaceT<T> &srcSurface, const Area
 template<typename T>
 void SurfaceT<T>::copyRawRgb( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &absoluteOffset )
 {
-	const int32_t srcRowBytes = srcSurface.getRowBytes();
-	const int8_t srcPixelInc = srcSurface.getPixelInc();
+	const size_t srcRowBytes = srcSurface.getRowBytes();
+	const size_t srcPixelInc = srcSurface.getPixelInc();
 	const uint8_t srcRed = srcSurface.getChannelOrder().getRedOffset();
 	const uint8_t srcGreen = srcSurface.getChannelOrder().getGreenOffset();
 	const uint8_t srcBlue = srcSurface.getChannelOrder().getBlueOffset();
-	
+
 	const uint8_t dstPixelInc = getPixelInc();
 	const uint8_t dstRed = getChannelOrder().getRedOffset();
 	const uint8_t dstGreen = getChannelOrder().getGreenOffset();
 	const uint8_t dstBlue = getChannelOrder().getBlueOffset();
-	
+
 	int32_t width = srcArea.getWidth();
-	
+
 	for( int32_t y = 0; y < srcArea.getHeight(); ++y ) {
 		const T *src = reinterpret_cast<const T*>( reinterpret_cast<const uint8_t*>( srcSurface.getData() + srcArea.x1 * srcPixelInc ) + ( srcArea.y1 + y ) * srcRowBytes );
 		T *dst = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( getData() + absoluteOffset.x * dstPixelInc ) + ( y + absoluteOffset.y ) * getRowBytes() );
@@ -529,7 +529,7 @@ ColorT<T> SurfaceT<T>::areaAverage( const Area &area ) const
 		return ColorT<T>( 0, 0, 0 );
 
 	uint8_t red = getRedOffset(), green = getGreenOffset(), blue = getBlueOffset();
-	uint8_t inc = getPixelInc();
+	size_t inc = getPixelInc();
 	const T *line = getData( clipped.getUL() );
 	for( int32_t y = clipped.y1; y < clipped.y2; ++y ) {
 		const T *d = line;

--- a/src/cinder/cocoa/CinderCocoa.mm
+++ b/src/cinder/cocoa/CinderCocoa.mm
@@ -667,7 +667,7 @@ SurfaceChannelOrder SurfaceConstraintsCgBitmapContext::getChannelOrder( bool alp
 	return ( alpha ) ? SurfaceChannelOrder::RGBA : SurfaceChannelOrder::RGBX;
 }
 
-int32_t SurfaceConstraintsCgBitmapContext::getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const
+size_t SurfaceConstraintsCgBitmapContext::getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const
 {
 	return requestedWidth * elementSize * 4;
 }

--- a/src/cinder/cocoa/CinderCocoa.mm
+++ b/src/cinder/cocoa/CinderCocoa.mm
@@ -667,7 +667,7 @@ SurfaceChannelOrder SurfaceConstraintsCgBitmapContext::getChannelOrder( bool alp
 	return ( alpha ) ? SurfaceChannelOrder::RGBA : SurfaceChannelOrder::RGBX;
 }
 
-size_t SurfaceConstraintsCgBitmapContext::getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const
+ptrdiff_t SurfaceConstraintsCgBitmapContext::getRowBytes( int requestedWidth, const SurfaceChannelOrder &sco, int elementSize ) const
 {
 	return requestedWidth * elementSize * 4;
 }

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -506,7 +506,7 @@ void TextureBase::setCompareFunc( GLenum compareFunc )
 }
 
 template<typename T>
-bool TextureBase::surfaceRequiresIntermediate( int32_t width, size_t pixelBytes, size_t rowBytes, SurfaceChannelOrder surfaceChannelOrder )
+bool TextureBase::surfaceRequiresIntermediate( int32_t width, uint8_t pixelBytes, ptrdiff_t rowBytes, SurfaceChannelOrder surfaceChannelOrder )
 {
 	if( width * pixelBytes != rowBytes )
 		return true;

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -506,7 +506,7 @@ void TextureBase::setCompareFunc( GLenum compareFunc )
 }
 
 template<typename T>
-bool TextureBase::surfaceRequiresIntermediate( int32_t width, uint8_t pixelBytes, int32_t rowBytes, SurfaceChannelOrder surfaceChannelOrder )
+bool TextureBase::surfaceRequiresIntermediate( int32_t width, size_t pixelBytes, size_t rowBytes, SurfaceChannelOrder surfaceChannelOrder )
 {
 	if( width * pixelBytes != rowBytes )
 		return true;

--- a/src/cinder/ip/Blend.cpp
+++ b/src/cinder/ip/Blend.cpp
@@ -39,18 +39,18 @@ template<bool DSTALPHA, bool DSTPREMULT, bool SRCPREMULT>
 void blendImpl_u8( Surface8u *background, const Surface8u &foreground, const Area &srcArea, ivec2 absOffset )
 {
 	bool SRCALPHA = foreground.hasAlpha();
-	const size_t srcRowBytes = foreground.getRowBytes();
+	const ptrdiff_t srcRowBytes = foreground.getRowBytes();
 	const uint8_t sR = foreground.getChannelOrder().getRedOffset();
 	const uint8_t sG = foreground.getChannelOrder().getGreenOffset();
 	const uint8_t sB = foreground.getChannelOrder().getBlueOffset();
 	const uint8_t sA = SRCALPHA ? (foreground.getChannelOrder().getAlphaOffset()) : 0;	
-	const size_t srcInc = foreground.getPixelInc();
-	const size_t dstRowBytes = background->getRowBytes();
+	const uint8_t srcInc = foreground.getPixelInc();
+	const ptrdiff_t dstRowBytes = background->getRowBytes();
 	const uint8_t dR = background->getChannelOrder().getRedOffset();
 	const uint8_t dG = background->getChannelOrder().getGreenOffset();
 	const uint8_t dB = background->getChannelOrder().getBlueOffset();
 	const uint8_t dA = DSTALPHA ? (background->getChannelOrder().getAlphaOffset()) : 0;
-	const size_t dstInc = background->getPixelInc();
+	const uint8_t dstInc = background->getPixelInc();
 	const int32_t width = srcArea.getWidth();
 	
 	if( ! SRCALPHA ) {// normal blend with no src alpha is a copy
@@ -113,18 +113,18 @@ template<bool DSTALPHA, bool DSTPREMULT, bool SRCPREMULT>
 void blendImpl_float( Surface32f *background, const Surface32f &foreground, const Area &srcArea, ivec2 absOffset )
 {
 	bool SRCALPHA = foreground.hasAlpha();
-	const size_t srcRowBytes = foreground.getRowBytes();
+	const ptrdiff_t srcRowBytes = foreground.getRowBytes();
 	const uint8_t sR = foreground.getChannelOrder().getRedOffset();
 	const uint8_t sG = foreground.getChannelOrder().getGreenOffset();
 	const uint8_t sB = foreground.getChannelOrder().getBlueOffset();
 	const uint8_t sA = SRCALPHA ? (foreground.getChannelOrder().getAlphaOffset()) : 0;	
-	const size_t srcInc = foreground.getPixelInc();
-	const size_t dstRowBytes = background->getRowBytes();
+	const uint8_t srcInc = foreground.getPixelInc();
+	const ptrdiff_t dstRowBytes = background->getRowBytes();
 	const uint8_t dR = background->getChannelOrder().getRedOffset();
 	const uint8_t dG = background->getChannelOrder().getGreenOffset();
 	const uint8_t dB = background->getChannelOrder().getBlueOffset();
 	const uint8_t dA = DSTALPHA ? (background->getChannelOrder().getAlphaOffset()) : 0;
-	const size_t dstInc = background->getPixelInc();	
+	const uint8_t dstInc = background->getPixelInc();	
 	const int32_t width = srcArea.getWidth();
 	
 	if( ! SRCALPHA ) {// normal blend with no src alpha is a copy

--- a/src/cinder/ip/Blend.cpp
+++ b/src/cinder/ip/Blend.cpp
@@ -39,18 +39,18 @@ template<bool DSTALPHA, bool DSTPREMULT, bool SRCPREMULT>
 void blendImpl_u8( Surface8u *background, const Surface8u &foreground, const Area &srcArea, ivec2 absOffset )
 {
 	bool SRCALPHA = foreground.hasAlpha();
-	const int32_t srcRowBytes = foreground.getRowBytes();
+	const size_t srcRowBytes = foreground.getRowBytes();
 	const uint8_t sR = foreground.getChannelOrder().getRedOffset();
 	const uint8_t sG = foreground.getChannelOrder().getGreenOffset();
 	const uint8_t sB = foreground.getChannelOrder().getBlueOffset();
 	const uint8_t sA = SRCALPHA ? (foreground.getChannelOrder().getAlphaOffset()) : 0;	
-	const uint8_t srcInc = foreground.getPixelInc();
-	const int32_t dstRowBytes = background->getRowBytes();
+	const size_t srcInc = foreground.getPixelInc();
+	const size_t dstRowBytes = background->getRowBytes();
 	const uint8_t dR = background->getChannelOrder().getRedOffset();
 	const uint8_t dG = background->getChannelOrder().getGreenOffset();
 	const uint8_t dB = background->getChannelOrder().getBlueOffset();
 	const uint8_t dA = DSTALPHA ? (background->getChannelOrder().getAlphaOffset()) : 0;
-	const uint8_t dstInc = background->getPixelInc();	
+	const size_t dstInc = background->getPixelInc();
 	const int32_t width = srcArea.getWidth();
 	
 	if( ! SRCALPHA ) {// normal blend with no src alpha is a copy
@@ -113,18 +113,18 @@ template<bool DSTALPHA, bool DSTPREMULT, bool SRCPREMULT>
 void blendImpl_float( Surface32f *background, const Surface32f &foreground, const Area &srcArea, ivec2 absOffset )
 {
 	bool SRCALPHA = foreground.hasAlpha();
-	const int32_t srcRowBytes = foreground.getRowBytes();
+	const size_t srcRowBytes = foreground.getRowBytes();
 	const uint8_t sR = foreground.getChannelOrder().getRedOffset();
 	const uint8_t sG = foreground.getChannelOrder().getGreenOffset();
 	const uint8_t sB = foreground.getChannelOrder().getBlueOffset();
 	const uint8_t sA = SRCALPHA ? (foreground.getChannelOrder().getAlphaOffset()) : 0;	
-	const uint8_t srcInc = foreground.getPixelInc();
-	const int32_t dstRowBytes = background->getRowBytes();
+	const size_t srcInc = foreground.getPixelInc();
+	const size_t dstRowBytes = background->getRowBytes();
 	const uint8_t dR = background->getChannelOrder().getRedOffset();
 	const uint8_t dG = background->getChannelOrder().getGreenOffset();
 	const uint8_t dB = background->getChannelOrder().getBlueOffset();
 	const uint8_t dA = DSTALPHA ? (background->getChannelOrder().getAlphaOffset()) : 0;
-	const uint8_t dstInc = background->getPixelInc();	
+	const size_t dstInc = background->getPixelInc();	
 	const int32_t width = srcArea.getWidth();
 	
 	if( ! SRCALPHA ) {// normal blend with no src alpha is a copy

--- a/src/cinder/ip/Blur.cpp
+++ b/src/cinder/ip/Blur.cpp
@@ -27,13 +27,13 @@ namespace cinder { namespace ip {
 namespace {
 
 template<typename T>
-size_t getPixelIncrement( const SurfaceT<T> &surface )
+uint8_t getPixelIncrement( const SurfaceT<T> &surface )
 {
 	return surface.getPixelInc();
 }
 
 template<typename T>
-size_t getPixelIncrement( const ChannelT<T> &channel )
+uint8_t getPixelIncrement( const ChannelT<T> &channel )
 {
 	return channel.getIncrement();
 }
@@ -65,10 +65,10 @@ void stackBlur_impl( const IMAGET &srcSurface, IMAGET *dstSurface, const Area &a
 	const int32_t radiusPlusOne = radius + 1;
 	const SUMT divisor = (SUMT)(((div+1)>>1)*((div+1)>>1));
 	const SUMT invDivisor = 1 / divisor;
-	const size_t srcPixelInc = ( CHANNELS == 4 ) ? 4 : getPixelIncrement( srcSurface );
-	const size_t dstPixelInc = ( CHANNELS == 4 ) ? 4 : getPixelIncrement( *dstSurface );
-	const size_t srcRowInc = srcSurface.getRowBytes() / sizeof(T);
-	const size_t dstRowInc = dstSurface->getRowBytes() / sizeof(T);
+	const uint8_t srcPixelInc = ( CHANNELS == 4 ) ? 4 : getPixelIncrement( srcSurface );
+	const uint8_t dstPixelInc = ( CHANNELS == 4 ) ? 4 : getPixelIncrement( *dstSurface );
+	const ptrdiff_t srcRowInc = srcSurface.getRowBytes() / sizeof(T);
+	const ptrdiff_t dstRowInc = dstSurface->getRowBytes() / sizeof(T);
 
 	const T *srcPixelData = srcSurface.getData( area.getUL() );
 	T *dstPixelData = dstSurface->getData( area.getUL() );

--- a/src/cinder/ip/Blur.cpp
+++ b/src/cinder/ip/Blur.cpp
@@ -27,13 +27,13 @@ namespace cinder { namespace ip {
 namespace {
 
 template<typename T>
-uint8_t getPixelIncrement( const SurfaceT<T> &surface )
+size_t getPixelIncrement( const SurfaceT<T> &surface )
 {
 	return surface.getPixelInc();
 }
 
 template<typename T>
-uint8_t getPixelIncrement( const ChannelT<T> &channel )
+size_t getPixelIncrement( const ChannelT<T> &channel )
 {
 	return channel.getIncrement();
 }
@@ -65,10 +65,10 @@ void stackBlur_impl( const IMAGET &srcSurface, IMAGET *dstSurface, const Area &a
 	const int32_t radiusPlusOne = radius + 1;
 	const SUMT divisor = (SUMT)(((div+1)>>1)*((div+1)>>1));
 	const SUMT invDivisor = 1 / divisor;
-	const uint8_t srcPixelInc = ( CHANNELS == 4 ) ? 4 : getPixelIncrement( srcSurface );
-	const uint8_t dstPixelInc = ( CHANNELS == 4 ) ? 4 : getPixelIncrement( *dstSurface );
-	const int32_t srcRowInc = srcSurface.getRowBytes() / sizeof(T);
-	const int32_t dstRowInc = dstSurface->getRowBytes() / sizeof(T);
+	const size_t srcPixelInc = ( CHANNELS == 4 ) ? 4 : getPixelIncrement( srcSurface );
+	const size_t dstPixelInc = ( CHANNELS == 4 ) ? 4 : getPixelIncrement( *dstSurface );
+	const size_t srcRowInc = srcSurface.getRowBytes() / sizeof(T);
+	const size_t dstRowInc = dstSurface->getRowBytes() / sizeof(T);
 
 	const T *srcPixelData = srcSurface.getData( area.getUL() );
 	T *dstPixelData = dstSurface->getData( area.getUL() );

--- a/src/cinder/ip/Checkerboard.cpp
+++ b/src/cinder/ip/Checkerboard.cpp
@@ -30,8 +30,8 @@ void checkerboard_impl( SurfaceT<T> *surface, const Area &area, int32_t tileSize
 {
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
 
-	int32_t rowBytes = surface->getRowBytes();
-	uint8_t pixelInc = surface->getPixelInc();
+	size_t rowBytes = surface->getRowBytes();
+	size_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		T *dstPtr = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes );
@@ -57,8 +57,8 @@ void checkerboard_impl( SurfaceT<T> *surface, const Area &area, int32_t tileSize
 	
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
 
-	int32_t rowBytes = surface->getRowBytes();
-	uint8_t pixelInc = surface->getPixelInc();
+	size_t rowBytes = surface->getRowBytes();
+	size_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		T *dstPtr = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes );

--- a/src/cinder/ip/Checkerboard.cpp
+++ b/src/cinder/ip/Checkerboard.cpp
@@ -30,8 +30,8 @@ void checkerboard_impl( SurfaceT<T> *surface, const Area &area, int32_t tileSize
 {
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
 
-	size_t rowBytes = surface->getRowBytes();
-	size_t pixelInc = surface->getPixelInc();
+	ptrdiff_t rowBytes = surface->getRowBytes();
+	uint8_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		T *dstPtr = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes );
@@ -57,8 +57,8 @@ void checkerboard_impl( SurfaceT<T> *surface, const Area &area, int32_t tileSize
 	
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
 
-	size_t rowBytes = surface->getRowBytes();
-	size_t pixelInc = surface->getPixelInc();
+	ptrdiff_t rowBytes = surface->getRowBytes();
+	uint8_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		T *dstPtr = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes );

--- a/src/cinder/ip/EdgeDetect.cpp
+++ b/src/cinder/ip/EdgeDetect.cpp
@@ -42,9 +42,9 @@ void edgeDetectSobel( const ChannelT<T> &srcChannel, const Area &srcArea, const 
 	const ivec2 &dstOffset( srcDst.second );
 	typename CHANTRAIT<T>::SignedSum sumX, sumY;
 
-	int32_t srcRowInc = srcChannel.getRowBytes() / sizeof(T);
-	int8_t srcPixelInc = srcChannel.getIncrement();
-	int8_t dstPixelInc = dstChannel->getIncrement();
+	size_t srcRowInc = srcChannel.getRowBytes() / sizeof(T);
+	size_t srcPixelInc = srcChannel.getIncrement();
+	size_t dstPixelInc = dstChannel->getIncrement();
 	const T maxValue = CHANTRAIT<T>::max();
 	for( int32_t y = 1; y < area.getHeight() - 1; ++y ) {
 		const T *srcLine = srcChannel.getData( area.getX1() + 1, area.getY1() + y );

--- a/src/cinder/ip/EdgeDetect.cpp
+++ b/src/cinder/ip/EdgeDetect.cpp
@@ -42,9 +42,9 @@ void edgeDetectSobel( const ChannelT<T> &srcChannel, const Area &srcArea, const 
 	const ivec2 &dstOffset( srcDst.second );
 	typename CHANTRAIT<T>::SignedSum sumX, sumY;
 
-	size_t srcRowInc = srcChannel.getRowBytes() / sizeof(T);
-	size_t srcPixelInc = srcChannel.getIncrement();
-	size_t dstPixelInc = dstChannel->getIncrement();
+	ptrdiff_t srcRowInc = srcChannel.getRowBytes() / sizeof(T);
+	uint8_t srcPixelInc = srcChannel.getIncrement();
+	uint8_t dstPixelInc = dstChannel->getIncrement();
 	const T maxValue = CHANTRAIT<T>::max();
 	for( int32_t y = 1; y < area.getHeight() - 1; ++y ) {
 		const T *srcLine = srcChannel.getData( area.getX1() + 1, area.getY1() + y );

--- a/src/cinder/ip/Fill.cpp
+++ b/src/cinder/ip/Fill.cpp
@@ -31,8 +31,8 @@ void fill_impl( SurfaceT<T> *surface, const ColorT<T> &color, const Area &area )
 {
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
 
-	int32_t rowBytes = surface->getRowBytes();
-	uint8_t pixelInc = surface->getPixelInc();
+	size_t rowBytes = surface->getRowBytes();
+	size_t pixelInc = surface->getPixelInc();
 	const T red = color.r, green = color.g, blue = color.b;
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
@@ -57,8 +57,8 @@ void fill_impl( SurfaceT<T> *surface, const ColorAT<T> &color, const Area &area 
 	
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
 
-	int32_t rowBytes = surface->getRowBytes();
-	uint8_t pixelInc = surface->getPixelInc();
+	size_t rowBytes = surface->getRowBytes();
+	size_t pixelInc = surface->getPixelInc();
 	const T red = color.r, green = color.g, blue = color.b, alpha = color.a;
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
@@ -106,8 +106,8 @@ void fill( ChannelT<T> *channel, T value, const Area &area )
 {
 	const Area clippedArea = area.getClipBy( channel->getBounds() );
 	
-	int32_t rowBytes = channel->getRowBytes();
-	uint8_t inc = channel->getIncrement();
+	size_t rowBytes = channel->getRowBytes();
+	size_t inc = channel->getIncrement();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		T *dstPtr = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( channel->getData() + clippedArea.getX1() * inc ) + y * rowBytes );
 		for( int32_t x = 0; x < clippedArea.getWidth(); ++x ) {

--- a/src/cinder/ip/Fill.cpp
+++ b/src/cinder/ip/Fill.cpp
@@ -31,8 +31,8 @@ void fill_impl( SurfaceT<T> *surface, const ColorT<T> &color, const Area &area )
 {
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
 
-	size_t rowBytes = surface->getRowBytes();
-	size_t pixelInc = surface->getPixelInc();
+	ptrdiff_t rowBytes = surface->getRowBytes();
+	uint8_t pixelInc = surface->getPixelInc();
 	const T red = color.r, green = color.g, blue = color.b;
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
@@ -57,8 +57,8 @@ void fill_impl( SurfaceT<T> *surface, const ColorAT<T> &color, const Area &area 
 	
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
 
-	size_t rowBytes = surface->getRowBytes();
-	size_t pixelInc = surface->getPixelInc();
+	ptrdiff_t rowBytes = surface->getRowBytes();
+	uint8_t pixelInc = surface->getPixelInc();
 	const T red = color.r, green = color.g, blue = color.b, alpha = color.a;
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
@@ -106,8 +106,8 @@ void fill( ChannelT<T> *channel, T value, const Area &area )
 {
 	const Area clippedArea = area.getClipBy( channel->getBounds() );
 	
-	size_t rowBytes = channel->getRowBytes();
-	size_t inc = channel->getIncrement();
+	ptrdiff_t rowBytes = channel->getRowBytes();
+	uint8_t inc = channel->getIncrement();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		T *dstPtr = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( channel->getData() + clippedArea.getX1() * inc ) + y * rowBytes );
 		for( int32_t x = 0; x < clippedArea.getWidth(); ++x ) {

--- a/src/cinder/ip/Flip.cpp
+++ b/src/cinder/ip/Flip.cpp
@@ -31,7 +31,7 @@ namespace cinder { namespace ip {
 template<typename T>
 void flipVertical( SurfaceT<T> *surface )
 {
-	const size_t rowBytes = surface->getRowBytes();
+	const ptrdiff_t rowBytes = surface->getRowBytes();
 	unique_ptr<uint8_t[]> buffer( new uint8_t[rowBytes] );
 	
 	const int32_t lastRow = surface->getHeight() - 1;
@@ -47,7 +47,7 @@ namespace { // anonymous
 template<typename T>
 void flipVerticalRawSameChannelOrder( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface, const ivec2 &size )
 {
-	const size_t srcPixelInc = srcSurface.getPixelInc();
+	const uint8_t srcPixelInc = srcSurface.getPixelInc();
 	const size_t copyBytes = size.x * srcPixelInc * sizeof(T);
 	for( int32_t y = 0; y < size.y; ++y ) {
 		const T *srcPtr = srcSurface.getData( ivec2( 0, y ) );
@@ -90,7 +90,7 @@ void flipVerticalRawRgbFullAlpha( const SurfaceT<T> &srcSurface, SurfaceT<T> *de
 	const uint8_t srcGreen = srcSurface.getChannelOrder().getGreenOffset();
 	const uint8_t srcBlue = srcSurface.getChannelOrder().getBlueOffset();
 	const T fullAlpha = CHANTRAIT<T>::max();
-	const int8_t srcPixelInc = srcSurface.getPixelInc();
+	const uint8_t srcPixelInc = srcSurface.getPixelInc();
 	
 	const uint8_t dstRed = destSurface->getChannelOrder().getRedOffset();
 	const uint8_t dstGreen = destSurface->getChannelOrder().getGreenOffset();
@@ -117,12 +117,12 @@ void flipVerticalRawRgb( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface
 	const uint8_t srcRed = srcSurface.getChannelOrder().getRedOffset();
 	const uint8_t srcGreen = srcSurface.getChannelOrder().getGreenOffset();
 	const uint8_t srcBlue = srcSurface.getChannelOrder().getBlueOffset();
-	const int8_t srcPixelInc = srcSurface.getPixelInc();
+	const uint8_t srcPixelInc = srcSurface.getPixelInc();
 	
 	const uint8_t dstRed = destSurface->getChannelOrder().getRedOffset();
 	const uint8_t dstGreen = destSurface->getChannelOrder().getGreenOffset();
 	const uint8_t dstBlue = destSurface->getChannelOrder().getBlueOffset();
-	const int8_t dstPixelInc = destSurface->getPixelInc();
+	const uint8_t dstPixelInc = destSurface->getPixelInc();
 	
 	for( int32_t y = 0; y < size.y; ++y ) {
 		const T *src = srcSurface.getData( ivec2( 0, y ) );
@@ -168,8 +168,8 @@ void flipVertical( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel )
 		}
 	}
 	else {
-		const int8_t srcInc	= srcChannel.getIncrement();
-		const int8_t destInc = destChannel->getIncrement();
+		const uint8_t srcInc = srcChannel.getIncrement();
+		const uint8_t destInc = destChannel->getIncrement();
 		const int32_t width = srcDst.first.getWidth();
 		for( int y = 0; y < srcDst.first.getHeight(); ++y ) {
 			const T* src = srcChannel.getData( 0, y );

--- a/src/cinder/ip/Flip.cpp
+++ b/src/cinder/ip/Flip.cpp
@@ -31,7 +31,7 @@ namespace cinder { namespace ip {
 template<typename T>
 void flipVertical( SurfaceT<T> *surface )
 {
-	const int32_t rowBytes = surface->getRowBytes();
+	const size_t rowBytes = surface->getRowBytes();
 	unique_ptr<uint8_t[]> buffer( new uint8_t[rowBytes] );
 	
 	const int32_t lastRow = surface->getHeight() - 1;
@@ -47,7 +47,7 @@ namespace { // anonymous
 template<typename T>
 void flipVerticalRawSameChannelOrder( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface, const ivec2 &size )
 {
-	const int32_t srcPixelInc = srcSurface.getPixelInc();
+	const size_t srcPixelInc = srcSurface.getPixelInc();
 	const size_t copyBytes = size.x * srcPixelInc * sizeof(T);
 	for( int32_t y = 0; y < size.y; ++y ) {
 		const T *srcPtr = srcSurface.getData( ivec2( 0, y ) );
@@ -159,7 +159,7 @@ void flipVertical( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel )
 	std::pair<Area,ivec2> srcDst = clippedSrcDst( srcChannel.getBounds(), destChannel->getBounds(), destChannel->getBounds(), ivec2(0,0) );
 	
 	if( srcChannel.isPlanar() && destChannel->isPlanar() ) { // both channels are planar, so do a series of memcpy()'s
-		const int32_t srcPixelInc = srcChannel.getIncrement();
+		const size_t srcPixelInc = srcChannel.getIncrement();
 		const size_t copyBytes = srcDst.first.getWidth() * srcPixelInc * sizeof(T);
 		for( int32_t y = 0; y < srcDst.first.getHeight(); ++y ) {
 			const T *srcPtr = srcChannel.getData( ivec2( 0, y ) );

--- a/src/cinder/ip/Premultiply.cpp
+++ b/src/cinder/ip/Premultiply.cpp
@@ -39,8 +39,8 @@ void premultiply( SurfaceT<T> *surface )
 
 	surface->setPremultiplied( true );
 
-	int32_t rowBytes = surface->getRowBytes();
-	uint8_t pixelInc = surface->getPixelInc();
+	size_t rowBytes = surface->getRowBytes();
+	size_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		T *dstPtr = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes );
@@ -67,8 +67,8 @@ void unpremultiply<uint8_t>( SurfaceT<uint8_t> *surface )
 
 	surface->setPremultiplied( false );
 
-	int32_t rowBytes = surface->getRowBytes();
-	uint8_t pixelInc = surface->getPixelInc();
+	size_t rowBytes = surface->getRowBytes();
+	size_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		uint8_t *dstPtr = reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes;
@@ -96,8 +96,8 @@ void unpremultiply<float>( SurfaceT<float> *surface )
 
 	surface->setPremultiplied( false );
 
-	int32_t rowBytes = surface->getRowBytes();
-	uint8_t pixelInc = surface->getPixelInc();
+	size_t rowBytes = surface->getRowBytes();
+	size_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		float *dstPtr = reinterpret_cast<float*>( reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes );

--- a/src/cinder/ip/Premultiply.cpp
+++ b/src/cinder/ip/Premultiply.cpp
@@ -39,8 +39,8 @@ void premultiply( SurfaceT<T> *surface )
 
 	surface->setPremultiplied( true );
 
-	size_t rowBytes = surface->getRowBytes();
-	size_t pixelInc = surface->getPixelInc();
+	ptrdiff_t rowBytes = surface->getRowBytes();
+	uint8_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		T *dstPtr = reinterpret_cast<T*>( reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes );
@@ -67,8 +67,8 @@ void unpremultiply<uint8_t>( SurfaceT<uint8_t> *surface )
 
 	surface->setPremultiplied( false );
 
-	size_t rowBytes = surface->getRowBytes();
-	size_t pixelInc = surface->getPixelInc();
+	ptrdiff_t rowBytes = surface->getRowBytes();
+	uint8_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		uint8_t *dstPtr = reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes;
@@ -96,8 +96,8 @@ void unpremultiply<float>( SurfaceT<float> *surface )
 
 	surface->setPremultiplied( false );
 
-	size_t rowBytes = surface->getRowBytes();
-	size_t pixelInc = surface->getPixelInc();
+	ptrdiff_t rowBytes = surface->getRowBytes();
+	uint8_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset(), alphaOffset = surface->getAlphaOffset();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
 		float *dstPtr = reinterpret_cast<float*>( reinterpret_cast<uint8_t*>( surface->getData() + clippedArea.getX1() * pixelInc ) + y * rowBytes );

--- a/src/cinder/ip/Threshold.cpp
+++ b/src/cinder/ip/Threshold.cpp
@@ -33,8 +33,8 @@ template<typename T>
 void thresholdImpl( SurfaceT<T> *surface, T value, const Area &area )
 {
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
-	int32_t rowBytes = surface->getRowBytes();
-	uint8_t pixelInc = surface->getPixelInc();
+	size_t rowBytes = surface->getRowBytes();
+	size_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset();
 	T maxValue = CHANTRAIT<T>::max();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
@@ -55,11 +55,11 @@ void thresholdImpl( const SurfaceT<T> &srcSurface, T value, const Area &srcArea,
 	const Area &area( srcDst.first );
 	const ivec2 &dstOffset( srcDst.second );
 
-	int32_t srcRowBytes = srcSurface.getRowBytes();
-	int8_t srcPixelInc = srcSurface.getPixelInc();
+	size_t srcRowBytes = srcSurface.getRowBytes();
+	size_t srcPixelInc = srcSurface.getPixelInc();
 	uint8_t srcRedOffset = srcSurface.getRedOffset(), srcGreenOffset = srcSurface.getGreenOffset(), srcBlueOffset = srcSurface.getBlueOffset();
-	int32_t dstRowBytes = dstSurface->getRowBytes();
-	int8_t dstPixelInc = dstSurface->getPixelInc();
+	size_t dstRowBytes = dstSurface->getRowBytes();
+	size_t dstPixelInc = dstSurface->getPixelInc();
 	uint8_t dstRedOffset = dstSurface->getRedOffset(), dstGreenOffset = dstSurface->getGreenOffset(), dstBlueOffset = dstSurface->getBlueOffset();
 	const T maxValue = CHANTRAIT<T>::max();
 	for( int32_t y = 0; y < area.getHeight(); ++y ) {
@@ -82,8 +82,8 @@ void thresholdImpl( const ChannelT<T> &srcChannel, T value, const Area &srcArea,
 	const Area &area( srcDst.first );
 	const ivec2 &dstOffset( srcDst.second );
 
-	int8_t srcInc = srcChannel.getIncrement();
-	int8_t dstInc = dstChannel->getIncrement();
+	size_t srcInc = srcChannel.getIncrement();
+	size_t dstInc = dstChannel->getIncrement();
 	const T maxValue = CHANTRAIT<T>::max();
 	for( int32_t y = 0; y < area.getHeight(); ++y ) {
 		T *dstPtr = dstChannel->getData( ivec2( area.getX1(), y ) + dstOffset );
@@ -129,8 +129,8 @@ void calculateAdaptiveThreshold( const ChannelT<T> *srcChannel, typename CHANTRA
 	int32_t imageHeight = srcChannel->getHeight();
 
 	int s2 = windowSize / 2;
-	uint8_t srcInc = srcChannel->getIncrement();
-	uint8_t dstInc = dstChannel->getIncrement();
+	size_t srcInc = srcChannel->getIncrement();
+	size_t dstInc = dstChannel->getIncrement();
 
 	SUMT comparisonMult = static_cast<SUMT>( ( 1.0f - percentageDelta ) * 256 );
 	const T maxValue = CHANTRAIT<T>::max();
@@ -176,8 +176,8 @@ void calculateAdaptiveThresholdZero( const ChannelT<T> *srcChannel, typename CHA
 	int32_t imageWidth = srcChannel->getWidth();
 	int32_t imageHeight = srcChannel->getHeight();
 	int s2 = windowSize / 2;
-	uint8_t srcInc = srcChannel->getIncrement();
-	uint8_t dstInc = dstChannel->getIncrement();
+	size_t srcInc = srcChannel->getIncrement();
+	size_t dstInc = dstChannel->getIncrement();
 
 	// perform thresholding
 	for( int32_t j = 0; j < imageHeight; j++ ) {
@@ -220,8 +220,8 @@ template<typename T>
 void calculateIntegralImage( const ChannelT<T> &channel, typename CHANTRAIT<T>::Accum *integralImage )
 {
 	int32_t imageWidth = channel.getWidth(), imageHeight = channel.getHeight();
-	int32_t srcRowBytes = channel.getRowBytes();
-	uint8_t srcInc = channel.getIncrement();
+	size_t srcRowBytes = channel.getRowBytes();
+	size_t srcInc = channel.getIncrement();
 	const T *src = channel.getData();
 	/*for( int32_t i = 0; i < imageWidth; i++ ) {
 		// reset this column sum

--- a/src/cinder/ip/Threshold.cpp
+++ b/src/cinder/ip/Threshold.cpp
@@ -33,8 +33,8 @@ template<typename T>
 void thresholdImpl( SurfaceT<T> *surface, T value, const Area &area )
 {
 	const Area clippedArea = area.getClipBy( surface->getBounds() );
-	size_t rowBytes = surface->getRowBytes();
-	size_t pixelInc = surface->getPixelInc();
+	ptrdiff_t rowBytes = surface->getRowBytes();
+	uint8_t pixelInc = surface->getPixelInc();
 	uint8_t redOffset = surface->getRedOffset(), greenOffset = surface->getGreenOffset(), blueOffset = surface->getBlueOffset();
 	T maxValue = CHANTRAIT<T>::max();
 	for( int32_t y = clippedArea.getY1(); y < clippedArea.getY2(); ++y ) {
@@ -55,11 +55,11 @@ void thresholdImpl( const SurfaceT<T> &srcSurface, T value, const Area &srcArea,
 	const Area &area( srcDst.first );
 	const ivec2 &dstOffset( srcDst.second );
 
-	size_t srcRowBytes = srcSurface.getRowBytes();
-	size_t srcPixelInc = srcSurface.getPixelInc();
+	ptrdiff_t srcRowBytes = srcSurface.getRowBytes();
+	uint8_t srcPixelInc = srcSurface.getPixelInc();
 	uint8_t srcRedOffset = srcSurface.getRedOffset(), srcGreenOffset = srcSurface.getGreenOffset(), srcBlueOffset = srcSurface.getBlueOffset();
-	size_t dstRowBytes = dstSurface->getRowBytes();
-	size_t dstPixelInc = dstSurface->getPixelInc();
+	ptrdiff_t dstRowBytes = dstSurface->getRowBytes();
+	uint8_t dstPixelInc = dstSurface->getPixelInc();
 	uint8_t dstRedOffset = dstSurface->getRedOffset(), dstGreenOffset = dstSurface->getGreenOffset(), dstBlueOffset = dstSurface->getBlueOffset();
 	const T maxValue = CHANTRAIT<T>::max();
 	for( int32_t y = 0; y < area.getHeight(); ++y ) {
@@ -82,8 +82,8 @@ void thresholdImpl( const ChannelT<T> &srcChannel, T value, const Area &srcArea,
 	const Area &area( srcDst.first );
 	const ivec2 &dstOffset( srcDst.second );
 
-	size_t srcInc = srcChannel.getIncrement();
-	size_t dstInc = dstChannel->getIncrement();
+	uint8_t srcInc = srcChannel.getIncrement();
+	uint8_t dstInc = dstChannel->getIncrement();
 	const T maxValue = CHANTRAIT<T>::max();
 	for( int32_t y = 0; y < area.getHeight(); ++y ) {
 		T *dstPtr = dstChannel->getData( ivec2( area.getX1(), y ) + dstOffset );
@@ -129,8 +129,8 @@ void calculateAdaptiveThreshold( const ChannelT<T> *srcChannel, typename CHANTRA
 	int32_t imageHeight = srcChannel->getHeight();
 
 	int s2 = windowSize / 2;
-	size_t srcInc = srcChannel->getIncrement();
-	size_t dstInc = dstChannel->getIncrement();
+	uint8_t srcInc = srcChannel->getIncrement();
+	uint8_t dstInc = dstChannel->getIncrement();
 
 	SUMT comparisonMult = static_cast<SUMT>( ( 1.0f - percentageDelta ) * 256 );
 	const T maxValue = CHANTRAIT<T>::max();
@@ -176,8 +176,8 @@ void calculateAdaptiveThresholdZero( const ChannelT<T> *srcChannel, typename CHA
 	int32_t imageWidth = srcChannel->getWidth();
 	int32_t imageHeight = srcChannel->getHeight();
 	int s2 = windowSize / 2;
-	size_t srcInc = srcChannel->getIncrement();
-	size_t dstInc = dstChannel->getIncrement();
+	uint8_t srcInc = srcChannel->getIncrement();
+	uint8_t dstInc = dstChannel->getIncrement();
 
 	// perform thresholding
 	for( int32_t j = 0; j < imageHeight; j++ ) {
@@ -220,8 +220,8 @@ template<typename T>
 void calculateIntegralImage( const ChannelT<T> &channel, typename CHANTRAIT<T>::Accum *integralImage )
 {
 	int32_t imageWidth = channel.getWidth(), imageHeight = channel.getHeight();
-	size_t srcRowBytes = channel.getRowBytes();
-	size_t srcInc = channel.getIncrement();
+	ptrdiff_t srcRowBytes = channel.getRowBytes();
+	uint8_t srcInc = channel.getIncrement();
 	const T *src = channel.getData();
 	/*for( int32_t i = 0; i < imageWidth; i++ ) {
 		// reset this column sum

--- a/src/cinder/ip/Trim.cpp
+++ b/src/cinder/ip/Trim.cpp
@@ -43,7 +43,7 @@ template<typename T>
 bool transparentVerticalScanline( const SurfaceT<T> &surface, int32_t column, int32_t y1, int32_t y2 )
 {
 	const T *dstPtr = surface.getDataAlpha( ivec2( column, y1 ) );
-	int32_t rowBytes = surface.getRowBytes();
+	size_t rowBytes = surface.getRowBytes();
 	for( int32_t y = y1; y < y2; ++y ) {
 		if( *dstPtr ) return false;
 		dstPtr += rowBytes;

--- a/src/cinder/ip/Trim.cpp
+++ b/src/cinder/ip/Trim.cpp
@@ -43,7 +43,7 @@ template<typename T>
 bool transparentVerticalScanline( const SurfaceT<T> &surface, int32_t column, int32_t y1, int32_t y2 )
 {
 	const T *dstPtr = surface.getDataAlpha( ivec2( column, y1 ) );
-	size_t rowBytes = surface.getRowBytes();
+	ptrdiff_t rowBytes = surface.getRowBytes();
 	for( int32_t y = y1; y < y2; ++y ) {
 		if( *dstPtr ) return false;
 		dstPtr += rowBytes;


### PR DESCRIPTION
Allow Surfaces larger than 2GiB

Previously creating surfaces larger than 2^31 bytes would cause an int32_t overflow on data size calculation, throwing a bad_alloc exception.

This commit converts mRowBytes, mInc and mRowInc to size_t, which causes size calculations to be performed in size_t before the result is used for array allocation and pointer arithmetic. Also, sites where these variables are used have been converted to avoid loss of precision.