### PR TITLE
Added convenience gl::getVendorString().

### DIFF
--- a/include/cinder/gl/wrapper.h
+++ b/include/cinder/gl/wrapper.h
@@ -77,6 +77,8 @@ bool isExtensionAvailable( const std::string &extName );
 //! Returns the OpenGL version number as a pair<major,minor>
 std::pair<GLint,GLint>	getVersion();
 std::string getVersionString();
+std::string getVendorString();
+
 
 GlslProgRef& getStockShader( const class ShaderDef &shader );
 void bindStockShader( const class ShaderDef &shader );

--- a/src/cinder/gl/wrapper.cpp
+++ b/src/cinder/gl/wrapper.cpp
@@ -164,6 +164,13 @@ std::string getVersionString()
 	return std::string( reinterpret_cast<const char*>( s ) );
 }
 
+std::string getVendorString()
+{
+	const GLubyte* s = glGetString( GL_VENDOR );
+	
+	return std::string(reinterpret_cast<const char*>(s));
+}
+
 GlslProgRef& getStockShader( const class ShaderDef &shader )
 {
 	return context()->getStockShader( shader );


### PR DESCRIPTION
Adds cinder::gl::getVendorString() function which works similarly to cinder::gl::getVersionString() but for obtaining GL_VENDOR information.