### PR TITLE
Fixed write position bug in BufferRecorderNode::process()

### DIFF
--- a/src/cinder/audio/SampleRecorderNode.cpp
+++ b/src/cinder/audio/SampleRecorderNode.cpp
@@ -180,7 +180,7 @@ uint64_t BufferRecorderNode::getLastOverrun()
 
 void BufferRecorderNode::process( Buffer *buffer )
 {
-	const size_t writePos = mWritePos;
+	size_t writePos = mWritePos;
 	size_t numWriteFrames = buffer->getNumFrames();
 
 	if( writePos + numWriteFrames > mRecorderBuffer.getNumFrames() )
@@ -191,7 +191,10 @@ void BufferRecorderNode::process( Buffer *buffer )
 	if( numWriteFrames < buffer->getNumFrames() )
 		mLastOverrun = getContext()->getNumProcessedFrames();
 
-	mWritePos += numWriteFrames;
+    const size_t writePosNew = writePos + numWriteFrames;
+
+    // only update mWritePos if it hasn't been reset by start() in the meanwhile
+    mWritePos.compare_exchange_strong( writePos, writePosNew );
 }
 
 } } // namespace cinder::audio


### PR DESCRIPTION
Now mWritePos gets updated in process() through std::atomic::compare_exchange_strong().

The update only happens if mWritePos didn't change since the beginningof process().

If it did change, then it means mWritePos has been reset to 0 by anotherthread calling start() and
therefore it must not be updated ( by adding numWriteFrames to it ) or the new recording will start with an offset of numWriteFrames from the beginning of the buffer.