### PR TITLE
Added "label" to Params...

### DIFF
--- a/include/cinder/params/Params.h
+++ b/include/cinder/params/Params.h
@@ -78,12 +78,13 @@ class InterfaceGl {
 		void setKeyIncr( const std::string &keyIncr );
 		void setKeyDecr( const std::string &keyDecr );
 		void setKey( const std::string &key );
+		void setLabel( const std::string & label );
 		void setGroup( const std::string &group );
 		void setOptionsStr( const std::string &optionsStr );
 
 		void reAddOptions();
 
-		std::string mName, mKeyIncr, mKeyDecr, mKey, mGroup, mOptionsStr;
+		std::string mName, mKeyIncr, mKeyDecr, mKey, mLabel, mGroup, mOptionsStr;
 		void*		mVoidPtr;
 		float		mMin, mMax, mStep;
 		int			mPrecision;
@@ -118,6 +119,8 @@ class InterfaceGl {
 		Options&	keyDecr( const std::string &keyDecr )		{ setKeyDecr( keyDecr ); return *this; }
 		//! Sets a shortcut key for param types that cannot be incremented / decremented (ex. bool)
 		Options&	key( const std::string &key )				{ setKey( key ); return *this; }
+		//! Sets the param label
+		Options&	label( const std::string &label )			{ setLabel( label ); return *this; }
 		//! Sets the param group
 		Options&	group( const std::string &group )			{ setGroup( group ); return *this; }
 		//! Sets other implementation defined options via string.

--- a/include/cinder/params/Params.h
+++ b/include/cinder/params/Params.h
@@ -119,7 +119,7 @@ class InterfaceGl {
 		Options&	keyDecr( const std::string &keyDecr )		{ setKeyDecr( keyDecr ); return *this; }
 		//! Sets a shortcut key for param types that cannot be incremented / decremented (ex. bool)
 		Options&	key( const std::string &key )				{ setKey( key ); return *this; }
-		//! Sets the param label
+		//! Sets the param label. A parameter name must be unique, but you can override it with a 'label', which does not have to be unique.
 		Options&	label( const std::string &label )			{ setLabel( label ); return *this; }
 		//! Sets the param group
 		Options&	group( const std::string &group )			{ setGroup( group ); return *this; }

--- a/samples/ParamsBasic/src/ParamsBasicApp.cpp
+++ b/samples/ParamsBasic/src/ParamsBasicApp.cpp
@@ -34,6 +34,7 @@ class TweakBarApp : public App {
 	vec3					getLightDirection() { return mLightDirection; }
 	vec3					mLightDirection;
 	uint32_t				mSomeValue;
+	float					mA, mB, mC, mD;
 
 	vector<string>			mEnumNames;
 	int						mEnumSelection;
@@ -51,13 +52,14 @@ void TweakBarApp::setup()
 	mLightDirection = vec3( 0, 0, -1 );
 	mColor = ColorA( 0.25f, 0.5f, 1, 1 );
 	mSomeValue = 2;
+	mA = mB = mC = mD = 0;
 	mPrintFps = false;
 
 	// Setup our default camera, looking down the z-axis.
 	mCam.lookAt( vec3( -20, 0, 0 ), vec3( 0 ) );
 
 	// Create the interface and give it a name.
-	mParams = params::InterfaceGl::create( getWindow(), "App parameters", toPixels( ivec2( 200, 300 ) ) );
+	mParams = params::InterfaceGl::create( getWindow(), "App parameters", toPixels( ivec2( 200, 400 ) ) );
 
 	// Setup some basic parameters.
 	mParams->addParam( "Cube Size", &mObjSize ).min( 0.1f ).max( 20.5f ).keyIncr( "z" ).keyDecr( "Z" ).precision( 2 ).step( 0.02f );
@@ -79,6 +81,14 @@ void TweakBarApp::setup()
 	// Other types of controls that can be added to the interface.
 	mParams->addButton( "Button!", bind( &TweakBarApp::button, this ) );
 	mParams->addText( "text", "label=`This is a label without a parameter.`" );
+
+	mParams->addSeparator();
+
+	// A parameter name must be unique, but you can override it with a 'label', which does not have to be unique.
+	mParams->addParam( "float1", &mA ).group( "Group 1" ).label( "Item X" );
+	mParams->addParam( "float2", &mB ).group( "Group 1" ).label( "Item Y" );
+	mParams->addParam( "float3", &mC ).group( "Group 2" ).label( "Item X" );
+	mParams->addParam( "float4", &mD ).group( "Group 2" ).label( "Item Y" );
 
 	mParams->addSeparator();
 

--- a/src/cinder/params/Params.cpp
+++ b/src/cinder/params/Params.cpp
@@ -536,6 +536,15 @@ void InterfaceGl::OptionsBase::setKey( const std::string &key )
 	mKey = key;
 }
 
+void InterfaceGl::OptionsBase::setLabel( const std::string &label )
+{
+	assert( mParent );
+
+	string optionsStr = "label=`" + label + "`";
+	mParent->setOptions( getName(), optionsStr );
+	mLabel = label;
+}
+
 void InterfaceGl::OptionsBase::setGroup( const std::string &group )
 {
 	assert( mParent );
@@ -574,6 +583,8 @@ void InterfaceGl::OptionsBase::reAddOptions()
 		setKeyIncr( mKeyIncr );
 	if( ! mKeyDecr.empty() )
 		setKeyDecr( mKeyDecr );
+	if( !mLabel.empty() )
+		setLabel( mLabel );
 	if( ! mGroup.empty() )
 		setGroup( mGroup );
 	if( ! mOptionsStr.empty() )


### PR DESCRIPTION
...allowing you to specify an alternative name for your parameter. Normally, each parameter should have a unique name and this shows up in the Params window as well. Using a label, you can override this default name with a more appropriate name.