### PR TITLE
Add methods to determine orientation of PolyLine

### DIFF
--- a/include/cinder/PolyLine.h
+++ b/include/cinder/PolyLine.h
@@ -51,6 +51,11 @@ class PolyLineT {
 	void				setClosed( bool aClosed = true ) { mClosed = aClosed; }
 	bool				isClosed() const { return mClosed; }
 
+	//! Returns \c true if PolyLine is clockwise-oriented. If \a isColinear is non-null, it receives \c true if all points are colinear
+	bool  isClockwise( bool *isColinear = nullptr ) const;
+	//! Returns \c true if PolyLine is counterclockwise-oriented. If \a isColinear is non-null, it receives \c true if all points are colinear
+	bool  isCounterClockwise( bool *isColinear = nullptr ) const;
+
 	T			getPosition( float t ) const;
 	T			getDerivative( float t ) const;
 

--- a/test/unit/src/PolyLineTest.cpp
+++ b/test/unit/src/PolyLineTest.cpp
@@ -1,0 +1,96 @@
+#include "cinder/app/App.h"
+#include "cinder/PolyLine.h"
+
+#include "catch.hpp"
+
+
+using namespace ci;
+using namespace ci::app;
+using namespace std;
+
+TEST_CASE("PolyLine", "Orientation")
+{
+	SECTION("Just two points")
+	{
+		vector<vec2> input({
+			vec2( 294.641, 105.359 ),
+			vec2( 387.617, 12.3833 ),
+		});
+
+		PolyLine2f p1 = PolyLine2f( input );
+		bool colinear;
+		REQUIRE( ! p1.isClockwise() );
+		REQUIRE( ! p1.isClockwise( &colinear ) );
+		REQUIRE( colinear );
+
+		REQUIRE( ! p1.isCounterClockwise() );
+		REQUIRE( ! p1.isCounterClockwise( &colinear ) );
+		REQUIRE( colinear );
+	}
+
+	SECTION("Three in a row")
+	{
+		vector<vec2> input({
+			vec2( 0, 0 ),
+			vec2( 100, 0 ),
+			vec2( -29, 0 )
+		});
+		PolyLine2f p1 = PolyLine2f( input );
+		bool colinear;
+
+		REQUIRE( ! p1.isClockwise() );
+		REQUIRE( ! p1.isClockwise( &colinear ) );
+		REQUIRE( colinear );
+
+		REQUIRE( ! p1.isCounterClockwise() );
+		REQUIRE( ! p1.isCounterClockwise( &colinear ) );
+		REQUIRE( colinear );
+	}
+
+	SECTION("Open Polygon")
+	{
+		vector<vec2> input({
+			vec2( 294.641, 105.359 ),
+			vec2( 387.617, 12.3833 ),
+			vec2( 412.967, 2.96674 ),
+			vec2( 417.987, -7.98667 ),
+			vec2( 386.023, -94.0354 )
+		});
+		PolyLine2f p1 = PolyLine2f( input );
+		reverse( input.begin(), input.end() );
+		PolyLine2f p2 = PolyLine2f( input );
+		bool colinear;
+
+		REQUIRE( p1.isClockwise() );
+		REQUIRE( p1.isClockwise( &colinear ) );
+		REQUIRE( ! colinear );
+
+		REQUIRE( ! p2.isClockwise() );
+		REQUIRE( ! p2.isClockwise( &colinear ) );
+		REQUIRE( ! colinear );
+	}
+
+	SECTION("Closed Polygon")
+	{
+		vector<vec2> input({
+			vec2( 294.641, 105.359 ),
+			vec2( 387.617, 12.3833 ),
+			vec2( 412.967, 2.96674 ),
+			vec2( 417.987, -7.98667 ),
+			vec2( 386.023, -94.0354 ),
+			vec2( 294.641, 105.359 )
+		});
+		PolyLine2f p1 = PolyLine2f( input );
+		bool colinear;
+		reverse( input.begin(), input.end() );
+		PolyLine2f p2 = PolyLine2f( input );
+
+		REQUIRE( p1.isClockwise() );
+		REQUIRE( p1.isClockwise( &colinear ) );
+		REQUIRE( ! colinear );
+
+		REQUIRE( ! p2.isClockwise() );
+		REQUIRE( ! p2.isClockwise( &colinear ) );
+		REQUIRE( ! colinear );
+	}
+}

--- a/test/unit/xcode/UnitTests.xcodeproj/project.pbxproj
+++ b/test/unit/xcode/UnitTests.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		11E4FC491C26788A0082A67E /* BufferUnit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11E4FC441C26788A0082A67E /* BufferUnit.cpp */; };
 		11E4FC4D1C267DB70082A67E /* FftUnit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11E4FC451C26788A0082A67E /* FftUnit.cpp */; };
 		11E4FC4E1C26801E0082A67E /* RingBufferUnit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11E4FC471C26788A0082A67E /* RingBufferUnit.cpp */; };
