### PR TITLE
WIP building with cmake on Windows

### DIFF
--- a/proj/cmake/libcinder_configure_build.cmake
+++ b/proj/cmake/libcinder_configure_build.cmake
@@ -5,7 +5,9 @@ message( "Building Cinder for ${CINDER_TARGET}" )
 set( CINDER_SRC_DIR 	"${CINDER_ROOT}/src" )
 set( CINDER_INC_DIR		"${CINDER_ROOT}/include" )
 
-add_definitions( -Wfatal-errors )
+if( NOT CINDER_MSW )
+    add_definitions( -Wfatal-errors )
+endif()
 
 list( APPEND CMAKE_MODULE_PATH ${CINDER_CMAKE_DIR} ${CMAKE_CURRENT_LIST_DIR}/modules )
 

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -58,7 +58,6 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/Tween.cpp
 	${CINDER_SRC_DIR}/cinder/Unicode.cpp
 	${CINDER_SRC_DIR}/cinder/Url.cpp
-	${CINDER_SRC_DIR}/cinder/UrlImplCurl.cpp
 	${CINDER_SRC_DIR}/cinder/Utilities.cpp
 	${CINDER_SRC_DIR}/cinder/Xml.cpp
 )
@@ -67,6 +66,12 @@ if( NOT CINDER_LINUX )
 	list( APPEND SRC_SET_CINDER
 		${CINDER_SRC_DIR}/cinder/Capture.cpp
 		${CINDER_SRC_DIR}/cinder/Serial.cpp
+	)
+endif()
+
+if( NOT CINDER_MSW )
+	list( APPEND SRC_SET_CINDER
+		${CINDER_SRC_DIR}/cinder/UrlImplCurl.cpp
 	)
 endif()
 

--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -23,16 +23,16 @@ target_link_libraries( cinder INTERFACE ${CINDER_LIBS_DEPENDS} )
 target_compile_definitions( cinder PUBLIC ${CINDER_DEFINES} )
 
 # Check compiler support for enabling c++11 or c++14.
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+include( CheckCXXCompilerFlag )
+CHECK_CXX_COMPILER_FLAG( "-std=c++14" COMPILER_SUPPORTS_CXX14 )
+CHECK_CXX_COMPILER_FLAG( "-std=c++11" COMPILER_SUPPORTS_CXX11 )
 
-if(COMPILER_SUPPORTS_CXX14)
+if( COMPILER_SUPPORTS_CXX14 )
 	set( CINDER_COMPILER_FLAGS "-std=c++14" )
-elseif(COMPILER_SUPPORTS_CXX11)
+elseif( COMPILER_SUPPORTS_CXX11 )
 	set( CINDER_COMPILER_FLAGS "-std=c++11" )
 else()
-	message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has neither C++11 or C++14 support. Please use a different C++ compiler.")
+	message( FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has neither C++11 or C++14 support. Please use a different C++ compiler." )
 endif()
 
 set( CMAKE_CXX_FLAGS ${CINDER_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS} )

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -39,4 +39,10 @@ list( APPEND CINDER_SRC_FILES
 source_group( "cinder\\msw"       FILES ${SRC_SET_MSW} )
 source_group( "cinder\\app\\msw"  FILES ${SRC_SET_APP_MSW} )
 
+list( APPEND CINDER_INCLUDE_SYSTEM
+    ${CINDER_INC_DIR}/msw/zlib
+)
+
+list( APPEND CINDER_DEFINES "_LIB UNICODE _UNICODE NOMINMAX _WIN32_WINNT=0x0601 _CRT_SECURE_NO_WARNINGS _SCL_SECURE_NO_WARNINGS" )
+
 include( ${CINDER_CMAKE_DIR}/libcinder_target.cmake )

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -16,11 +16,19 @@ list( APPEND SRC_SET_MSW
 )
 
 list( APPEND SRC_SET_APP_MSW
+	# TODO: should these two files be added to "cinder\\app" group?
 	${CINDER_SRC_DIR}/cinder/app/AppScreenSaver.cpp
-	${CINDER_SRC_DIR}/cinder/app/AppImplMsw.cpp
-	${CINDER_SRC_DIR}/cinder/app/AppImplMswBasic.cpp
-	${CINDER_SRC_DIR}/cinder/app/AppImplMswRendererGl.cpp
 	${CINDER_SRC_DIR}/cinder/app/RendererDx.cpp
+
+	${CINDER_SRC_DIR}/cinder/app/msw/AppImplMsw.cpp
+	${CINDER_SRC_DIR}/cinder/app/msw/AppImplMswBasic.cpp
+	${CINDER_SRC_DIR}/cinder/app/msw/AppImplMswScreenSaver.cpp
+	${CINDER_SRC_DIR}/cinder/app/msw/AppMsw.cpp
+	${CINDER_SRC_DIR}/cinder/app/msw/PlatformMsw.cpp
+	${CINDER_SRC_DIR}/cinder/app/msw/RendererImpl2dGdi.cpp
+	${CINDER_SRC_DIR}/cinder/app/msw/RendererImplDx.cpp
+	${CINDER_SRC_DIR}/cinder/app/msw/RendererImplGlAngle.cpp
+	${CINDER_SRC_DIR}/cinder/app/msw/RendererImplGlMsw.cpp
 )
 
 list( APPEND CINDER_SRC_FILES


### PR DESCRIPTION
This gets things closer to building on windows, at least when generating a Visual Studio project (which isn't very useful in our case). When trying to build from the command line, not only is it incredibly involved to set up the build system, it doesn't look like gcc / libstdc++ support some of the things we'd need to build libcinder, such as `std::mutex`, so I stopped there.

I only added changes here that won't have an effect on other platforms, as part of due diligence towards #1301.