### PR TITLE
Handle writing zero frames to an audio::TargetFile

### DIFF
--- a/include/cinder/audio/msw/FileMediaFoundation.h
+++ b/include/cinder/audio/msw/FileMediaFoundation.h
@@ -91,6 +91,7 @@ class TargetFileMediaFoundation : public TargetFile {
 	  DWORD						mStreamIndex;
 	  size_t					mSampleSize;
 	  BufferDynamicInterleaved	mBitConverterBuffer;	// only used when bit conversion and interleaving are done in separate steps (ex. 24-bit stereo).
+	  bool						mSamplesWritten = false;
 };
 
 class MediaFoundationInitializer {

--- a/src/cinder/audio/Target.cpp
+++ b/src/cinder/audio/Target.cpp
@@ -66,6 +66,9 @@ void TargetFile::write( const Buffer *buffer )
 
 void TargetFile::write( const Buffer *buffer, size_t numFrames )
 {
+	if( ! numFrames )
+		return;
+
 	CI_ASSERT_MSG( numFrames <= buffer->getNumFrames(), "numFrames out of bounds" );
 
 	performWrite( buffer, numFrames, 0 );
@@ -73,6 +76,9 @@ void TargetFile::write( const Buffer *buffer, size_t numFrames )
 
 void TargetFile::write( const Buffer *buffer, size_t numFrames, size_t frameOffset )
 {
+	if( ! numFrames )
+		return;
+
 	CI_ASSERT_MSG( numFrames + frameOffset <= buffer->getNumFrames(), "numFrames + frameOffset out of bounds" );
 
 	performWrite( buffer, numFrames, frameOffset );

--- a/src/cinder/audio/msw/FileMediaFoundation.cpp
+++ b/src/cinder/audio/msw/FileMediaFoundation.cpp
@@ -471,9 +471,9 @@ TargetFileMediaFoundation::TargetFileMediaFoundation( const DataTargetRef &dataT
 
 TargetFileMediaFoundation::~TargetFileMediaFoundation()
 {
-	if( mSinkWriter ) {
+	if( mSinkWriter && mSamplesWritten ) {
 		HRESULT hr = mSinkWriter->Finalize();
-		CI_ASSERT( hr == S_OK );
+		CI_VERIFY( hr == S_OK );
 	}
 }
 
@@ -545,6 +545,8 @@ void TargetFileMediaFoundation::performWrite( const Buffer *buffer, size_t numFr
 
 	hr = mSinkWriter->WriteSample( mStreamIndex, mediaSample );
 	CI_ASSERT( hr == S_OK );
+
+	mSamplesWritten = true;
 }
 
 // ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The result should be an empty .wav file, but shouldn't crash (previously on Windows, an assertion was failing causing the program to abort).