### PR TITLE
Fix an invalid path in gensamplebuilds.

### DIFF
--- a/tools/linux/scripts/gensamplebuilds
+++ b/tools/linux/scripts/gensamplebuilds
@@ -8,7 +8,7 @@ import stat
 print( "Samples Linux Build File Generate v0.001\n" )
 
 Build = """#!/bin/sh
-$<CINDER_REL_PATH>/tools/linux/cbuilder -app "$@"
+$<CINDER_REL_PATH>/tools/linux/cibuilder -app "$@"
 """
 
 CMakeListsTxt= """# $<APPNAME>


### PR DESCRIPTION
Change "cbuilder" to "cibuilder". 
This makes it possible to generate valid build files to build samples on linux.