### PR TITLE
DDS default as 24 bit RGB for DDS files with no FOURCC

### DIFF
--- a/src/cinder/gl/TextureFormatParsers.cpp
+++ b/src/cinder/gl/TextureFormatParsers.cpp
@@ -275,6 +275,11 @@ void parseDds( const DataSourceRef &dataSource, TextureData *resultData )
 	int32_t blockSizeBytes = 16;
 	switch( ddsd.ddpfPixelFormat.dwFourCC ) { 
 #if ! defined( CINDER_GL_ANGLE )
+		case 0: /*Note that some DDS files do not have a valid format
+				 - we assume they are RGB 24
+				 - We might want some better logic here, but it is unclear how
+				 - one might discern a RGBA vs RGB DDS from exporters which do not
+				 - clearly mark their format */
 		case 20 /*D3DFMT_R8G8B8*/:
 			internalFormat = GL_RGB8;
 			dataFormat = GL_BGR;


### PR DESCRIPTION
Experimentation with the DDS texture format parser and various exporters like Image Magic, GIMP and Graphics Converter lead me to notice that some DDS exporters do not write a valid fourcc pixel format.

This is an attempt to be right half the time. Admittedly its not the best, but maybe this PR could be used to start some discussion for a more robust fix?

Thanks.