### PR TITLE
Finish unit test exe rename from 82649fe75 

### DIFF
--- a/test/unit/proj/cmake/CMakeLists.txt
+++ b/test/unit/proj/cmake/CMakeLists.txt
@@ -34,12 +34,12 @@ target_compile_definitions(
 )
 
 if( APPLE )
-	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/TestMain.app/Contents/MacOS )
+	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/UnitTests.app/Contents/MacOS )
 else()
 	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE} )
 endif()
 
 add_test(
-	NAME TestMain
-	COMMAND ${TESTBINDIR}/TestMain
+	NAME UnitTests
+	COMMAND ${TESTBINDIR}/UnitTests
 )


### PR DESCRIPTION
Without this, 'make check' cannot find executable.