### PR TITLE
Fixing small memory leak in DirectShow capture implementation

### DIFF
--- a/src/cinder/CaptureImplDirectShow.cpp
+++ b/src/cinder/CaptureImplDirectShow.cpp
@@ -87,7 +87,7 @@ class SurfaceCache {
 			if( ! mSurfaceUsed[i] ) {
 				mSurfaceUsed[i] = true;
 				auto newSurface = new Surface( mSurfaceData[i].get(), mWidth, mHeight, mWidth * mSCO.getPixelInc(), mSCO );
-				Surface8uRef result = shared_ptr<Surface8u>( newSurface, [=] ( Surface8u* s ) { mSurfaceUsed[i] = false; } );
+				Surface8uRef result = shared_ptr<Surface8u>(newSurface, [=](Surface8u* s) { delete s; mSurfaceUsed[i] = false; });
 				return result;
 			}
 		}


### PR DESCRIPTION
The surface cache uses a custom deleter for the Surface shared_ptr objects, but that custom deleter doesn't free up the allocated Surface objects. This small change cleans that that memory leak.