### PR TITLE
PolyLine should accept closed at initialization

### DIFF
--- a/include/cinder/PolyLine.h
+++ b/include/cinder/PolyLine.h
@@ -31,7 +31,7 @@ template<typename T>
 class PolyLineT {
   public:
 	PolyLineT() : mClosed( false ) {}
-	PolyLineT( const std::vector<T> &aPoints ) : mPoints( aPoints ), mClosed( false ) {}
+	PolyLineT( const std::vector<T> &aPoints, bool closed = false ) : mPoints( aPoints ), mClosed( closed ) {}
 	
 	const std::vector<T>&	getPoints() const { return mPoints; }
 	std::vector<T>&			getPoints() { return mPoints; }


### PR DESCRIPTION
This let's me simplify some code like:
```c++
ci::PolyLine2f BuildingPlan::triangle()
{
    ci::PolyLine2f result( { ci::vec2(10, -10), ci::vec2(10, 10), ci::vec2(-10, 10), ci::vec2(10, -10)  } );
    result.setClosed();
    return result;
}
```

Down to a one liner.
```c++
ci::PolyLine2f BuildingPlan::triangle()
{
    return ci::PolyLine2f( { ci::vec2(10, -10), ci::vec2(10, 10), ci::vec2(-10, 10), ci::vec2(10, -10)  }, true );
}
```
