### PR TITLE
Fixing Xcode-induced annoyance -NSDocumentRevisionsDebugMode

### DIFF
--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -169,6 +169,8 @@ class AppBase {
 
 		//! Returns the command line args passed to the application from its entry point (ex. a main's argc / argv).
 		const std::vector<std::string>&	getCommandLineArgs() const	{ return mCommandLineArgs; }
+		//! Primarily for internal use. Replaces the command line args.
+		void							setCommandLineArgs( const std::vector<std::string> &commandLineArgs ) { mCommandLineArgs = commandLineArgs; }
 
 		//!	Set this to true if the app should terminate prior to launching.
 		void	setShouldQuit( bool shouldQuit = true );

--- a/include/cinder/app/cocoa/AppMac.h
+++ b/include/cinder/app/cocoa/AppMac.h
@@ -71,6 +71,8 @@ class AppMac : public AppBase {
 	void	launch() override;
 
   private:
+	static void		initialize( Settings *settings, const RendererRef &defaultRenderer, const char *title, int argc, char * const argv[] );
+
 	AppImplMac*	mImpl;
 };
 
@@ -80,7 +82,7 @@ void AppMac::main( const RendererRef &defaultRenderer, const char *title, int ar
 	AppBase::prepareLaunch();
 
 	Settings settings;
-	AppBase::initialize( &settings, defaultRenderer, title, argc, argv );
+	AppMac::initialize( &settings, defaultRenderer, title, argc, argv );
 
 	if( settingsFn )
 		settingsFn( &settings );

--- a/src/cinder/app/cocoa/AppMac.cpp
+++ b/src/cinder/app/cocoa/AppMac.cpp
@@ -45,6 +45,23 @@ AppMac::~AppMac()
 	[mImpl release];
 }
 
+void AppMac::initialize( Settings *settings, const RendererRef &defaultRenderer, const char *title, int argc, char * const argv[] )
+{
+	AppBase::initialize( settings, defaultRenderer, title, argc, argv );
+
+	// Xcode automatically adds a pair of command line args, `NSDocumentRevisionsDebugMode YES` if "Allow debugging when using document Versions Browser" is not explicitly unchecked.
+	// We strip this known flag here
+	vector<string> replacedArgs;
+	const vector<string>& currentArgs = settings->getCommandLineArgs();
+	for( size_t i = 0; i < currentArgs.size(); ++i ) {
+		if( ( currentArgs[i] == "-NSDocumentRevisionsDebugMode" ) && ( i + 1 < currentArgs.size() ) )
+			i += 2; // skip this arg and the successor, which will be 'YES' or 'NO'
+		else
+			replacedArgs.push_back( currentArgs[i] );
+	}
+	settings->setCommandLineArgs( replacedArgs );
+}
+
 void AppMac::launch()
 {
 	[[NSApplication sharedApplication] run];


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/227107/15596000/bc337062-2391-11e6-9f8e-f0e3cd19df67.png)
By default Xcode has this option enabled, which introduces 2 additional command line arguments, `NSDocumentRevisionsDebugMode YES`

For cases requiring cross-platform argument parsing, this is obviously frustrating, especially since this is adjusted through the Xcode scheme rather than project settings. This PR takes the same approach that [wxWidgets takes](https://groups.google.com/forum/#!msg/wx-dev/FW6yHFFLA6Y/RLIaNADxkFIJ). Here's some [relevant discussion](https://bugs.chromium.org/p/skia/issues/detail?id=2976) on the Skia list as well.