### PR TITLE
enhance arcball implementation and add zooming support

### DIFF
--- a/include/cinder/Arcball.h
+++ b/include/cinder/Arcball.h
@@ -39,86 +39,87 @@ class Arcball {
 		setNoConstraintAxis();
 	}
 
-	Arcball( CameraPersp *camera, const Sphere &sphere )
-		: mCamera( camera ), mUseConstraint( false ), mSphere( sphere )
+	Arcball( CameraPersp *camera )
+		: mCamera(camera), mUseConstraint(false), mZoomSpeed(0.1f), mMinCamDistance2Center(0.1f)
 	{
 	}
-	
+	Arcball(CameraPersp *camera,vec3 center)
+		: mCamera(camera), mUseConstraint(false), mCenter(center), mZoomSpeed(0.1f), mMinCamDistance2Center(0.1f)
+	{
+	}
 	void mouseDown( const app::MouseEvent &event )
 	{
+		if (!mCamera) return;
 		mouseDown( event.getPos(), event.getWindow()->getSize() );
 	}
 	
 	void mouseDown( const vec2 &mousePos, const ivec2 &windowSize )
 	{
 		mInitialMousePos = mousePos;
-		mInitialQuat = mCurrentQuat;
-		float temp;
-		mouseOnSphere( mInitialMousePos, windowSize, &mFromVector, &temp );
+		mouseOnSphere( mInitialMousePos, windowSize, &mFromVector );
 	}
 
 	void mouseDrag( const app::MouseEvent &event )
 	{
-		mouseDrag( event.getPos(), event.getWindow()->getSize() );
+		if (!mCamera) return;
+		mouseDrag(event.getPos(), event.getWindow()->getSize());
 	}
 	
