### PR TITLE
Variation of InterfaceGl::addParm that permits using only a "getter" function without a "setter" function.

### DIFF
--- a/include/cinder/params/Params.h
+++ b/include/cinder/params/Params.h
@@ -125,6 +125,8 @@ class InterfaceGl {
 
 		//!! Sets \a setterFn and \a getterFn as callbacks for this param. the target is ignored in this case.
 		Options&	accessors( const SetterFn &setterFn, const GetterFn &getterFn );
+		//!! Sets \a getterFn as callbacks for this param. the target is ignored in this case.
+		Options&	accessors(const GetterFn &getterFn);
 		//!! Sets an update function that will be called after the target param is updated.
 		Options&	updateFn( const UpdateFn &updateFn );
 
@@ -172,6 +174,9 @@ class InterfaceGl {
 	//! Adds a param to the interface with no target, but is instead accessed with \a setterFn and \a getterFn. \return Options<T> for chaining options to the param.
 	template <typename T>
 	Options<T>	addParam( const std::string &name, const std::function<void ( T )> &setterFn, const std::function<T ()> &getterFn );
+	//! Adds a read-only param to the interface with no target, but is accessed with \a getterFn. \return Options<T> for chaining options to the param.
+	template <typename T>
+	Options<T>	addParam(const std::string &name, const std::function<T()> &getterFn);
 
 	//! Adds enumerated parameter. The value corresponds to the indices of \a enumNames.
 	Options<int> addParam( const std::string &name, const std::vector<std::string> &enumNames, int *param, bool readOnly = false );
@@ -240,6 +245,8 @@ class InterfaceGl {
 	Options<T>	addParamImpl( const std::string &name, T *param, int type, bool readOnly );
 	template <class T>
 	void addParamCallbackImpl( const std::function<void (T)> &setter, const std::function<T ()> &getter, const Options<T> &options );
+	template <class T>
+	void addParamCallbackImpl(const std::function<T()> &getter, const Options<T> &options);
 
 	std::weak_ptr<app::Window>		mWindow;
 	std::shared_ptr<TwBar>			mBar;
@@ -255,12 +262,30 @@ InterfaceGl::Options<T>	InterfaceGl::addParam( const std::string &name, const st
 }
 
 template <typename T>
+InterfaceGl::Options<T>	InterfaceGl::addParam(const std::string &name, const std::function<T()> &getterFn)
+{
+	return addParam<T>(name, nullptr).accessors(getterFn);
+}
+
+template <typename T>
 InterfaceGl::Options<T>& InterfaceGl::Options<T>::accessors( const SetterFn &setterFn, const GetterFn &getterFn )
 {
 	if( mTarget )
 		mParent->removeParam( getName() );
 
 	mParent->addParamCallbackImpl( setterFn, getterFn, *this );
+
+	reAddOptions();
+	return *this;
+}
+
+template <typename T>
+InterfaceGl::Options<T>& InterfaceGl::Options<T>::accessors(const GetterFn &getterFn)
+{
+	if (mTarget)
+		mParent->removeParam(getName());
+
+	mParent->addParamCallbackImpl(getterFn, *this);
 
 	reAddOptions();
 	return *this;

--- a/include/cinder/params/Params.h
+++ b/include/cinder/params/Params.h
@@ -40,7 +40,7 @@ namespace app {
 }
 
 namespace params {
-  
+
 typedef std::shared_ptr<class InterfaceGl>	InterfaceGlRef;
 
 //! Interface for adding params to your window.  Wraps AntTweakBar.
@@ -251,7 +251,7 @@ class InterfaceGl {
 	std::weak_ptr<app::Window>		mWindow;
 	std::shared_ptr<TwBar>			mBar;
 	int								mTwWindowId;
-	
+
 	std::map<std::string, std::shared_ptr<void> >	mStoredCallbacks; // key = name, value = memory managed pointer
 };
 

--- a/samples/ParamsBasic/src/ParamsBasicApp.cpp
+++ b/samples/ParamsBasic/src/ParamsBasicApp.cpp
@@ -29,11 +29,20 @@ class TweakBarApp : public App {
 	ColorA					mColor;
 	string					mString;
 	bool					mPrintFps;
-	
+
 	void					setLightDirection( vec3 direction );
 	vec3					getLightDirection() { return mLightDirection; }
 	vec3					mLightDirection;
 	uint32_t				mSomeValue;
+
+	float					getSpeed() const { return 55.5f; };
+
+	pair<int, string>			mStatus[2];
+	const pair<int, string>&	getStatus(bool bSomeOption) const { return mStatus[bSomeOption ? 0 : 1]; };
+
+	bool					mLoop;
+	bool					isLoopingEnabled() const { return mLoop; };
+	void					enableLooping(bool bLoop) { mLoop = bLoop; };
 
 	vector<string>			mEnumNames;
 	int						mEnumSelection;
@@ -52,6 +61,8 @@ void TweakBarApp::setup()
 	mColor = ColorA( 0.25f, 0.5f, 1, 1 );
 	mSomeValue = 2;
 	mPrintFps = false;
+	mStatus[0] = { 1, "good" };
+	mStatus[1] = { 2, "bad" };
 
 	// Setup our default camera, looking down the z-axis.
 	mCam.lookAt( vec3( -20, 0, 0 ), vec3( 0 ) );
@@ -75,6 +86,18 @@ void TweakBarApp::setup()
 	function<void( vec3 )> setter	= bind( &TweakBarApp::setLightDirection, this, placeholders::_1 );
 	function<vec3 ()> getter		= bind( &TweakBarApp::getLightDirection, this );
 	mParams->addParam( "Light Direction", setter, getter );
+
+	// Or alternatively provide just a getter function for "read-only" values;
+	mParams->addParam<float>( "Speed m/s", bind( &TweakBarApp::getSpeed, this ) );
+
+	// Lambda closures - (think anonymous functions defined 'in-place') - are also possible.
+	// This allows morec complex use of getter/setter functions without having to define wrapper methods.
+	// For example, transforming a value for display...
+	mParams->addParam<float>( "Speed km/h", [&]() -> float { return getSpeed() * (3600 / 1000); } );
+	// Or toggling a value..
+	mParams->addParam<bool>( "Loop?", [&](bool value) -> void { enableLooping(!isLoopingEnabled()); }, [&]() -> bool { return isLoopingEnabled(); } );
+	// Or binding getters/setters that don't easily fit the expected template
+	mParams->addParam<string>( "Status", [&]() -> const string& { return getStatus(isLoopingEnabled()).second; } );
 
 	// Other types of controls that can be added to the interface.
 	mParams->addButton( "Button!", bind( &TweakBarApp::button, this ) );

--- a/src/cinder/params/Params.cpp
+++ b/src/cinder/params/Params.cpp
@@ -268,6 +268,9 @@ void TW_CALL buttonCallback( void *clientData )
 // struct used to start getter/setter pair
 template <class T>
 struct Accessors {
+	Accessors(std::function<T()> getter)
+		: mSetter(nullptr), mGetter(getter)
+	{}
 	Accessors( std::function<void( T )> setter, std::function<T ()> getter )
 		: mSetter( setter )	, mGetter( getter )
 	{}
@@ -771,6 +774,20 @@ void InterfaceGl::addParamCallbackImpl( const function<void (T)> &setter, const 
 	TwAddVarCB( mBar.get(), name.c_str(), (TwType) type, setterCallback<T>, getterCallback<T>, (void *)callbackPtr.get(), NULL );
 }
 
+template <typename T>
+void InterfaceGl::addParamCallbackImpl(const function<T()> &getter, const Options<T> &options)
+{
+	TwSetCurrentWindow(mTwWindowId);
+
+	const string &name = options.getName();
+	int type = options.mTwType;
+
+	auto callbackPtr = std::make_shared<Accessors<T>>(getter);
+	mStoredCallbacks.insert(make_pair(name, callbackPtr));
+
+	TwAddVarCB(mBar.get(), name.c_str(), (TwType)type, (TwSetVarCallback) nullptr, getterCallback<T>, (void *)callbackPtr.get(), NULL);
+}
+
 template <> InterfaceGl::Options<bool>		InterfaceGl::addParam( const std::string &name, bool *param, bool readOnly )		{ return addParamImpl( name, param, TW_TYPE_BOOLCPP, readOnly ); }
 template <> InterfaceGl::Options<char>		InterfaceGl::addParam( const std::string &name, char *param, bool readOnly )		{ return addParamImpl( name, param, TW_TYPE_CHAR, readOnly ); }
 template <> InterfaceGl::Options<int8_t>	InterfaceGl::addParam( const std::string &name, int8_t *param, bool readOnly )		{ return addParamImpl( name, param, TW_TYPE_INT8, readOnly ); }
@@ -807,4 +824,21 @@ template void InterfaceGl::addParamCallbackImpl( const function<void( dquat )>		
 template void InterfaceGl::addParamCallbackImpl( const function<void( vec3 )>		&setter, const function<vec3 ()>		&getter, const Options<vec3>		&options );
 template void InterfaceGl::addParamCallbackImpl( const function<void( dvec3 )>		&setter, const function<dvec3 ()>		&getter, const Options<dvec3>		&options );
 
+template void InterfaceGl::addParamCallbackImpl( const function<bool ()>		&getter, const Options<bool>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<char ()>		&getter, const Options<char>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<int8_t ()>		&getter, const Options<int8_t>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<uint8_t ()>		&getter, const Options<uint8_t>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<int16_t ()>		&getter, const Options<int16_t>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<uint16_t ()>	&getter, const Options<uint16_t>	&options );
+template void InterfaceGl::addParamCallbackImpl( const function<int32_t ()>		&getter, const Options<int32_t>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<uint32_t ()>	&getter, const Options<uint32_t>	&options );
+template void InterfaceGl::addParamCallbackImpl( const function<float ()>		&getter, const Options<float>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<double ()>		&getter, const Options<double>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<string ()>		&getter, const Options<string>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<Color ()>		&getter, const Options<Color>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<ColorA ()>		&getter, const Options<ColorA>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<quat ()>		&getter, const Options<quat>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<dquat ()>		&getter, const Options<dquat>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<vec3 ()>		&getter, const Options<vec3>		&options );
+template void InterfaceGl::addParamCallbackImpl( const function<dvec3 ()>		&getter, const Options<dvec3>		&options );
 } } // namespace cinder::params


### PR DESCRIPTION
Added a variation of InterfaceGl::addParm that permits using only a "getter" function without a "setter" function. The resulting param is read-only.
e.g.
	mParams->addParam<float>( "Speed", bind( &TweakBarApp::getSpeed, this ) );
or
	mParams->addParam<float>( "Speed km/h", [&]() -> float { return getSpeed() * (3600 / 1000); } );


