### PR TITLE
Added audio::MonitorSpectralNode::getSpectralCentroid()

### DIFF
--- a/include/cinder/audio/MonitorNode.h
+++ b/include/cinder/audio/MonitorNode.h
@@ -148,6 +148,7 @@ class MonitorSpectralNode : public MonitorNode {
 	size_t						mFftSize;
 	dsp::WindowType				mWindowType;
 	float						mSmoothingFactor;
+	uint64_t					mLastFrameMagSpectrumComputed;
 };
 
 } } // namespace cinder::audio

--- a/include/cinder/audio/MonitorNode.h
+++ b/include/cinder/audio/MonitorNode.h
@@ -125,7 +125,9 @@ class MonitorSpectralNode : public MonitorNode {
 
 	//! Returns the magnitude spectrum of the currently sampled audio stream, suitable for consuming on the main UI thread.
 	const	std::vector<float>& getMagSpectrum();
-	//! Returns the number of frequency bins in the analyzed magnitude spectrum. Equivilant to fftSize / 2.
+	//! Returns the 'center of mass' of the magnitude spectrum, which is often correlated with the perception of 'brightness', in hertz.
+	float	getSpectralCentroid();
+	//! Returns the number of frequency bins in the analyzed magnitude spectrum. Equivalent to fftSize / 2.
 	size_t	getNumBins() const				{ return mFftSize / 2; }
 	//! Returns the size of the FFT used for spectral analysis.
 	size_t	getFftSize() const				{ return mFftSize; }

--- a/include/cinder/audio/MonitorNode.h
+++ b/include/cinder/audio/MonitorNode.h
@@ -126,6 +126,8 @@ class MonitorSpectralNode : public MonitorNode {
 	//! Returns the magnitude spectrum of the currently sampled audio stream, suitable for consuming on the main UI thread.
 	const	std::vector<float>& getMagSpectrum();
 	//! Returns the 'center of mass' of the magnitude spectrum, which is often correlated with the perception of 'brightness', in hertz.
+	//! \note The calculation of the magnitude spectrum happens on the main thread, so the result of getMagSpectrum() and getSpectralCentroid() might be analyzing different
+	//! audio data that is streaming on the audio thread. For a more precise centroid of getMagSpectrum(), you can use audio::dsp::spectralCentroid() directly on it.
 	float	getSpectralCentroid();
 	//! Returns the number of frequency bins in the analyzed magnitude spectrum. Equivalent to fftSize / 2.
 	size_t	getNumBins() const				{ return mFftSize / 2; }

--- a/include/cinder/audio/dsp/Dsp.h
+++ b/include/cinder/audio/dsp/Dsp.h
@@ -84,5 +84,7 @@ float sum( const float *array, size_t length );
 float rms( const float *array, size_t length );
 //! normalizes \a array to \a maxValue (default = 1)
 void normalize( float *array, size_t length, float maxValue = 1 );
+//! returns the spectral centroid of the frequency magnitude spectrum in \a magArray, computed the provided \a sampleRate. \a magArrayLength is expected to be half of the FFT size used to compute the magnitude spectrum.
+float spectralCentroid( const float *magArray, size_t magArrayLength, size_t sampleRate );
 
 } } } // namespace cinder::audio::dsp

--- a/src/cinder/audio/MonitorNode.cpp
+++ b/src/cinder/audio/MonitorNode.cpp
@@ -95,7 +95,8 @@ void MonitorNode::fillCopiedBuffer()
 // ----------------------------------------------------------------------------------------------------
 
 MonitorSpectralNode::MonitorSpectralNode( const Format &format )
-	: MonitorNode( format ), mFftSize( format.getFftSize() ), mWindowType( format.getWindowType() ), mSmoothingFactor( 0.5f )
+	: MonitorNode( format ), mFftSize( format.getFftSize() ), mWindowType( format.getWindowType() ),
+		mSmoothingFactor( 0.5f ), mLastFrameMagSpectrumComputed( 0 )
 {
 }
 
