### PR TITLE
Unit test cmake whitespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,6 @@ endif()
 
 if( CINDER_BUILD_TESTS )
 	enable_testing()
-	add_subdirectory(${CINDER_PATH}/test/unit/proj/cmake )
-	add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose)
+	add_subdirectory( ${CINDER_PATH}/test/unit/proj/cmake )
+	add_custom_target( check COMMAND ${CMAKE_CTEST_COMMAND} --verbose )
 endif()

--- a/test/unit/proj/cmake/CMakeLists.txt
+++ b/test/unit/proj/cmake/CMakeLists.txt
@@ -8,7 +8,7 @@ get_filename_component( UNIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
-SET(SOURCES
+set( SOURCES
 	${UNIT_DIR}/src/Base64Test.cpp
 	${UNIT_DIR}/src/JsonTest.cpp
 	${UNIT_DIR}/src/ObjLoaderTest.cpp
@@ -25,20 +25,21 @@ SET(SOURCES
 ci_make_app(
 	SOURCES     ${SOURCES}
 	CINDER_PATH ${CINDER_PATH}
-	INCLUDES "${UNIT_DIR}/src"    # for catch.hpp
+	INCLUDES    "${UNIT_DIR}/src"    # for catch.hpp
 )
-TARGET_COMPILE_DEFINITIONS(
+
+target_compile_definitions(
 	TestMain
 	PRIVATE -DUNIT_DIR_ASSETS="${UNIT_DIR}/assets"
 )
 
-IF (APPLE)
-	SET(TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/TestMain.app/Contents/MacOS)
-ELSE()
-	SET(TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
-ENDIF()
+if( APPLE )
+	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/TestMain.app/Contents/MacOS )
+else()
+	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE} )
+endif()
 
-ADD_TEST(
+add_test(
 	NAME TestMain
 	COMMAND ${TESTBINDIR}/TestMain
 )

--- a/test/unit/proj/cmake/CMakeLists.txt
+++ b/test/unit/proj/cmake/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
-project( TestMain )
+project( UnitTests )
 
 get_filename_component( CINDER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE )
 get_filename_component( UNIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
@@ -29,7 +29,7 @@ ci_make_app(
 )
 
 target_compile_definitions(
-	TestMain
+	UnitTests
 	PRIVATE -DUNIT_DIR_ASSETS="${UNIT_DIR}/assets"
 )
 

--- a/test/unit/src/JsonTest.cpp
+++ b/test/unit/src/JsonTest.cpp
@@ -11,7 +11,7 @@ using namespace std;
 
 TEST_CASE("Json", "[noisy]")
 {
-	app::Platform::get()->addAssetDirectory(UNIT_DIR_ASSETS);
+	app::Platform::get()->addAssetDirectory( UNIT_DIR_ASSETS );
 
 	SECTION("Basic JSON Parsing")
 	{

--- a/test/unit/src/UnicodeTest.cpp
+++ b/test/unit/src/UnicodeTest.cpp
@@ -25,7 +25,7 @@ TYPE loadStringFromFile( const DataSourceRef &dataSource )
 
 TEST_CASE("Unicode")
 {
-	app::Platform::get()->addAssetDirectory(UNIT_DIR_ASSETS);
+	app::Platform::get()->addAssetDirectory( UNIT_DIR_ASSETS );
 
 	SECTION("Unicode strings are convertible between 8, 16, and 32 bit representations.")
 	{


### PR DESCRIPTION
Pretty minor, updates the recent additions from #1550 to match existing cmake code and in general the [style guide](https://github.com/cinder/Cinder/blob/master/CONTRIBUTING.md#style-guide).

Also updated the unit test cmake project name to match Xcode and Visual Studio.