### PR TITLE
symlink assets directory to be next to executable

### DIFF
--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -129,6 +129,11 @@ function( ci_make_app )
 		get_filename_component( ASSETS_SYMLINK_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets" ABSOLUTE )
 
 		if( EXISTS "${ARG_ASSETS_PATH}" AND IS_DIRECTORY "${ARG_ASSETS_PATH}" )
+			# Need to ensure that the runtime output dir already exists before symlinking something into it
+			if( NOT EXISTS "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+				file( MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
+			endif()
+
 			execute_process(
 					COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "${ARG_ASSETS_PATH}" "${ASSETS_SYMLINK_PATH}"
 					RESULT_VARIABLE resultCode

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -124,24 +124,24 @@ function( ci_make_app )
 			MACOSX_BUNDLE_BUNDLE_NAME ${ARG_APP_NAME}
 			MACOSX_BUNDLE_ICON_FILE ${ICON_NAME}
 		)
-	elseif( CINDER_LINUX )
-		# If an assets directory exists, symlink it next to the executable
-		get_filename_component( ASSETS_SYMLINK_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets" ABSOLUTE )
+	endif()
 
-		if( EXISTS "${ARG_ASSETS_PATH}" AND IS_DIRECTORY "${ARG_ASSETS_PATH}" )
-			# Need to ensure that the runtime output dir already exists before symlinking something into it
-			if( NOT EXISTS "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-				file( MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
-			endif()
+	# If an assets directory exists, symlink it next to the executable
+	get_filename_component( ASSETS_SYMLINK_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets" ABSOLUTE )
 
-			execute_process(
-					COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "${ARG_ASSETS_PATH}" "${ASSETS_SYMLINK_PATH}"
-					RESULT_VARIABLE resultCode
-			)
+	if( EXISTS "${ARG_ASSETS_PATH}" AND IS_DIRECTORY "${ARG_ASSETS_PATH}" )
+		# Need to ensure that the runtime output dir already exists before symlinking something into it
+		if( NOT EXISTS "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+			file( MAKE_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
+		endif()
 
-			if( NOT resultCode EQUAL 0 )
-			  	message( WARNING "Failed to symlink '${ARG_ASSETS_PATH}' to '${ASSETS_SYMLINK_PATH}', result: ${resultCode}" )
-			endif()
+		execute_process(
+				COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "${ARG_ASSETS_PATH}" "${ASSETS_SYMLINK_PATH}"
+				RESULT_VARIABLE resultCode
+		)
+
+		if( NOT resultCode EQUAL 0 )
+		    message( WARNING "Failed to symlink '${ARG_ASSETS_PATH}' to '${ASSETS_SYMLINK_PATH}', result: ${resultCode}" )
 		endif()
 	endif()
 

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -12,7 +12,7 @@ function( ci_make_app )
 
 	if( NOT ARG_ASSETS_PATH )
 		# Set the default assets path to be in the standard app location (next to proj folder)
-		get_filename_component( ARG_ASSETS_PATH "../../assets" ABSOLUTE )
+		get_filename_component( ARG_ASSETS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../assets" ABSOLUTE )
 	endif()
 
 	if( ARG_UNPARSED_ARGUMENTS )


### PR DESCRIPTION
Opening this for discussion. This is a solution for the problem mentioned in [this forum post](http://discourse.libcinder.org/t/rfc-cross-platform-cmake-support/102/25), where the assets fold can't be build when you build a cinder sample with something like:

```
cmake -DCINDER_BUILD_SAMPLE=Geometry ..
```

In order for this to work, the executable has to be placed in a subfolder, I used used the app name for this.

It looks for the assets folder in its common place by default (next to proj folder), but this can be overridden by passing in an argument for `ASSETS_PATH` to the `ci_make_app()` function. The symlink is currently always named `assets`.

Still to-do:
- [x] add cmake option that forces the assets to be copied instead of symlinked.
- [x] test on mac
