### PR TITLE
Handle no available audio device in a recoverable manner.

### DIFF
--- a/src/cinder/audio/InputNode.cpp
+++ b/src/cinder/audio/InputNode.cpp
@@ -58,6 +58,14 @@ void InputNode::connectInput( const NodeRef &input )
 InputDeviceNode::InputDeviceNode( const DeviceRef &device, const Format &format )
 	: InputNode( format ), mDevice( device ), mLastOverrun( 0 ), mLastUnderrun( 0 )
 {
+	if( ! mDevice ) {
+		string errorMsg = "Empty DeviceRef.";
+		if( ! audio::Device::getDefaultInput() )
+			errorMsg += " Also, no default input Device so perhaps there is no available hardware input.";
+
+		throw AudioDeviceExc( errorMsg );
+	}
+
 	size_t deviceNumChannels = mDevice->getNumInputChannels();
 
 	// If number of channels hasn't been specified, default to 2.

--- a/src/cinder/audio/OutputNode.cpp
+++ b/src/cinder/audio/OutputNode.cpp
@@ -83,7 +83,13 @@ bool OutputNode::checkNotClipping()
 OutputDeviceNode::OutputDeviceNode( const DeviceRef &device, const Format &format )
 	: OutputNode( format ), mDevice( device )
 {
-	CI_ASSERT( mDevice );
+	if( ! mDevice ) {
+		string errorMsg = "Empty DeviceRef.";
+		if( ! audio::Device::getDefaultOutput() )
+			errorMsg += " Also, no default output Device so perhaps there is no available hardware output.";
+
+		throw AudioDeviceExc( errorMsg );
+	}
 
 	// listen to the notifications sent by device property changes in order to update the audio graph.
 	mWillChangeConn = mDevice->getSignalParamsWillChange().connect( bind( &OutputDeviceNode::deviceParamsWillChange, this ) );

--- a/src/cinder/audio/msw/DeviceManagerWasapi.cpp
+++ b/src/cinder/audio/msw/DeviceManagerWasapi.cpp
@@ -61,6 +61,9 @@ DeviceRef DeviceManagerWasapi::getDefaultOutput()
 
 	::IMMDevice *device;
 	hr = enumerator->GetDefaultAudioEndpoint( eRender, eConsole, &device );
+	if( hr == E_NOTFOUND ) {
+		return nullptr; // no device available
+	}
 	CI_ASSERT( hr == S_OK );
 
 	auto devicePtr = ci::msw::makeComUnique( device );
@@ -83,6 +86,9 @@ DeviceRef DeviceManagerWasapi::getDefaultInput()
 
 	::IMMDevice *device;
 	hr = enumerator->GetDefaultAudioEndpoint( eCapture, eConsole, &device );
+	if( hr == E_NOTFOUND ) {
+		return nullptr; // no device available
+	}
 	CI_ASSERT( hr == S_OK );
 
 	auto devicePtr = ci::msw::makeComUnique( device );

--- a/test/_audio/DeviceTest/src/DeviceTestApp.cpp
+++ b/test/_audio/DeviceTest/src/DeviceTestApp.cpp
@@ -92,19 +92,23 @@ void DeviceTestApp::setup()
 	mRecorder->setEnabled( false );
 	mGain >> mRecorder;
 
+	setupUI();
+	setupTest( mTestSelector.currentSection() );
 
 //	setupInputPulled();
 //	setupIOClean();
 
 	PRINT_GRAPH( ctx );
-
-	setupUI();
-
 	CI_LOG_V( "Context samplerate: " << ctx->getSampleRate() );
 }
 
 void DeviceTestApp::setOutputDevice( const audio::DeviceRef &device, size_t numChannels )
 {
+	if( ! device ) {
+		CI_LOG_E( "Empty DeviceRef" );
+		return;
+	}
+
 	auto ctx = audio::master();
 
 	ctx->uninitializeAllNodes();
@@ -143,6 +147,11 @@ void DeviceTestApp::setOutputDevice( const audio::DeviceRef &device, size_t numC
 
 void DeviceTestApp::setInputDevice( const audio::DeviceRef &device, size_t numChannels  )
 {
+	if( ! device ) {
+		CI_LOG_E( "Empty DeviceRef" );
+		return;
+	}
+
 	audio::ScopedEnableNode enableNodeScope( mInputDeviceNode, false );
 
 	if( mInputDeviceNode )
@@ -153,8 +162,6 @@ void DeviceTestApp::setInputDevice( const audio::DeviceRef &device, size_t numCh
 		format.channels( numChannels );
 
 	mInputDeviceNode = audio::master()->createInputDeviceNode( device, format );
-
-	setupTest( mTestSelector.currentSection() );
 
 	CI_LOG_V( "InputDeviceNode device properties: " );
 	printDeviceDetails( device );
@@ -483,6 +490,7 @@ void DeviceTestApp::processTap( ivec2 pos )
 		CI_LOG_V( "selected output device named: " << dev->getName() << ", key: " << dev->getKey() );
 
 		setOutputDevice( dev );
+		// Don't need to reset test as the Device will be updated on the Context's OutputDeviceNode and the change will propagate through the graph
 		return;
 	}
 
@@ -492,6 +500,7 @@ void DeviceTestApp::processTap( ivec2 pos )
 		CI_LOG_V( "selected input named: " << dev->getName() << ", key: " << dev->getKey() );
 
 		setInputDevice( dev );
+		setupTest( mTestSelector.currentSection() ); // need to reset the test so that we construct the InputDeviceNode with the proper Device
 		return;
 	}
 }
@@ -664,5 +673,5 @@ void DeviceTestApp::draw()
 
 CINDER_APP( DeviceTestApp, RendererGl, []( App::Settings *settings ) {
 	settings->setWindowSize( 800, 600 );
-	settings->setWindowPos( 10, 10 );
+	settings->setWindowPos( 6, 30 );
 } )


### PR DESCRIPTION
Previously the MSW Media Foundation implementation would blow up on an assertion failure if you tried to make a default audio input or output device and there wasn't connected hardware for that. Now the solution is as follows:

* `Device::getDefault[Input|Output]()` will return nullptr (empty `DeviceRef`) if there is no input or output device.
* Calling `Context::create[Input|Output]DeviceNode()` will cause an exception to be thrown if there is no default input or output device. This can be avoided by first querying for the default input or output device node before doing any other audio graph configuration.