-	void mouseDrag( const vec2 &mousePos, const ivec2 &windowSize )
+	void mouseDrag(const ivec2 &mousePos, const ivec2 &windowSize)
 	{
-		float addition;
-		mouseOnSphere( mousePos, windowSize, &mToVector, &addition );
+		mouseOnSphere(mousePos, windowSize, &mToVector);
 		vec3 from = mFromVector, to = mToVector;
-		if( mUseConstraint ) {
-			from = constrainToAxis( from, mConstraintAxis );
-			to = constrainToAxis( to, mConstraintAxis );
+		if (mUseConstraint) {
+			from = constrainToAxis(from, mConstraintAxis);
+			to = constrainToAxis(to, mConstraintAxis);
 		}
-
-		quat rotation = glm::rotation( from, to );
-		vec3 axis = glm::axis( rotation );
-		float angle = glm::angle( rotation );
-		rotation = glm::angleAxis( angle + addition, axis );
-
-		mCurrentQuat = normalize( rotation * mInitialQuat );
+		//the axis to rotate around in view space
+		vec3 axis = cross(from, to);
+		float angle = acos(glm::min(dot(from, to), 1.0f));
+		vec3 eye = mCamera->getEyePoint();
+		mat3 view2World = mat3(glm::inverse(mCamera->getViewMatrix()));
+		//axis in world space
+		vec3 worldAxis = view2World*axis;
+		//rotate the eye around the point mCenter 
+		mat4 tarnslation = glm::translate(mCenter);
+		mat4 tarnslationinv = glm::translate(-mCenter);
+		quat rotation = glm::angleAxis(-angle, normalize(worldAxis));
+		mat4 finalmat = tarnslation*glm::toMat4(rotation)*tarnslationinv;
+		mCamera->setEyePoint(vec3(finalmat*vec4(eye, 1)));
+		mCamera->setViewDirection(rotation*mCamera->getViewDirection());
+		mCamera->setWorldUp(rotation*mCamera->getWorldUp());
+		mFromVector = mToVector;
 	}
-	
-	void			resetQuat()						{ mCurrentQuat = mInitialQuat = quat(); }
-	const quat& 	getQuat() const					{ return mCurrentQuat; }
-	void			setQuat( const quat &q )		{ mCurrentQuat = q; }
-	void			setSphere( const Sphere &s )	{ mSphere = s; }
-	const Sphere&	getSphere() const				{ return mSphere; }
-	
+	void mouseWheel(const app::MouseEvent &event)
+	{
+		if (!mCamera) return;
+		vec3 eye = mCamera->getEyePoint();
+		float factor = mZoomSpeed*event.getWheelIncrement();
+		vec3 newEye = eye + (mCenter - eye)*factor;
+		if (distance(newEye, mCenter) < mMinCamDistance2Center)
+			newEye = eye;
+		mCamera->setEyePoint(newEye);
+	}
+
+	void setCameraOnSphere(const Sphere &s)
+	{
+		if (!mCamera)return;
+		mCenter = s.getCenter();
+		vec3 view = mCamera->getViewDirection();
+		vec3 eye = mCenter - s.getRadius()*normalize(view);
+		mCamera->setEyePoint(eye);
+		mCamera->setPivotDistance(s.getRadius());
+
+	}
+
+	void		setZoomSpeed(float zoomSpeed)						{ mZoomSpeed = zoomSpeed; }
+	void		setMinDistance2Center(float minDistance)			{ mMinCamDistance2Center = minDistance; }
 	void		setConstraintAxis( const vec3 &constraintAxis )		{ mConstraintAxis = normalize( constraintAxis ); mUseConstraint = true; }
 	void		setNoConstraintAxis()								{ mUseConstraint = false; }
 	bool		isUsingConstraint() const							{ return mUseConstraint; }
 	const vec3&	getConstraintAxis() const							{ return mConstraintAxis; }
-	
-	void mouseOnSphere( const vec2 &point, const ivec2 &windowSize, vec3 *resultVector, float *resultAngleAddition )
-	{
-		float rayT;
-		Ray ray = mCamera->generateRay( point, windowSize );
-		if( mSphere.intersect( ray, &rayT ) > 0 ) { // is click inside the sphere?
-			// trace a ray through the pixel to the sphere
-			*resultVector = normalize( ray.calcPosition( rayT ) - mSphere.getCenter() );
-			*resultAngleAddition = 0;
-		}
-		else { // not inside the sphere
-			// first project the sphere according to the camera, resulting in an ellipse (possible a circle)
-			Sphere cameraSpaceSphere( vec3( mCamera->getViewMatrix() * vec4( mSphere.getCenter(), 1 ) ), mSphere.getRadius() );
-			vec2 center, axisA, axisB;
-			cameraSpaceSphere.calcProjection( mCamera->getFocalLength(), windowSize, &center, &axisA, &axisB );
-			// find the point closest on the screen-projected ellipse to the mouse
-			vec2 screenSpaceClosest = getClosestPointEllipse( center, axisA, axisB, point );
-			// and send a ray through that point, finding the closest point on the sphere to it
-			Ray newRay = mCamera->generateRay( screenSpaceClosest, windowSize );
-			vec3 closestPointOnSphere = mSphere.closestPoint( newRay );
-			// our result point is the vector between this closest point on the sphere and its center
-			*resultVector = normalize( closestPointOnSphere - mSphere.getCenter() );
-			
-			// our angle addition is the screen-space distance between the mouse and the closest point on the sphere, divided into
-			// the screen-space radius of the sphere's projected ellipse, multiplied by pi
-			float screenRadius = std::max( length( axisA ), length( axisB ) );
-			*resultAngleAddition = distance( vec2(point), screenSpaceClosest ) / screenRadius * (float)M_PI;
-		}
-	}
+	float		getZoomSpeed() const								{ return mZoomSpeed; }
+	float		getMinDistance2Center() const						{ return mMinCamDistance2Center; }
 
 	vec3 getFromVector() const
 	{
@@ -131,6 +132,21 @@ class Arcball {
 	}
 
  private:
+	 void mouseOnSphere(const ivec2 &point, const ivec2 &windowSize, vec3 *resultVector)
+	 {
+
+		 glm::vec3 p = glm::vec3(1.0*point.x / windowSize.x * 2 - 1.0,
+			 1.0*point.y / windowSize.y * 2 - 1.0, 0);
+		 p.y = -p.y;
+		 float opSquared = p.x*p.x + p.y*p.y;
+		 if (opSquared < 1)
+		 {
+			 p.z = sqrt(1 - opSquared);
+		 }
+		 else
+			 p = normalize(p);
+		 *resultVector = p;
+	 }
 	// Force sphere point to be perpendicular to axis
 	vec3 constrainToAxis( const vec3 &loose, const vec3 &axis )
 	{
@@ -153,9 +169,10 @@ class Arcball {
 
 	CameraPersp	*mCamera;
 	vec2		mInitialMousePos;
-	quat		mCurrentQuat, mInitialQuat;
-	Sphere		mSphere;
 	vec3		mFromVector, mToVector, mConstraintAxis;
+	vec3		mCenter;
+	float		mZoomSpeed;
+	float		mMinCamDistance2Center;
 	bool		mUseConstraint;
 };
 

--- a/samples/ArcballDemo/src/ArcballDemoApp.cpp
+++ b/samples/ArcballDemo/src/ArcballDemoApp.cpp
@@ -14,7 +14,8 @@ class ArcballDemoApp : public App {
 	void setup() override;
 	void resize() override;
 	void mouseDown( MouseEvent event ) override;
-	void mouseDrag( MouseEvent event ) override;
+	void mouseDrag(MouseEvent event) override;
+	void mouseWheel(MouseEvent event) override;
 	void draw() override;
 	
 	Arcball			mArcball;
@@ -37,7 +38,7 @@ void ArcballDemoApp::setup()
 	mEarth = gl::Batch::create( geom::Sphere( mEarthSphere ).subdivisions( 50 ), gl::getStockShader( gl::ShaderDef().texture() ) );
 	mEarthTex = gl::Texture::create( loadImage( loadResource( EARTH_TEX_RES ) ) );
 
-	mArcball = Arcball( &mCamera, mEarthSphere );
+	mArcball = Arcball( &mCamera,vec3(0) );
 }
 
 void ArcballDemoApp::resize()
@@ -50,6 +51,11 @@ void ArcballDemoApp::mouseDown( MouseEvent event )
 	mArcball.mouseDown( event );
 }
 
+void ArcballDemoApp::mouseWheel(MouseEvent event)
+{
+	mArcball.mouseWheel(event);
+}
+
 void ArcballDemoApp::mouseDrag( MouseEvent event )
 {
 	mArcball.mouseDrag( event );
@@ -60,7 +66,6 @@ void ArcballDemoApp::draw()
 	gl::clear( Color( 0, 0.0f, 0.15f ) );
 	gl::setMatrices( mCamera );
 
-	gl::rotate( mArcball.getQuat() );
 	mEarthTex->bind();
 	mEarth->draw();
 }

--- a/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
+++ b/samples/_opengl/ObjLoader/src/ObjLoaderApp.cpp
@@ -20,7 +20,8 @@ class ObjLoaderApp : public App {
 	void	setup() override;
 
 	void	mouseDown( MouseEvent event ) override;
-	void	mouseDrag( MouseEvent event ) override;
+	void	mouseDrag(MouseEvent event) override;
+	void	mouseWheel(MouseEvent event) override;
 	void	keyDown( KeyEvent event ) override;
 
 	void	loadObj( const DataSourceRef &dataSource );
@@ -53,9 +54,10 @@ void ObjLoaderApp::setup()
 	mCheckerTexture = gl::Texture::create( ip::checkerboard( 512, 512, 32 ) );
 	mCheckerTexture->bind( 0 );
 
-	loadObj( loadResource( RES_8LBS_OBJ ) );
+	mArcball = Arcball(&mCam);
 
-	mArcball = Arcball( &mCam, mBoundingSphere );
+	loadObj(loadResource(RES_8LBS_OBJ));
+
 }
 
 void ObjLoaderApp::mouseDown( MouseEvent event )
@@ -64,6 +66,11 @@ void ObjLoaderApp::mouseDown( MouseEvent event )
 		mCamUi.mouseDown( event );
 	else
 		mArcball.mouseDown( event );
+}
+
+void ObjLoaderApp::mouseWheel(MouseEvent event)
+{
+	mArcball.mouseWheel(event);
 }
 
 void ObjLoaderApp::mouseDrag( MouseEvent event )
@@ -85,7 +92,8 @@ void ObjLoaderApp::loadObj( const DataSourceRef &dataSource )
 	mBatch = gl::Batch::create( *mMesh, mGlsl );
 	
 	mBoundingSphere = Sphere::calculateBoundingSphere( mMesh->getPositions<3>(), mMesh->getNumVertices() );
-	mArcball.setSphere( mBoundingSphere );
+	mBoundingSphere.setRadius(mBoundingSphere.getRadius()*2);
+	mArcball.setCameraOnSphere( mBoundingSphere );
 }
 
 void ObjLoaderApp::writeObj()
@@ -127,10 +135,7 @@ void ObjLoaderApp::draw()
 
 	gl::setMatrices( mCam );
 
-	gl::pushMatrices();
-		gl::rotate( mArcball.getQuat() );
-		mBatch->draw();
-	gl::popMatrices();
+	mBatch->draw();
 }
 
 


### PR DESCRIPTION
Current Implementation of Arcball has the following issues:
- Start dragging from outside the arcball's sphere leads to wired behavior.
- The arcball has a reference to its target camera, but it does not control it directly and we have to call `gl::rotate( mArcball.getQuat() );` for all meshes.
- Current arcball implementation does not support zooming which is important feature for arcball.

I re-implemented some parts of the arcball according to this article : [Arcball](https://en.wikibooks.org/wiki/OpenGL_Programming/Modern_OpenGL_Tutorial_Arcball) and added a zoom support.