+		4989E06C1DB6889500503C9A /* PolyLineTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4989E06B1DB6889500503C9A /* PolyLineTest.cpp */; };
 		9CA851C01C1F74000049358B /* Base64Test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9CA851B61C1F74000049358B /* Base64Test.cpp */; };
 		9CA851C11C1F74000049358B /* JsonTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9CA851B81C1F74000049358B /* JsonTest.cpp */; };
 		9CA851C21C1F74000049358B /* ObjLoaderTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9CA851B91C1F74000049358B /* ObjLoaderTest.cpp */; };
@@ -61,6 +62,7 @@
 		11E4FC481C26788A0082A67E /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		4989E06B1DB6889500503C9A /* PolyLineTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PolyLineTest.cpp; sourceTree = "<group>"; };
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		6E8118130C2B4ADCA23B5B2B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9CA851B61C1F74000049358B /* Base64Test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Base64Test.cpp; sourceTree = "<group>"; };
@@ -207,6 +209,7 @@
 				9CA851B71C1F74000049358B /* catch.hpp */,
 				9CA851B81C1F74000049358B /* JsonTest.cpp */,
 				9CA851B91C1F74000049358B /* ObjLoaderTest.cpp */,
+				4989E06B1DB6889500503C9A /* PolyLineTest.cpp */,
 				9CA851BA1C1F74000049358B /* RandTest.cpp */,
 				9CA851BD1C1F74000049358B /* SystemTest.cpp */,
 				9CA851BE1C1F74000049358B /* TestMain.cpp */,
@@ -285,6 +288,7 @@
 				9CA851C01C1F74000049358B /* Base64Test.cpp in Sources */,
 				9CA851C31C1F74000049358B /* RandTest.cpp in Sources */,
 				11E4FC4D1C267DB70082A67E /* FftUnit.cpp in Sources */,
+				4989E06C1DB6889500503C9A /* PolyLineTest.cpp in Sources */,
 				9CA851C11C1F74000049358B /* JsonTest.cpp in Sources */,
 				11E4FC4E1C26801E0082A67E /* RingBufferUnit.cpp in Sources */,
 				9CA851C51C1F74000049358B /* SystemTest.cpp in Sources */,


### PR DESCRIPTION
I'd been using [CGAL's Polygon_2](http://doc.cgal.org/latest/Polygon/classCGAL_1_1Polygon__2.html) to determine the orientation but realized the math isn't that complicated and would be a nice addition to the PolyLine class.

The algorithm is based of this answer the [FAQ for comp.graphics.algorithms](http://www.faqs.org/faqs/graphics/algorithms-faq/):

    Subject 2.07: How do I find the orientation of a simple polygon?

    Compute the signed area (Subject 2.01).  The orientation is 
    counter-clockwise if this area is positive.  

    A slightly faster method is based on the observation that it isn't
    necessary to compute the area.  Find the lowest vertex (or, if 
    there is more than one vertex with the same lowest coordinate, 
    the rightmost of those vertices) and then take the cross product 
    of the edges fore and aft of it.  Both methods are O(n) for n vertices, 
    but it does seem a waste to add up the total area when a single cross
    product (of just the right edges) suffices.  Code for this is
    available at ftp://cs.smith.edu/pub/code/polyorient.C (2K).

    The reason that the lowest, rightmost (or any other such extreme) point
    works is that the internal angle at this vertex is necessarily convex, 
    strictly less than pi (even if there are several equally-lowest points).

And some other details I found on the [Wikipedia Curve orientation page](https://en.wikipedia.org/wiki/Curve_orientation).

The code ~~is kind of klunky but~~ works well. It includes some basic unit tests.