### PR TITLE
CMake: Implement option for building Cinder as a shared library.

### DIFF
--- a/include/cinder/audio/linux/DeviceManagerJack.h
+++ b/include/cinder/audio/linux/DeviceManagerJack.h
@@ -32,24 +32,24 @@ class DeviceManagerJack : public DeviceManager {
 	DeviceManagerJack();
 	virtual ~DeviceManagerJack();
 
-	const std::vector<DeviceRef>& getDevices()									override;
-	DeviceRef getDefaultOutput()												override;
-	DeviceRef getDefaultInput()													override;
+	const std::vector<DeviceRef>& getDevices()									override {};
+	DeviceRef getDefaultOutput()												override {};
+	DeviceRef getDefaultInput()													override {};
 
-	std::string getName( const DeviceRef &device )								override;
-	size_t getNumInputChannels( const DeviceRef &device )						override;
-	size_t getNumOutputChannels( const DeviceRef &device )						override;
-	size_t getSampleRate( const DeviceRef &device )								override;
-	size_t getFramesPerBlock( const DeviceRef &device )							override;
+	std::string getName( const DeviceRef &device )								override {};
+	size_t getNumInputChannels( const DeviceRef &device )						override {};
+	size_t getNumOutputChannels( const DeviceRef &device )						override {};
+	size_t getSampleRate( const DeviceRef &device )								override {};
+	size_t getFramesPerBlock( const DeviceRef &device )							override {};
 
-	void setSampleRate( const DeviceRef &device, size_t sampleRate )			override;
-	void setFramesPerBlock( const DeviceRef &device, size_t framesPerBlock )	override;
+	void setSampleRate( const DeviceRef &device, size_t sampleRate )			override {};
+	void setFramesPerBlock( const DeviceRef &device, size_t framesPerBlock )	override {};
 
 	//! Returns the hardware's actual frames per block, which might not be a power of two.
-	size_t getFramesPerBlockHardware( const DeviceRef &device );
+	size_t getFramesPerBlockHardware( const DeviceRef &device ){};
 
 private:
-	DeviceRef getDefaultDevice();
+	DeviceRef getDefaultDevice(){};
 
 	DeviceRef   mDefaultDevice;
 };	

--- a/proj/cmake/configure.cmake
+++ b/proj/cmake/configure.cmake
@@ -3,6 +3,7 @@
 
 set( CINDER_TARGET "" CACHE STRING "Target platform to build for." )
 option( CINDER_VERBOSE "Print verbose build configuration messages. " OFF )
+option( BUILD_SHARED_LIBS "Build Cinder as a shared library. " OFF )
 
 # Set default build type to Debug
 if( NOT CMAKE_BUILD_TYPE )

--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -3,20 +3,25 @@ cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
 cmake_policy( SET CMP0022 NEW )
 
 set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CINDER_PATH}/${CINDER_LIB_DIRECTORY} )
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CINDER_PATH}/${CINDER_LIB_DIRECTORY} )
 
 if( CINDER_VERBOSE )
 	message( "CMAKE_ARCHIVE_OUTPUT_DIRECTORY: ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}" )
 endif()
 
+# The type is based on the value of the BUILD_SHARED_LIBS variable.
+# When OFF ( default value ) Cinder will be built as a static lib
+# and when ON as a shared library.
+# See https://cmake.org/cmake/help/v3.0/command/add_library.html for more info.
 add_library(
-    cinder STATIC
+	cinder 
     ${CINDER_SRC_FILES}
 )
 
 target_include_directories( cinder BEFORE PUBLIC ${CINDER_INCLUDE_USER} )
 target_include_directories( cinder SYSTEM BEFORE PUBLIC ${CINDER_INCLUDE_SYSTEM} )
 
-target_link_libraries( cinder INTERFACE ${CINDER_LIBS_DEPENDS} )
+target_link_libraries( cinder PUBLIC ${CINDER_LIBS_DEPENDS} )
 
 target_compile_definitions( cinder PUBLIC ${CINDER_DEFINES} )
 

--- a/proj/cmake/platform_linux.cmake
+++ b/proj/cmake/platform_linux.cmake
@@ -54,6 +54,7 @@ if( NOT CINDER_GL_ES_2_RPI )
 		)
 		list( APPEND SRC_SET_CINDER_LINUX
 			${CINDER_SRC_DIR}/glload/glx_load.c
+			${CINDER_SRC_DIR}/glload/glx_load_cpp.cpp
 		)
 	endif()
 		


### PR DESCRIPTION
Set [BUILD_SHARED_LIBS](https://github.com/cinder/Cinder/compare/cmake...PetrosKataras:cmake-shared-lib-build-option?expand=1#diff-02073d153aae95890ea625f9a8b2c7b4R6) to `ON` for building Cinder as a shared library ( Currently tested only under Linux. )