### PR TITLE
Fix source path for OSC and TUIO blocks.

### DIFF
--- a/blocks/OSC/proj/cmake/OSCConfig.cmake
+++ b/blocks/OSC/proj/cmake/OSCConfig.cmake
@@ -2,7 +2,7 @@ if( NOT TARGET OSC )
 	get_filename_component( OSC_SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../src" ABSOLUTE )
 	get_filename_component( CINDER_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../.." ABSOLUTE )
 
-	add_library( OSC ${OSC_SOURCE_PATH}/cinder/osc/OSC.cpp )
+	add_library( OSC ${OSC_SOURCE_PATH}/cinder/osc/Osc.cpp )
 
 	target_compile_options( OSC PUBLIC "-std=c++11" )
 

--- a/blocks/TUIO/proj/cmake/TUIOConfig.cmake
+++ b/blocks/TUIO/proj/cmake/TUIOConfig.cmake
@@ -1,7 +1,7 @@
 if( NOT TARGET TUIO )
 	get_filename_component( TUIO_SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../src" ABSOLUTE )
 
-	add_library( TUIO ${TUIO_SOURCE_PATH}/cinder/tuio/TUIO.cpp )
+	add_library( TUIO ${TUIO_SOURCE_PATH}/cinder/tuio/Tuio.cpp )
 
 	target_compile_options( TUIO PUBLIC "-std=c++11" )
 	target_include_directories( TUIO PUBLIC "${TUIO_SOURCE_PATH}" )


### PR DESCRIPTION
These ones got missed with the recent changes.