### PR TITLE
adding cstring to RingBuffer.h for std::memcpy

### DIFF
--- a/include/cinder/audio/dsp/RingBuffer.h
+++ b/include/cinder/audio/dsp/RingBuffer.h
@@ -26,6 +26,7 @@
 #include "cinder/CinderAssert.h"
 
 #include <atomic>
+#include <cstring>
 
 namespace cinder { namespace audio { namespace dsp {
 


### PR DESCRIPTION
One of the issues in ##1551
cstring is needed to expose std::memcpy in RingBuffer.  OS X and Window must automatically include `<cstring>` in their build process.