### PR TITLE
Adds scoped texture binding to gl::drawEquirectangular

### DIFF
--- a/src/cinder/gl/draw.cpp
+++ b/src/cinder/gl/draw.cpp
@@ -690,6 +690,9 @@ void drawEquirectangular( const gl::TextureCubeMapRef &texture, const Rectf &rec
 	glsl->uniform( "uCubeMapTex", 0 );
 	if( useLod )
 		glsl->uniform( "uLod", lod );
+
+	 gl::ScopedTextureBind scTex( texture );
+
 	drawSolidRect( rect, vec2( 0, 1 ), vec2( 1, 0 ) );
 }
 


### PR DESCRIPTION
Fixes #1279 

Thought I'd grab an easy one to cross off the list. I'm not sure if having only scoped texture bind is appropriate here, or if the function needs to save the existing context state first, and then restore it after drawing.