### PR TITLE
Added Arcball missing includes

### DIFF
--- a/include/cinder/Arcball.h
+++ b/include/cinder/Arcball.h
@@ -24,10 +24,12 @@
 
 #pragma once
 
+#include "cinder/Camera.h"
 #include "cinder/Quaternion.h"
 #include "cinder/Vector.h"
 #include "cinder/Sphere.h"
 #include "cinder/app/MouseEvent.h"
+#include "cinder/app/Window.h"
 
 namespace cinder {
 


### PR DESCRIPTION
If you include `cinder/Arcball.h` first in your project it does not compile because `CameraPersp` and `WindowRef` are not defined, only forward declared. Tested with clang on OS X.