### PR TITLE
quit()-centric app fixes

### DIFF
--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -453,6 +453,7 @@ class AppBase {
 	double					mFpsLastSampleTime;
 	double					mFpsSampleInterval;
 	bool					mMultiTouchEnabled, mHighDensityDisplayEnabled;
+	bool					mLaunchCalled, mQuitCalledBeforeLaunch;
 	RendererRef				mDefaultRenderer;
 
 	std::vector<std::string>	mCommandLineArgs;
@@ -469,6 +470,9 @@ class AppBase {
   protected:
 	static AppBase*			sInstance;
 	static Settings*		sSettingsFromMain;
+
+	bool					getLaunchCalled() const { return mLaunchCalled; }
+	void					setQuitCalledBeforeLaunch() { mQuitCalledBeforeLaunch = true; }
 
 	bool					mPowerManagement;
 };

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -235,7 +235,7 @@ class AppBase {
 	
 	//! Override to cleanup any resources before app destruction
 	virtual void	cleanup() {}
-	//! Requests that the application exit gracefully. Use std::terminate() instead to end application immediately.
+	//! Requests that the application exit gracefully upon completion of the current event loop. Use std::terminate() instead to end application immediately.
 	virtual void	quit() = 0;
 
 	//! Emitted at the start of each application update cycle

--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -420,6 +420,9 @@ class AppBase {
 	// DO NOT CALL - should be private but aren't for esoteric reasons
 	//! \cond
 	// Internal handlers - these are called into by AppImpl's. If you are calling one of these, you have likely strayed far off the path.
+	//! Returns whether a call to quit() has been issued
+	bool			getQuitRequested() const { return mQuitRequested; }
+	void			setQuitRequested() { mQuitRequested = true; }	
 	virtual void	privateSetup__();
 	virtual void	privateUpdate__();
 	bool			privateEmitShouldQuit()		{ return mSignalShouldQuit.emit(); }
@@ -453,7 +456,7 @@ class AppBase {
 	double					mFpsLastSampleTime;
 	double					mFpsSampleInterval;
 	bool					mMultiTouchEnabled, mHighDensityDisplayEnabled;
-	bool					mLaunchCalled, mQuitCalledBeforeLaunch;
+	bool					mLaunchCalled, mQuitRequested;
 	RendererRef				mDefaultRenderer;
 
 	std::vector<std::string>	mCommandLineArgs;
@@ -472,7 +475,6 @@ class AppBase {
 	static Settings*		sSettingsFromMain;
 
 	bool					getLaunchCalled() const { return mLaunchCalled; }
-	void					setQuitCalledBeforeLaunch() { mQuitCalledBeforeLaunch = true; }
 
 	bool					mPowerManagement;
 };

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -141,7 +141,7 @@ void AppBase::Settings::setShouldQuit( bool shouldQuit )
 
 AppBase::AppBase()
 	: mFrameCount( 0 ), mAverageFps( 0 ), mFpsSampleInterval( 1 ), mTimer( true ), mTimeline( Timeline::create() ),
-		mFpsLastSampleFrame( 0 ), mFpsLastSampleTime( 0 ), mLaunchCalled( false ), mQuitCalledBeforeLaunch( false )
+		mFpsLastSampleFrame( 0 ), mFpsLastSampleTime( 0 ), mLaunchCalled( false ), mQuitRequested( false )
 {
 	sInstance = this;
 
@@ -183,7 +183,8 @@ void AppBase::initialize( Settings *settings, const RendererRef &defaultRenderer
 void AppBase::executeLaunch()
 {
 	try {
-		if( mQuitCalledBeforeLaunch )
+		// a quit() was called from the app constructor; don't launch
+		if( mQuitRequested )
 			return;
 		mLaunchCalled = true;
 		launch();

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -141,7 +141,7 @@ void AppBase::Settings::setShouldQuit( bool shouldQuit )
 
 AppBase::AppBase()
 	: mFrameCount( 0 ), mAverageFps( 0 ), mFpsSampleInterval( 1 ), mTimer( true ), mTimeline( Timeline::create() ),
-		mFpsLastSampleFrame( 0 ), mFpsLastSampleTime( 0 )
+		mFpsLastSampleFrame( 0 ), mFpsLastSampleTime( 0 ), mLaunchCalled( false ), mQuitCalledBeforeLaunch( false )
 {
 	sInstance = this;
 
@@ -183,6 +183,9 @@ void AppBase::initialize( Settings *settings, const RendererRef &defaultRenderer
 void AppBase::executeLaunch()
 {
 	try {
+		if( mQuitCalledBeforeLaunch )
+			return;
+		mLaunchCalled = true;
 		launch();
 	}
 	catch( std::exception &exc ) {

--- a/src/cinder/app/cocoa/AppCocoaTouch.cpp
+++ b/src/cinder/app/cocoa/AppCocoaTouch.cpp
@@ -229,6 +229,7 @@ void AppCocoaTouch::setFullScreen( bool fullScreen, const FullScreenOptions &opt
 
 void AppCocoaTouch::quit()
 {
+	CI_LOG_W( "quit() has no effect on iOS" );
 	return; // no effect on iOS
 }
 

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -349,6 +349,12 @@ using namespace cinder::app;
 		return;
 
 	[NSApp stop:nil];
+
+	// we need to post a dummy event to force the runloop to cycle once more
+	// otherwise the app won't actually terminate until the mouse is moved or similar
+	NSEvent* event = [NSEvent otherEventWithType: NSApplicationDefined location: NSMakePoint(0,0)
+							modifierFlags: 0 timestamp: 0.0 windowNumber: 0 context: nil subtype: 0 data1: 0 data2: 0];
+	[NSApp postEvent:event atStart:YES];
 }
 
 - (void)setPowerManagementEnabled:(BOOL)flag

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -146,6 +146,10 @@ using namespace cinder::app;
 		// issue update() event
 		mApp->privateUpdate__();
 
+		// if quit() was called from update(), we don't want to issue another draw()
+		if( mApp->getQuitRequested() )
+			return;
+
 		// mark all windows as ready to draw; this really only matters the first time, to ensure the first update() fires before draw()
 		for( WindowImplBasicCocoa* winIt in mWindows ) {
 			[winIt->mCinderView setReadyToDraw:YES];
@@ -347,6 +351,8 @@ using namespace cinder::app;
 	// so we call this here and then pass nil to terminate: instead
 	if( ! mApp->privateEmitShouldQuit() )
 		return;
+
+	mApp->setQuitRequested();
 
 	[NSApp stop:nil];
 

--- a/src/cinder/app/cocoa/AppMac.cpp
+++ b/src/cinder/app/cocoa/AppMac.cpp
@@ -68,8 +68,9 @@ WindowRef AppMac::createWindow( const Window::Format &format )
 
 void AppMac::quit()
 {
+	// if launch() has not yet been called, we note the request rather than issue the call to AppImpl's quit
 	if( ! getLaunchCalled() )
-		setQuitCalledBeforeLaunch();
+		setQuitRequested();
 	else
 		[mImpl quit];
 }

--- a/src/cinder/app/cocoa/AppMac.cpp
+++ b/src/cinder/app/cocoa/AppMac.cpp
@@ -68,7 +68,10 @@ WindowRef AppMac::createWindow( const Window::Format &format )
 
 void AppMac::quit()
 {
-	[mImpl quit];
+	if( ! getLaunchCalled() )
+		setQuitCalledBeforeLaunch();
+	else
+		[mImpl quit];
 }
 
 float AppMac::getFrameRate() const

--- a/src/cinder/app/linux/AppImplLinuxGlfw.cpp
+++ b/src/cinder/app/linux/AppImplLinuxGlfw.cpp
@@ -289,6 +289,10 @@ void AppImplLinux::run()
 	mApp->privateSetup__();
 	mSetupHasBeenCalled = true;
 
+	// quit() was called from setup()
+	if( mShouldQuit )
+		goto terminate;
+
 	// issue initial app activation event
 	mApp->emitDidBecomeActive();
 	
@@ -304,6 +308,8 @@ void AppImplLinux::run()
 		// update and draw
 		mApp->privateUpdate__();
 		for( auto &window : mWindows ) {
+			if( mShouldQuit ) // test for quit() issued from update() or draw()
+				goto terminate;
 			window->draw();
 		}
 
@@ -318,6 +324,7 @@ void AppImplLinux::run()
 		}
 	}
 
+  terminate:
 	// Destroy the main window - this should resolve to
 	// a call for ::glfwDestroyWindow( ... );
 	mMainWindow.reset();
@@ -362,6 +369,7 @@ void AppImplLinux::quit()
 	for( auto &window : mWindows ) {
 		::glfwSetWindowShouldClose( window->getNative(), true );	
 	}
+	mShouldQuit = true;
 }
 
 float AppImplLinux::getFrameRate() const 

--- a/src/cinder/app/linux/AppLinux.cpp
+++ b/src/cinder/app/linux/AppLinux.cpp
@@ -55,7 +55,11 @@ WindowRef AppLinux::createWindow( const Window::Format &format )
 
 void AppLinux::quit()
 {
-	mImpl->quit();
+	// if launch() has not yet been called, we note the request rather than issue the call to mImpl::quit()
+	if( ! getLaunchCalled() )
+		setQuitRequested();
+	else
+		mImpl->quit();
 }
 
 float AppLinux::getFrameRate() const

--- a/src/cinder/app/msw/AppImplMswBasic.cpp
+++ b/src/cinder/app/msw/AppImplMswBasic.cpp
@@ -79,9 +79,10 @@ void AppImplMswBasic::run()
 
 		// update and draw
 		mApp->privateUpdate__();
-		for( auto &window : mWindows )
-			window->redraw();
-
+		for( auto &window : mWindows ) {
+			if( ! mShouldQuit ) // test for quit() issued either from update() or prior draw()
+				window->redraw();
+		}
 		// get current time in seconds
 		double currentSeconds = mApp->getElapsedSeconds();
 

--- a/src/cinder/app/msw/AppMsw.cpp
+++ b/src/cinder/app/msw/AppMsw.cpp
@@ -99,7 +99,11 @@ WindowRef AppMsw::createWindow( const Window::Format &format )
 
 void AppMsw::quit()
 {
-	mImpl->quit();
+	// if launch() has not yet been called, we note the request rather than issue the call to mImpl::quit()
+	if( ! getLaunchCalled() )
+		setQuitRequested();
+	else
+		mImpl->quit();
 }
 
 float AppMsw::getFrameRate() const


### PR DESCRIPTION
This should address 3 issues related to `quit()`. 
* #1072 where `quit()` called from the app constructor had no effect
* `quit()` called from `update()` or `draw()` required an additional event (like a mouse move) for it to take effect on OS X
* `draw()` could be called even though `quit()` was called from `update()`

These should all be fixed and tested on OS X, Linux, and MSW, using the code below:
```
#include "cinder/app/App.h"
#include "cinder/app/RendererGl.h"
#include "cinder/gl/gl.h"

#define TEST_QUIT_IN_CONSTRUCTOR
//#define TEST_QUIT_AT_SETUP
//#define TEST_QUIT_IN_UPDATE

class QuitTestApp : public ci::app::App {
  public:
    QuitTestApp();
    void setup() override;
    void update() override;
    void draw() override;
   
    bool    mQuitCalledFromUpdate, mQuitCalledFromConstructor, mQuitCalledFromSetup;
};

QuitTestApp::QuitTestApp()
    : mQuitCalledFromUpdate( false ), mQuitCalledFromConstructor( false ), mQuitCalledFromSetup( false )
{
#if defined( TEST_QUIT_IN_CONSTRUCTOR )
    mQuitCalledFromConstructor = true;
    quit();
#endif    
}

void QuitTestApp::setup()
{
    CI_ASSERT( ! mQuitCalledFromConstructor );
#if defined( TEST_QUIT_AT_SETUP )
    console() << "Quitting from setup" << std::endl;
    quit();
    mQuitCalledFromSetup = true;
#endif
}

void QuitTestApp::draw()
{
    CI_ASSERT( ! mQuitCalledFromConstructor );
    CI_ASSERT( ! mQuitCalledFromSetup );
    CI_ASSERT( ! mQuitCalledFromUpdate );
}

void QuitTestApp::update()
{
    CI_ASSERT( ! mQuitCalledFromConstructor );
    CI_ASSERT( ! mQuitCalledFromSetup );
#if defined( TEST_QUIT_IN_UPDATE )
    if( getElapsedSeconds() > 1 ) {
        quit();
        mQuitCalledFromUpdate = true; 
    }
#endif
}

CINDER_APP( QuitTestApp, ci::app::RendererGl )
```

To verify, enable each #define one-by-one and run.