### PR TITLE
Fix default RPi build.

### DIFF
--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -213,18 +213,6 @@ list( APPEND CINDER_SRC_FILES               ${SRC_SET_TINYEXR} )
 source_group( "thirdparty\\tinyexr" FILES   ${SRC_SET_TINYEXR} )
 
 # ----------------------------------------------------------------------------------------------------------------------
-# glload
-# ----------------------------------------------------------------------------------------------------------------------
-
-list( APPEND SRC_SET_GLLOAD
-	${CINDER_SRC_DIR}/glload/gl_load_cpp.cpp
-	${CINDER_SRC_DIR}/glload/gl_load.c
-)
-
-list( APPEND CINDER_SRC_FILES               ${SRC_SET_GLLOAD} )
-source_group( "thirdparty\\glload" FILES    ${SRC_SET_GLLOAD} )
-
-# ----------------------------------------------------------------------------------------------------------------------
 # jsoncpp
 # ----------------------------------------------------------------------------------------------------------------------
 

--- a/proj/cmake/platform_linux.cmake
+++ b/proj/cmake/platform_linux.cmake
@@ -58,6 +58,8 @@ if( NOT CINDER_GL_ES_2_RPI )
 			${CINDER_SRC_DIR}/glfw/src/glx_context.c
 		)
 		list( APPEND SRC_SET_CINDER_LINUX
+			${CINDER_SRC_DIR}/glload/gl_load_cpp.cpp
+			${CINDER_SRC_DIR}/glload/gl_load.c
 			${CINDER_SRC_DIR}/glload/glx_load.c
 			${CINDER_SRC_DIR}/glload/glx_load_cpp.cpp
 		)

--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -70,11 +70,17 @@ set_source_files_properties( ${CINDER_SOURCES_OBJCPP}
 	PROPERTIES COMPILE_FLAGS "-x objective-c++"
 )
 
+list( APPEND SRC_SET_GLLOAD
+	${CINDER_SRC_DIR}/glload/gl_load_cpp.cpp
+	${CINDER_SRC_DIR}/glload/gl_load.c
+)
+
 list( APPEND CINDER_SRC_FILES
 	${SRC_SET_COCOA}
 	${SRC_SET_APP_COCOA}
 	${SRC_SET_AUDIO_COCOA}
 	${SRC_SET_QTIME}
+	${SRC_SET_GLLOAD}
 )
 
 list( APPEND CINDER_LIBS_DEPENDS


### PR DESCRIPTION
Relevant forum thread [here](http://discourse.libcinder.org/t/errors-building-cinder-on-raspberry-pi-3/193/4).

GL sources should not be included by default when building on the RPi.