### PR TITLE
Removed power of 2 restriction on MonitorNode's window size

### DIFF
--- a/include/cinder/audio/MonitorNode.h
+++ b/include/cinder/audio/MonitorNode.h
@@ -52,8 +52,8 @@ class MonitorNode : public NodeAutoPullable {
 	struct Format : public Node::Format {
 		Format() : mWindowSize( 0 ) {}
 
-		//! Sets the window size, the number of samples that are recorded for one 'window' into the audio signal. Default is the Context's frames-per-block.
-		//! \note will be rounded up to the nearest power of two.
+		//! Sets the window size, which is the number of samples that are recorded for one 'window' into the audio signal.
+		//! Default is the Context's frames-per-block.
 		Format&		windowSize( size_t size )		{ mWindowSize = size; return *this; }
 		//! Returns the window size.
 		size_t		getWindowSize() const			{ return mWindowSize; }
@@ -99,12 +99,12 @@ class MonitorSpectralNode : public MonitorNode {
 	struct Format : public MonitorNode::Format {
 		Format() : MonitorNode::Format(), mFftSize( 0 ), mWindowType( dsp::WindowType::BLACKMAN ) {}
 
-		//! Sets the FFT size, rounded up to the nearest power of 2 greater or equal to \a windowSize. Setting this larger than \a windowSize causes the FFT transform to be 'zero-padded'. Default is the same as windowSize.
-		//! \note resulting number of output spectral bins is equal to (\a size / 2)
+		//! Sets the FFT size, rounded up to the nearest power of 2 greater or equal to \a windowSize. Setting this larger than \a windowSize causes the FFT transform to be 'zero-padded'.
+		//! Default is getWindowSize() rounded up to the nearest power of two. \note resulting number of output spectral bins is equal to (\a size / 2)
 		Format&     fftSize( size_t size )              { mFftSize = size; return *this; }
-		//! defaults to WindowType::BLACKMAN
+		//! The windowing function applied to the samples before computing the transform. Defaults to WindowType::BLACKMAN
 		Format&		windowType( dsp::WindowType type )	{ mWindowType = type; return *this; }
-		//! \see Scope::windowSize()
+		//! \see MonitorNode::Format::windowSize() 
 		Format&		windowSize( size_t size )			{ MonitorNode::Format::windowSize( size ); return *this; }
 
 		size_t			getFftSize() const				{ return mFftSize; }

--- a/src/cinder/audio/MonitorNode.cpp
+++ b/src/cinder/audio/MonitorNode.cpp
@@ -48,8 +48,6 @@ void MonitorNode::initialize()
 {
 	if( ! mWindowSize )
 		mWindowSize = getFramesPerBlock();
-	else if( ! isPowerOf2( mWindowSize ) )
-		mWindowSize = nextPowerOf2( static_cast<uint32_t>( mWindowSize ) );
 
 	for( size_t ch = 0; ch < getNumChannels(); ch++ )
 		mRingBuffers.emplace_back( mWindowSize * mRingBufferPaddingFactor );
@@ -113,16 +111,11 @@ void MonitorSpectralNode::initialize()
 		mFftSize = mWindowSize;
 	if( ! isPowerOf2( mFftSize ) )
 		mFftSize = nextPowerOf2( static_cast<uint32_t>( mFftSize ) );
-	
+
 	mFft = unique_ptr<dsp::Fft>( new dsp::Fft( mFftSize ) );
 	mFftBuffer = audio::Buffer( mFftSize );
 	mBufferSpectral = audio::BufferSpectral( mFftSize );
 	mMagSpectrum.resize( mFftSize / 2 );
-
-	if( ! mWindowSize  )
-		mWindowSize = mFftSize;
-	else if( ! isPowerOf2( mWindowSize ) )
-		mWindowSize = nextPowerOf2( static_cast<uint32_t>( mWindowSize ) );
 
 	mWindowingTable = makeAlignedArray<float>( mWindowSize );
 	generateWindow( mWindowType, mWindowingTable.get(), mWindowSize );


### PR DESCRIPTION
Only the FFT size needs to be a power of 2.