### PR TITLE
Added qtime files for CMake in OSX

### DIFF
--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -28,6 +28,15 @@ list( APPEND SRC_SET_AUDIO_COCOA
 	${CINDER_SRC_DIR}/cinder/audio/cocoa/FileCoreAudio.cpp
 )
 
+list( APPEND SRC_SET_QTIME
+	${CINDER_SRC_DIR}/cinder/qtime/AvfUtils.mm
+	${CINDER_SRC_DIR}/cinder/qtime/AvfWriter.mm
+	${CINDER_SRC_DIR}/cinder/qtime/MovieWriter.cpp
+	${CINDER_SRC_DIR}/cinder/qtime/QuickTimeGlImplAvf.cpp
+	${CINDER_SRC_DIR}/cinder/qtime/QuickTimeImplAvf.mm
+	${CINDER_SRC_DIR}/cinder/qtime/QuickTimeUtils.cpp
+)
+
 # specify what files need to be compiled as Objective-C++
 list( APPEND CINDER_SOURCES_OBJCPP
 	${CINDER_SRC_DIR}/cinder/Capture.cpp
@@ -44,6 +53,7 @@ list( APPEND CINDER_SOURCES_OBJCPP
 	${CINDER_SRC_DIR}/cinder/app/cocoa/AppMac.cpp
 	${CINDER_SRC_DIR}/cinder/app/cocoa/PlatformCocoa.cpp
 	${CINDER_SRC_DIR}/cinder/gl/Environment.cpp
+	${CINDER_SRC_DIR}/cinder/qtime/QuickTimeGlImplAvf.cpp
 
 	${CINDER_SRC_DIR}/AntTweakBar/TwColors.cpp
 	${CINDER_SRC_DIR}/AntTweakBar/TwFonts.cpp
@@ -64,6 +74,7 @@ list( APPEND CINDER_SRC_FILES
 	${SRC_SET_COCOA}
 	${SRC_SET_APP_COCOA}
 	${SRC_SET_AUDIO_COCOA}
+	${SRC_SET_QTIME}
 )
 
 list( APPEND CINDER_LIBS_DEPENDS


### PR DESCRIPTION
The qtime files are missing from the CMake build. Without this the QuickTimeBasic sample fails to link on OSX with CMake:

```
[100%] Linking CXX executable Debug/QuickTimeBasic.app/Contents/MacOS/QuickTimeBasic
Undefined symbols for architecture x86_64:
  "cinder::qtime::MovieGl::getTexture()", referenced from:
      QuickTimeSampleApp::update() in QuickTimeBasicApp.cpp.o
  "cinder::qtime::MovieGl::MovieGl(boost::filesystem::path const&)", referenced from:
      cinder::qtime::MovieGl::create(boost::filesystem::path const&) in QuickTimeBasicApp.cpp.o
  "cinder::qtime::MovieBase::play(bool)", referenced from:
      QuickTimeSampleApp::loadMovieFile(boost::filesystem::path const&) in QuickTimeBasicApp.cpp.o
  "cinder::qtime::MovieBase::isDone() const", referenced from:
      QuickTimeSampleApp::update() in QuickTimeBasicApp.cpp.o
  "cinder::qtime::MovieBase::isPlaying() const", referenced from:
      QuickTimeSampleApp::loadMovieFile(boost::filesystem::path const&) in QuickTimeBasicApp.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [Debug/QuickTimeBasic.app/Contents/MacOS/QuickTimeBasic] Error 1
make[1]: *** [CMakeFiles/QuickTimeBasic.dir/all] Error 2
make: *** [all] Error 2
```

