### PR TITLE
audio - SourceFileMediaFoundation improvements

### DIFF
--- a/include/cinder/audio/msw/FileMediaFoundation.h
+++ b/include/cinder/audio/msw/FileMediaFoundation.h
@@ -55,7 +55,7 @@ class SourceFileMediaFoundation : public SourceFile {
 
   private:
 	void		initReader();
-	size_t		processNextReadSample();
+	size_t		processNextReadSample( bool *endOfFile );
 
 	ci::msw::ManagedComPtr<::IMFSourceReader>		mSourceReader;
 	ci::msw::ManagedComPtr<ci::msw::ComIStream>		mComIStream;

--- a/src/cinder/audio/msw/FileMediaFoundation.cpp
+++ b/src/cinder/audio/msw/FileMediaFoundation.cpp
@@ -119,16 +119,16 @@ size_t SourceFileMediaFoundation::performRead( Buffer *buffer, size_t bufferFram
 
 	size_t readCount = 0;
 	while( readCount < numFramesNeeded ) {
-
 		// first drain any frames that were previously read from an IMFSample
 		if( mFramesRemainingInReadBuffer ) {
 			size_t remainingToDrain = std::min( mFramesRemainingInReadBuffer, numFramesNeeded );
 
 			// TODO: use Buffer::copyChannel
+			size_t writeOffset = bufferFrameOffset + readCount;
 			for( size_t ch = 0; ch < mNumChannels; ch++ ) {
 				float *readChannel = mReadBuffer.getChannel( ch ) + mReadBufferPos;
-				float *resultChannel = buffer->getChannel( ch );
-				memcpy( resultChannel + readCount, readChannel, remainingToDrain * sizeof( float ) );
+				float *writeChannel = buffer->getChannel( ch );
+				memcpy( writeChannel + writeOffset, readChannel, remainingToDrain * sizeof( float ) );
 			}
 
 			mReadBufferPos += remainingToDrain;
@@ -161,11 +161,11 @@ size_t SourceFileMediaFoundation::performRead( Buffer *buffer, size_t bufferFram
 			outNumFrames = numFramesNeeded - readCount;
 		}
 
-		size_t offset = bufferFrameOffset + readCount;
+		size_t writeOffset = bufferFrameOffset + readCount;
 		for( size_t ch = 0; ch < mNumChannels; ch++ ) {
 			float *readChannel = mReadBuffer.getChannel( ch );
-			float *resultChannel = buffer->getChannel( ch );
-			memcpy( resultChannel + readCount, readChannel, outNumFrames * sizeof( float ) );
+			float *writeChannel = buffer->getChannel( ch );
+			memcpy( writeChannel + writeOffset, readChannel, outNumFrames * sizeof( float ) );
 		}
 
 		mReadBufferPos += outNumFrames;

--- a/src/cinder/audio/msw/FileMediaFoundation.cpp
+++ b/src/cinder/audio/msw/FileMediaFoundation.cpp
@@ -122,14 +122,8 @@ size_t SourceFileMediaFoundation::performRead( Buffer *buffer, size_t bufferFram
 		// first drain any frames that were previously read from an IMFSample
 		if( mFramesRemainingInReadBuffer ) {
 			size_t remainingToDrain = std::min( mFramesRemainingInReadBuffer, numFramesNeeded );
-
-			// TODO: use Buffer::copyChannel
 			size_t writeOffset = bufferFrameOffset + readCount;
-			for( size_t ch = 0; ch < mNumChannels; ch++ ) {
-				float *readChannel = mReadBuffer.getChannel( ch ) + mReadBufferPos;
-				float *writeChannel = buffer->getChannel( ch );
-				memcpy( writeChannel + writeOffset, readChannel, remainingToDrain * sizeof( float ) );
-			}
+			buffer->copyOffset( mReadBuffer, remainingToDrain, writeOffset, mReadBufferPos );
 
 			mReadBufferPos += remainingToDrain;
 			mFramesRemainingInReadBuffer -= remainingToDrain;
@@ -162,11 +156,7 @@ size_t SourceFileMediaFoundation::performRead( Buffer *buffer, size_t bufferFram
 		}
 
 		size_t writeOffset = bufferFrameOffset + readCount;
-		for( size_t ch = 0; ch < mNumChannels; ch++ ) {
-			float *readChannel = mReadBuffer.getChannel( ch );
-			float *writeChannel = buffer->getChannel( ch );
-			memcpy( writeChannel + writeOffset, readChannel, outNumFrames * sizeof( float ) );
-		}
+		buffer->copyOffset( mReadBuffer, outNumFrames, writeOffset, 0 );
 
 		mReadBufferPos += outNumFrames;
 		readCount += outNumFrames;

--- a/test/_audio/SampleTest/src/SampleTestApp.cpp
+++ b/test/_audio/SampleTest/src/SampleTestApp.cpp
@@ -115,7 +115,7 @@ void SamplePlayerNodeTestApp::setupBufferPlayerNode()
 	auto bufferPlayer = audio::master()->makeNode( new audio::BufferPlayerNode() );
 
 	auto loadFn = [bufferPlayer, this] {
-		bufferPlayer->loadBuffer( mSourceFile );
+		bufferPlayer->loadBuffer( mSourceFile->clone() );
 		mWaveformPlot.load( bufferPlayer->getBuffer(), getWindowBounds() );
 		CI_LOG_V( "loaded source buffer, frames: " << bufferPlayer->getBuffer()->getNumFrames() );
 
@@ -157,7 +157,7 @@ void SamplePlayerNodeTestApp::setupFilePlayerNode()
 //	mSourceFile->setMaxFramesPerRead( 8192 );
 	bool asyncRead = mAsyncButton.mEnabled;
 	CI_LOG_V( "async read: " << asyncRead );
-	mSamplePlayerNode = ctx->makeNode( new audio::FilePlayerNode( mSourceFile, asyncRead ) );
+	mSamplePlayerNode = ctx->makeNode( new audio::FilePlayerNode( mSourceFile->clone(), asyncRead ) );
 
 	// TODO: it is pretty surprising when you recreate mMonitor here without checking if there has already been one added.
 	//	- user will no longer see the old mMonitor, but the context still owns a reference to it, so another gets added each time we call this method.
@@ -473,14 +473,14 @@ void SamplePlayerNodeTestApp::fileDrop( FileDropEvent event )
 
 	auto bufferPlayer = dynamic_pointer_cast<audio::BufferPlayerNode>( mSamplePlayerNode );
 	if( bufferPlayer ) {
-		bufferPlayer->loadBuffer( mSourceFile );
+		bufferPlayer->loadBuffer( mSourceFile->clone() );
 		mWaveformPlot.load( bufferPlayer->getBuffer(), getWindowBounds() );
 	}
 	else {
 		auto filePlayer = dynamic_pointer_cast<audio::FilePlayerNode>( mSamplePlayerNode );
 		CI_ASSERT_MSG( filePlayer, "expected sample player to be either BufferPlayerNode or FilePlayerNode" );
 
-		filePlayer->setSourceFile( mSourceFile );
+		filePlayer->setSourceFile( mSourceFile->clone() );
 	}
 
 	mLoopBeginSlider.mMax = mLoopEndSlider.mMax = (float)mSamplePlayerNode->getNumSeconds();

--- a/test/_audio/SampleTest/src/SampleTestApp.cpp
+++ b/test/_audio/SampleTest/src/SampleTestApp.cpp
@@ -194,8 +194,6 @@ void SamplePlayerNodeTestApp::setupBufferRecorderNode()
 void SamplePlayerNodeTestApp::setSourceFile( const DataSourceRef &dataSource )
 {
 	mSourceFile = audio::load( dataSource, audio::master()->getSampleRate() );
-	mLoopEndSlider.mMax = (float)mSourceFile->getNumSeconds();
-	mLoopBeginSlider.set( (float)mSourceFile->getNumSeconds() );
 
 	getWindow()->setTitle( dataSource->getFilePath().filename().string() );
 
@@ -486,6 +484,8 @@ void SamplePlayerNodeTestApp::fileDrop( FileDropEvent event )
 	}
 
 	mLoopBeginSlider.mMax = mLoopEndSlider.mMax = (float)mSamplePlayerNode->getNumSeconds();
+	mLoopBeginSlider.set( mSamplePlayerNode->getLoopBeginTime() );
+	mLoopEndSlider.set( mSamplePlayerNode->getLoopEndTime() );
 
 	CI_LOG_V( "loaded and set new source buffer, channels: " << mSourceFile->getNumChannels() << ", frames: " << mSourceFile->getNumFrames() );
 	PRINT_GRAPH( audio::master() );


### PR DESCRIPTION
Fixes a bug that was reported quite a while ago but I couldn't reproduce until now - seems that some mp3s on windows hit the EOF marker before the actual reported frames, which was triggering an assert. For now, I fill the extra frames with silence. The only other option would be to change the internal `mFileNumFrames` property (and associated `mNumFrames`, the amount after samplerate conversion), but this could lead to client problems if they've already done some sizing based on `SourceFile::getNumFrames()`.  This is a rare enough case (only heard of it twice in the last year) that I think filling with silent frames is a better solution.

Also fixed some SampleTest issues and other SourceFileMediaFoundation cleanup.