### PR TITLE
Migrate some Buffer ivars to Protected

### DIFF
--- a/include/cinder/Buffer.h
+++ b/include/cinder/Buffer.h
@@ -72,7 +72,7 @@ class Buffer {
 	//! Writes a Buffer to a DataTarget
 	void	write( const DataTargetRef &dataTarget );
 	
-  private:
+  protected:
 	void*	mData;
 	size_t	mAllocatedSize;
 	size_t	mDataSize;


### PR DESCRIPTION
It might be nice to have BufferRef' subclasses be able to swizzle values for the mData, mAllocatedSize and mDataSize, particularly in the situation where page aligned memory is required for high performance disk reads or writes (unbuffered for example), as well as some types or DMA to PCI transfers.

