### PR TITLE
cmake: enable building and running catch-style unit test suite. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set( CMAKE_VERBOSE_MAKEFILE ON )
 project( cinder )
 
 option( CINDER_BUILD_SAMPLES "Build all samples." OFF )
+option( CINDER_BUILD_TESTS "Build all unit tests." OFF )
 set( CINDER_BUILD_SAMPLE "" CACHE STRING "Build a specific sample by specifying its path relative to the samples directory (ex. '_opengl/Cube')." )
 
 set( CINDER_PATH      "${CMAKE_CURRENT_SOURCE_DIR}" )
@@ -46,4 +47,10 @@ elseif( CINDER_BUILD_SAMPLE )
 		message( STATUS "adding sample: ${CINDER_BUILD_SAMPLE}" )
 	endif()
 	add_subdirectory( ${CINDER_PATH}/samples/${CINDER_BUILD_SAMPLE}/proj/cmake )
+endif()
+
+if( CINDER_BUILD_TESTS )
+	enable_testing()
+	add_subdirectory(${CINDER_PATH}/test/unit/proj/cmake )
+	add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose)
 endif()

--- a/test/unit/proj/cmake/CMakeLists.txt
+++ b/test/unit/proj/cmake/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE ON )
+
+project( TestMain )
+
+get_filename_component( CINDER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE )
+get_filename_component( UNIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
+
+include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
+
+SET(SOURCES
+	${UNIT_DIR}/src/Base64Test.cpp
+	${UNIT_DIR}/src/JsonTest.cpp
+	${UNIT_DIR}/src/ObjLoaderTest.cpp
+	${UNIT_DIR}/src/RandTest.cpp
+	${UNIT_DIR}/src/SystemTest.cpp
+	${UNIT_DIR}/src/TestMain.cpp
+	${UNIT_DIR}/src/UnicodeTest.cpp
+	${UNIT_DIR}/src/audio/BufferUnit.cpp
+	${UNIT_DIR}/src/audio/FftUnit.cpp
+	${UNIT_DIR}/src/audio/RingBufferUnit.cpp
+	${UNIT_DIR}/src/signals/SignalsTest.cpp
+)
+
+ci_make_app(
+	SOURCES     ${SOURCES}
+	CINDER_PATH ${CINDER_PATH}
+	INCLUDES "${UNIT_DIR}/src"    # for catch.hpp
+)
+TARGET_COMPILE_DEFINITIONS(
+	TestMain
+	PRIVATE -DUNIT_DIR_ASSETS="${UNIT_DIR}/assets"
+)
+
+IF (APPLE)
+	SET(TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/TestMain.app/Contents/MacOS)
+ELSE()
+	SET(TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+ENDIF()
+
+ADD_TEST(
+	NAME TestMain
+	COMMAND ${TESTBINDIR}/TestMain
+)

--- a/test/unit/src/JsonTest.cpp
+++ b/test/unit/src/JsonTest.cpp
@@ -1,4 +1,5 @@
 #include "cinder/app/App.h"
+#include "cinder/app/Platform.h"
 #include "cinder/Json.h"
 
 #include "jsoncpp/json.h"
@@ -10,6 +11,8 @@ using namespace std;
 
 TEST_CASE("Json", "[noisy]")
 {
+	app::Platform::get()->addAssetDirectory(UNIT_DIR_ASSETS);
+
 	SECTION("Basic JSON Parsing")
 	{
 		console() << "jsoncpp version: " << JSONCPP_VERSION_STRING << endl;

--- a/test/unit/src/UnicodeTest.cpp
+++ b/test/unit/src/UnicodeTest.cpp
@@ -25,6 +25,8 @@ TYPE loadStringFromFile( const DataSourceRef &dataSource )
 
 TEST_CASE("Unicode")
 {
+	app::Platform::get()->addAssetDirectory(UNIT_DIR_ASSETS);
+
 	SECTION("Unicode strings are convertible between 8, 16, and 32 bit representations.")
 	{
 		// these files should be identical except for their encoding


### PR DESCRIPTION
After doing 'make', to run the tests, do 'make test' (shows little output) or 'ctest -v' (shows more output) or
Debug/TestMain (bare metal, lets you use catch.hpp options).