### PR TITLE
Add TARGET_LIBRARIES param to ci_make_app

### DIFF
--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -58,7 +58,7 @@ function( ci_make_app )
 
 	add_executable( ${ARG_APP_NAME} MACOSX_BUNDLE WIN32 ${ARG_SOURCES} ${ICON_PATH} ${ARG_RESOURCES} )
 	target_include_directories( ${ARG_APP_NAME} PUBLIC ${ARG_INCLUDES} )
-  target_link_libraries( ${ARG_APP_NAME} cinder ${ARG_LIBRARIES} )
+	target_link_libraries( ${ARG_APP_NAME} cinder ${ARG_LIBRARIES} )
 
 	if( CINDER_MAC )
 		# set bundle info.plist properties

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -2,7 +2,7 @@ include( CMakeParseArguments )
 
 function( ci_make_app )
 	set( oneValueArgs APP_NAME CINDER_PATH )
-	set( multiValueArgs SOURCES INCLUDES RESOURCES )
+  set( multiValueArgs SOURCES INCLUDES RESOURCES TARGET_LIBRARIES)
 
 	cmake_parse_arguments( ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -58,7 +58,7 @@ function( ci_make_app )
 
 	add_executable( ${ARG_APP_NAME} MACOSX_BUNDLE WIN32 ${ARG_SOURCES} ${ICON_PATH} ${ARG_RESOURCES} )
 	target_include_directories( ${ARG_APP_NAME} PUBLIC ${ARG_INCLUDES} )
-	target_link_libraries( ${ARG_APP_NAME} cinder )
+  target_link_libraries( ${ARG_APP_NAME} cinder ${ARG_TARGET_LIBRARIES} )
 
 	if( CINDER_MAC )
 		# set bundle info.plist properties

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -2,7 +2,7 @@ include( CMakeParseArguments )
 
 function( ci_make_app )
 	set( oneValueArgs APP_NAME CINDER_PATH )
-  set( multiValueArgs SOURCES INCLUDES RESOURCES TARGET_LIBRARIES)
+  set( multiValueArgs SOURCES INCLUDES RESOURCES LIBRARIES)
 
 	cmake_parse_arguments( ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -58,7 +58,7 @@ function( ci_make_app )
 
 	add_executable( ${ARG_APP_NAME} MACOSX_BUNDLE WIN32 ${ARG_SOURCES} ${ICON_PATH} ${ARG_RESOURCES} )
 	target_include_directories( ${ARG_APP_NAME} PUBLIC ${ARG_INCLUDES} )
-  target_link_libraries( ${ARG_APP_NAME} cinder ${ARG_TARGET_LIBRARIES} )
+  target_link_libraries( ${ARG_APP_NAME} cinder ${ARG_LIBRARIES} )
 
 	if( CINDER_MAC )
 		# set bundle info.plist properties


### PR DESCRIPTION
e.g. PCL (PointCloudLibrary) needs to call `target_link_libraries`

http://www.pointclouds.org/documentation/tutorials/using_pcl_pcl_config.php

```cmake
ci_make_app(
  SOURCES           ${PROJECT_SOURCES}
  INCLUDES          ${PCL_INCLUDE_DIRS}
  CINDER_PATH       ${CINDER_PATH}
  TARGET_LIBRARIES  ${Boost_LIBRARIES} ${PCL_LIBRARIES}
)
```