@@ -125,6 +126,12 @@ void MonitorSpectralNode::initialize()
 // - alternatively, this tap can force mono output, which only works if it isn't a tap but is really a leaf node (no output).
 const std::vector<float>& MonitorSpectralNode::getMagSpectrum()
 {
+	uint64_t numFramesProcessed = getContext()->getNumProcessedFrames();
+	if( mLastFrameMagSpectrumComputed == numFramesProcessed )
+		return mMagSpectrum;
+
+	mLastFrameMagSpectrumComputed = numFramesProcessed;
+
 	fillCopiedBuffer();
 
 	// window the copied buffer and compute forward FFT transform
@@ -146,11 +153,11 @@ const std::vector<float>& MonitorSpectralNode::getMagSpectrum()
 	float *real = mBufferSpectral.getReal();
 	float *imag = mBufferSpectral.getImag();
 
-	// remove nyquist component
+	// remove Nyquist component
 	imag[0] = 0.0f;
 
 	// compute normalized magnitude spectrum
-	// TODO: break this into vector cartisian -> polar and then vector lowpass. skip lowpass if smoothing factor is very small
+	// TODO: break this into vector cartesian -> polar and then vector lowpass. skip lowpass if smoothing factor is very small
 	const float magScale = 1.0f / mFft->getSize();
 	for( size_t i = 0; i < mMagSpectrum.size(); i++ ) {
 		float re = real[i];

--- a/src/cinder/audio/MonitorNode.cpp
+++ b/src/cinder/audio/MonitorNode.cpp
@@ -168,6 +168,27 @@ const std::vector<float>& MonitorSpectralNode::getMagSpectrum()
 	return mMagSpectrum;
 }
 
+float MonitorSpectralNode::getSpectralCentroid()
+{
+	const auto &magSpectrum = getMagSpectrum();
+	float binToFreq = (float)getSampleRate() / (float)mFftSize;
+
+	float FA = 0;	// f(n) * x(n)
+	float A = 0;	// x(n)
+	for( size_t n = 0; n < magSpectrum.size(); n++ ) {
+		float freq = n * binToFreq;
+		float mag = magSpectrum[n];
+
+		FA += freq * mag;
+		A += mag;
+	}
+
+	if( A < EPSILON )
+		return 0;
+
+	return FA / A;
+}
+
 void MonitorSpectralNode::setSmoothingFactor( float factor )
 {
 	mSmoothingFactor = math<float>::clamp( factor );

--- a/src/cinder/audio/MonitorNode.cpp
+++ b/src/cinder/audio/MonitorNode.cpp
@@ -170,23 +170,9 @@ const std::vector<float>& MonitorSpectralNode::getMagSpectrum()
 
 float MonitorSpectralNode::getSpectralCentroid()
 {
+
 	const auto &magSpectrum = getMagSpectrum();
-	float binToFreq = (float)getSampleRate() / (float)mFftSize;
-
-	float FA = 0;	// f(n) * x(n)
-	float A = 0;	// x(n)
-	for( size_t n = 0; n < magSpectrum.size(); n++ ) {
-		float freq = n * binToFreq;
-		float mag = magSpectrum[n];
-
-		FA += freq * mag;
-		A += mag;
-	}
-
-	if( A < EPSILON )
-		return 0;
-
-	return FA / A;
+	return dsp::spectralCentroid( magSpectrum.data(), magSpectrum.size(), getSampleRate() );
 }
 
 void MonitorSpectralNode::setSmoothingFactor( float factor )

--- a/src/cinder/audio/dsp/Dsp.cpp
+++ b/src/cinder/audio/dsp/Dsp.cpp
@@ -259,4 +259,24 @@ void normalize( float *array, size_t length, float maxValue )
 	}
 }
 
+float spectralCentroid( const float *magArray, size_t magArrayLength, size_t sampleRate )
+{
+	float binToFreq = (float)sampleRate / (float)(magArrayLength * 2 ); // sr / fft size
+	float FA = 0;	// f(n) * x(n)
+	float A = 0;	// x(n)
+
+	for( size_t n = 0; n < magArrayLength; n++ ) {
+		float freq = n * binToFreq;
+		float mag = magArray[n];
+
+		FA += freq * mag;
+		A += mag;
+	}
+
+	if( A < EPSILON )
+		return 0;
+
+	return FA / A;
+}
+
 } } } // namespace cinder::audio::dsp


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Spectral_centroid.  After volume / loudness, this is arguably the most useful audio feature for doing visualizations and is quite simple to compute, so here it is.