### PR TITLE
Make sure CGContext exists before attempting to get window contents.

### DIFF
--- a/src/cinder/app/cocoa/RendererImpl2dMacQuartz.mm
+++ b/src/cinder/app/cocoa/RendererImpl2dMacQuartz.mm
@@ -71,11 +71,20 @@
 - (NSBitmapImageRep*)getContents:(cinder::Area)area
 {
 	[view lockFocus];
-	CGContextFlush( currentRef );
+	
+	// We need to recreate the CGContextRef if this method
+	// isn't called between startDraw and finishDraw
+	CGContextRef tempRef = currentRef;
+	if( !tempRef )
+		tempRef = (CGContextRef)[currentGraphicsContext graphicsPort];
+
+	CGContextFlush( tempRef );
 	NSRect rect = NSMakeRect( area.x1, area.y1, area.getWidth(), area.getHeight() );
 	NSBitmapImageRep *rep = [[NSBitmapImageRep alloc] initWithFocusedViewRect:rect];
 	[view unlockFocus];
-	return [rep autorelease];
+
+	// Caller assumes ownership
+	return rep;
 }
 
 - (void)startDraw

--- a/src/cinder/cocoa/CinderCocoa.mm
+++ b/src/cinder/cocoa/CinderCocoa.mm
@@ -157,7 +157,7 @@ Surface8uRef convertNsBitmapDataRep( const NSBitmapImageRep *rep, bool assumeOwn
 	int32_t width = (int32_t)[rep pixelsWide];
 	int32_t height = (int32_t)[rep pixelsHigh];
 	uint8_t *data = [rep bitmapData];
-	SurfaceChannelOrder co = ( bpp == 24 ) ? SurfaceChannelOrder::RGB : SurfaceChannelOrder::RGBA;
+	SurfaceChannelOrder co = ( bpp == 24 ) ? SurfaceChannelOrder::RGB : SurfaceChannelOrder::ARGB;
 	// If requested, point the result's deallocator to the appropriate function. This will get called when the Surface::Obj is destroyed
 	if( assumeOwnership )
 		return Surface8uRef( new Surface8u( data, width, height, rowBytes, co ),


### PR DESCRIPTION
Possible fix for issue #1454. 

In the Wisteria example, copyWindowSurface() is called from a key event, which means the CGContextRef currentRef has been released already by the finishDraw method in RendererImpl2dMacQuartz.mm.

This PR adds a check for the currentRef, and will create a temporary reference if needed.

I think the NSBitmapImageRep was also being released twice, since it's called by convertNsBitmapDataRep with "assumeOwnership" set to true, which should take care of clean-up.

Finally, I noticed that the channel order coming from initWithFocusedViewRect was ARGB instead of RGBA. Updated convertNsBitmapDataRep accordingly. (But not sure if this will break something elsewhere?)

Open to any feedback / revisions / insights. Thank you.