### PR TITLE
Add CXX_FLAGS using target_compile_options(), only to cpp sources

### DIFF
--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -34,15 +34,14 @@ CHECK_CXX_COMPILER_FLAG( "-std=c++14" COMPILER_SUPPORTS_CXX14 )
 CHECK_CXX_COMPILER_FLAG( "-std=c++11" COMPILER_SUPPORTS_CXX11 )
 
 if( COMPILER_SUPPORTS_CXX14 )
-	set( CINDER_COMPILER_FLAGS "-std=c++14" )
+	set( CINDER_CXX_FLAGS "-std=c++14" )
 elseif( COMPILER_SUPPORTS_CXX11 )
-	set( CINDER_COMPILER_FLAGS "-std=c++11" )
+	set( CINDER_CXX_FLAGS "-std=c++11" )
 else()
 	message( FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has neither C++11 or C++14 support. Please use a different C++ compiler." )
 endif()
 
-set( CMAKE_CXX_FLAGS ${CINDER_COMPILER_FLAGS} ${CMAKE_CXX_FLAGS} )
-target_compile_options( cinder INTERFACE ${CINDER_COMPILER_FLAGS} )
+target_compile_options( cinder PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${CINDER_CXX_FLAGS}> )
 
 # This file will contain all dependencies, includes, definition, compiler flags and so on..
 export( TARGETS cinder FILE ${PROJECT_BINARY_DIR}/${CINDER_LIB_DIRECTORY}/cinderTargets.cmake )


### PR DESCRIPTION
This change uses [cmake generator expressions](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html) so that we can set the `-std=C++11/14` flag as PUBLIC on cinder target, without adversely affecting non-cpp files that get linked in.

This way anything that depends on cinder will automatically be compiled with the same cpp langage.