### PR TITLE
Unset cached cinder config path if previously set.

### DIFF
--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -35,6 +35,10 @@ function( ci_make_app )
 		message( STATUS "CINDER_LIB_DIRECTORY: ${CINDER_LIB_DIRECTORY}" )
 	endif()
 
+	if( cinder_DIR )
+		unset( cinder_DIR CACHE )
+	endif()
+
 	# pull in cinder's exported configuration
 	if( NOT TARGET cinder )
 		find_package( cinder REQUIRED PATHS

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -34,7 +34,10 @@ function( ci_make_app )
 		message( STATUS "CINDER_TARGET: ${CINDER_TARGET}" )
 		message( STATUS "CINDER_LIB_DIRECTORY: ${CINDER_LIB_DIRECTORY}" )
 	endif()
-
+    
+    # This ensures that the application will link with the correct version of Cinder
+    # based on the current build type without the need to remove the entire build folder
+    # when switching build type after an initial configuration. See PR #1518 for more info. 
 	if( cinder_DIR )
 		unset( cinder_DIR CACHE )
 	endif()


### PR DESCRIPTION
Without this there is a mismatch between build type configuration and actual linking after a second configuration run.

i.e
During configuration and a call to `find_package`, if the package is found CMake, will create a cached variable `packagename_DIR` to hold the directory for finding the config file for the specific package. This means that if you then switch build type from debug to release, since this path is cached, CMake will still link with the debug version of Cinder and not the release one.

This PR unsets this var if previously set to ensure appropriate linking according to the build type.

You can check what is currently happening by building both Release and Debug versions of Cinder and then building a sample with :

`cmake .. && make VERBOSE=1`

and then

`cmake .. -DCMAKE_BUILD_TYPE && make VERBOSE=1`

You will notice in the log output that in the second run the application binary is still linking with the debug version of Cinder instead of the release one.
