### PR TITLE
[iOS] Nix audio glitches during sleep and interruptions

### DIFF
--- a/include/cinder/audio/Device.h
+++ b/include/cinder/audio/Device.h
@@ -129,15 +129,19 @@ class DeviceManager : private Noncopyable {
 	//! override if subclass needs to update params async, and will issue formatWillChange callbacks
 	virtual bool			isFormatUpdatedAsync() const		{ return false; }
 
+	signals::Signal<void()> &getSignalInterruptionBegan() { return mSignalInterruptionBegan; }
+	signals::Signal<void()> &getSignalInterruptionEnded() { return mSignalInterruptionEnded; }
   protected:
-	DeviceManager()	{}
+	DeviceManager() {}
 
-	DeviceRef	addDevice( const std::string &key );
+	DeviceRef addDevice( const std::string &key );
 
 	void emitParamsWillChange( const DeviceRef &device );
 	void emitParamsDidChange( const DeviceRef &device );
 
 	std::vector<DeviceRef> mDevices;
+
+	signals::Signal<void()> mSignalInterruptionBegan, mSignalInterruptionEnded;
 };
 
 } } // namespace cinder::audio

--- a/include/cinder/audio/Device.h
+++ b/include/cinder/audio/Device.h
@@ -130,7 +130,7 @@ class DeviceManager : private Noncopyable {
 	virtual bool			isFormatUpdatedAsync() const		{ return false; }
 
 	signals::Signal<void()> &getSignalInterruptionBegan() { return mSignalInterruptionBegan; }
-	signals::Signal<void(bool)> &getSignalInterruptionEnded() { return mSignalInterruptionEnded; }
+	signals::Signal<void()> &getSignalInterruptionEnded() { return mSignalInterruptionEnded; }
   protected:
 	DeviceManager() {}
 
@@ -141,8 +141,7 @@ class DeviceManager : private Noncopyable {
 
 	std::vector<DeviceRef> mDevices;
 
-	signals::Signal<void()> mSignalInterruptionBegan;
-	signals::Signal<void(bool)> mSignalInterruptionEnded;
+	signals::Signal<void()> mSignalInterruptionBegan, mSignalInterruptionEnded;
 };
 
 } } // namespace cinder::audio

--- a/include/cinder/audio/Device.h
+++ b/include/cinder/audio/Device.h
@@ -130,7 +130,7 @@ class DeviceManager : private Noncopyable {
 	virtual bool			isFormatUpdatedAsync() const		{ return false; }
 
 	signals::Signal<void()> &getSignalInterruptionBegan() { return mSignalInterruptionBegan; }
-	signals::Signal<void()> &getSignalInterruptionEnded() { return mSignalInterruptionEnded; }
+	signals::Signal<void(bool)> &getSignalInterruptionEnded() { return mSignalInterruptionEnded; }
   protected:
 	DeviceManager() {}
 
@@ -141,7 +141,8 @@ class DeviceManager : private Noncopyable {
 
 	std::vector<DeviceRef> mDevices;
 
-	signals::Signal<void()> mSignalInterruptionBegan, mSignalInterruptionEnded;
+	signals::Signal<void()> mSignalInterruptionBegan;
+	signals::Signal<void(bool)> mSignalInterruptionEnded;
 };
 
 } } // namespace cinder::audio

--- a/include/cinder/audio/OutputNode.h
+++ b/include/cinder/audio/OutputNode.h
@@ -88,7 +88,7 @@ class OutputDeviceNode : public OutputNode {
 
 	DeviceRef					mDevice;
 	bool						mWasEnabledBeforeParamsChange;
-	signals::ScopedConnection	mWillChangeConn, mDidChangeConn;
+	signals::ScopedConnection	mWillChangeConn, mDidChangeConn, mInterruptionBeganConn, mInterruptionEndedConn;
 };
 
 } } // namespace cinder::audio

--- a/include/cinder/audio/OutputNode.h
+++ b/include/cinder/audio/OutputNode.h
@@ -88,7 +88,7 @@ class OutputDeviceNode : public OutputNode {
 
 	DeviceRef					mDevice;
 	bool						mWasEnabledBeforeParamsChange;
-	signals::ScopedConnection	mWillChangeConn, mDidChangeConn, mInterruptionBeganConn, mInterruptionEndedConn;
+	signals::ScopedConnection	mWillChangeConn, mDidChangeConn, mInterruptionBeganConn, mInterruptionEndedConn, mAppDidBecomeActiveConn;
 };
 
 } } // namespace cinder::audio

--- a/include/cinder/audio/OutputNode.h
+++ b/include/cinder/audio/OutputNode.h
@@ -88,7 +88,7 @@ class OutputDeviceNode : public OutputNode {
 
 	DeviceRef					mDevice;
 	bool						mWasEnabledBeforeParamsChange;
-	signals::ScopedConnection	mWillChangeConn, mDidChangeConn, mInterruptionBeganConn, mInterruptionEndedConn, mAppDidBecomeActiveConn;
+	signals::ScopedConnection	mWillChangeConn, mDidChangeConn, mInterruptionBeganConn, mInterruptionEndedConn;
 };
 
 } } // namespace cinder::audio

--- a/include/cinder/audio/cocoa/CinderCoreAudio.h
+++ b/include/cinder/audio/cocoa/CinderCoreAudio.h
@@ -60,7 +60,7 @@ inline void copyToBufferList( ::AudioBufferList *bufferList, const Buffer *buffe
 		memcpy( bufferList->mBuffers[i].mData, buffer->getChannel( i ), bufferList->mBuffers[i].mDataByteSize );
 }
 
-inline void copyToBufferList(::AudioBufferList *bufferList, const Buffer *buffer, size_t startFrame, size_t frameCount )
+inline void copyToBufferList( ::AudioBufferList *bufferList, const Buffer *buffer, size_t startFrame, size_t frameCount )
 {
 	for( UInt32 i = 0; i < bufferList->mNumberBuffers; i++ ) {
 		Float32 *startPtr = static_cast<Float32 *>( bufferList->mBuffers[i].mData ) + startFrame;

--- a/include/cinder/audio/cocoa/CinderCoreAudio.h
+++ b/include/cinder/audio/cocoa/CinderCoreAudio.h
@@ -60,6 +60,14 @@ inline void copyToBufferList( ::AudioBufferList *bufferList, const Buffer *buffe
 		memcpy( bufferList->mBuffers[i].mData, buffer->getChannel( i ), bufferList->mBuffers[i].mDataByteSize );
 }
 
+inline void copyToBufferList(::AudioBufferList *bufferList, const Buffer *buffer, size_t startFrame, size_t frameCount )
+{
+	for( UInt32 i = 0; i < bufferList->mNumberBuffers; i++ ) {
+		Float32 *startPtr = static_cast<Float32 *>( bufferList->mBuffers[i].mData ) + startFrame;
+		memcpy( startPtr, buffer->getChannel( i ), frameCount * sizeof( Float32 ) );
+	}
+}
+
 inline void copyFromBufferList( Buffer *buffer, const ::AudioBufferList *bufferList )
 {
 	for( UInt32 i = 0; i < bufferList->mNumberBuffers; i++ )
@@ -70,6 +78,14 @@ inline void zeroBufferList( const ::AudioBufferList *bufferList )
 {
 	for( UInt32 i = 0; i < bufferList->mNumberBuffers; i++ )
 		memset( bufferList->mBuffers[i].mData, 0, bufferList->mBuffers[i].mDataByteSize );
+}
+
+inline void zeroBufferList( const ::AudioBufferList *bufferList, size_t startFrame, size_t frameCount )
+{
+	for( UInt32 i = 0; i < bufferList->mNumberBuffers; i++ ) {
+		Float32 *startPtr = static_cast<Float32 *>( bufferList->mBuffers[i].mData ) + startFrame;
+		memset( startPtr, 0, frameCount * sizeof( Float32 ) );
+	}
 }
 
 // ----------------------------------------------------------------------------------------------------

--- a/include/cinder/audio/cocoa/DeviceManagerAudioSession.h
+++ b/include/cinder/audio/cocoa/DeviceManagerAudioSession.h
@@ -60,9 +60,8 @@ class DeviceManagerAudioSession : public DeviceManager {
 	void setInputEnabled( bool enable = true );
 	bool isInputEnabled() const		{ return mInputEnabled; }
 
-	void beginInterruption();
-	void endInterruption();
-	void endInterruptionOnceAppIsActive();
+	void privateBeginInterruption();
+	void privateEndInterruption( bool resumeImmediately );
 
  private:
 	const DeviceRef&				getRemoteIODevice();
@@ -71,7 +70,7 @@ class DeviceManagerAudioSession : public DeviceManager {
 	void							activateSession();
 
 	DeviceRef mRemoteIODevice;
-	bool mSessionIsActive, mInputEnabled, mEndInterruptionOnceAppIsActive;
+	bool mSessionIsActive, mInputEnabled, mInterruptionHasEnded;
 
 	signals::ScopedConnection mAppDidBecomeActiveConn;
 

--- a/include/cinder/audio/cocoa/DeviceManagerAudioSession.h
+++ b/include/cinder/audio/cocoa/DeviceManagerAudioSession.h
@@ -61,7 +61,8 @@ class DeviceManagerAudioSession : public DeviceManager {
 	bool isInputEnabled() const		{ return mInputEnabled; }
 
 	void beginInterruption();
-	void endInterruption( bool resumeImmediately );
+	void endInterruption();
+	void endInterruptionOnceAppIsActive();
 
  private:
 	const DeviceRef&				getRemoteIODevice();
@@ -70,7 +71,9 @@ class DeviceManagerAudioSession : public DeviceManager {
 	void							activateSession();
 
 	DeviceRef mRemoteIODevice;
-	bool mSessionIsActive, mInputEnabled;
+	bool mSessionIsActive, mInputEnabled, mEndInterruptionOnceAppIsActive;
+
+	signals::ScopedConnection mAppDidBecomeActiveConn;
 
 	AudioSessionNotificationHandlerImpl *mSessionNotificationHandler;
 };

--- a/include/cinder/audio/cocoa/DeviceManagerAudioSession.h
+++ b/include/cinder/audio/cocoa/DeviceManagerAudioSession.h
@@ -27,9 +27,9 @@
 #include "cinder/audio/Device.h"
 
 #if defined( __OBJC__ )
-	@class AudioSessionInterruptionHandlerImpl;
+	@class AudioSessionNotificationHandlerImpl;
 #else
-	class AudioSessionInterruptionHandlerImpl;
+	class AudioSessionNotificationHandlerImpl;
 #endif
 
 namespace cinder { namespace audio { namespace cocoa {
@@ -60,19 +60,19 @@ class DeviceManagerAudioSession : public DeviceManager {
 	void setInputEnabled( bool enable = true );
 	bool isInputEnabled() const		{ return mInputEnabled; }
 
-  private:
+	void beginInterruption();
+	void endInterruption( bool shouldResume );
 
+ private:
 	const DeviceRef&				getRemoteIODevice();
-	void							activateSession();
 	std::string						getSessionCategory();
-
-	AudioSessionInterruptionHandlerImpl *getSessionInterruptionHandler();
-
+	
+	void							activateSession();
 
 	DeviceRef mRemoteIODevice;
 	bool mSessionIsActive, mInputEnabled;
 
-	AudioSessionInterruptionHandlerImpl *mSessionInterruptionHandler;
+	AudioSessionNotificationHandlerImpl *mSessionNotificationHandler;
 };
 
 } } } // namespace cinder::audio::cocoa

--- a/include/cinder/audio/cocoa/DeviceManagerAudioSession.h
+++ b/include/cinder/audio/cocoa/DeviceManagerAudioSession.h
@@ -61,7 +61,7 @@ class DeviceManagerAudioSession : public DeviceManager {
 	bool isInputEnabled() const		{ return mInputEnabled; }
 
 	void beginInterruption();
-	void endInterruption( bool shouldResume );
+	void endInterruption( bool resumeImmediately );
 
  private:
 	const DeviceRef&				getRemoteIODevice();

--- a/src/cinder/audio/OutputNode.cpp
+++ b/src/cinder/audio/OutputNode.cpp
@@ -96,7 +96,7 @@ OutputDeviceNode::OutputDeviceNode( const DeviceRef &device, const Format &forma
 	mDidChangeConn = mDevice->getSignalParamsDidChange().connect( bind( &OutputDeviceNode::deviceParamsDidChange, this ) );
 
 	mInterruptionBeganConn = Context::deviceManager()->getSignalInterruptionBegan().connect( [this] { disable(); } );
-	mInterruptionBeganConn = Context::deviceManager()->getSignalInterruptionEnded().connect( [this] { enable(); } );
+	mInterruptionEndedConn = Context::deviceManager()->getSignalInterruptionEnded().connect( [this]( bool shouldResume ) { enable(); } );
 
 	size_t deviceNumChannels = mDevice->getNumOutputChannels();
 

--- a/src/cinder/audio/OutputNode.cpp
+++ b/src/cinder/audio/OutputNode.cpp
@@ -95,6 +95,9 @@ OutputDeviceNode::OutputDeviceNode( const DeviceRef &device, const Format &forma
 	mWillChangeConn = mDevice->getSignalParamsWillChange().connect( bind( &OutputDeviceNode::deviceParamsWillChange, this ) );
 	mDidChangeConn = mDevice->getSignalParamsDidChange().connect( bind( &OutputDeviceNode::deviceParamsDidChange, this ) );
 
+	mInterruptionBeganConn = Context::deviceManager()->getSignalInterruptionBegan().connect( [this] { disable(); } );
+	mInterruptionBeganConn = Context::deviceManager()->getSignalInterruptionEnded().connect( [this] { enable(); } );
+
 	size_t deviceNumChannels = mDevice->getNumOutputChannels();
 
 	// If number of channels hasn't been specified, default to 2 (or 1 if that is all that is available).

--- a/src/cinder/audio/OutputNode.cpp
+++ b/src/cinder/audio/OutputNode.cpp
@@ -26,6 +26,8 @@
 #include "cinder/audio/Utilities.h"
 #include "cinder/audio/Exception.h"
 
+#include "cinder/app/App.h"
+
 #include <string>
 
 using namespace std;
@@ -96,7 +98,21 @@ OutputDeviceNode::OutputDeviceNode( const DeviceRef &device, const Format &forma
 	mDidChangeConn = mDevice->getSignalParamsDidChange().connect( bind( &OutputDeviceNode::deviceParamsDidChange, this ) );
 
 	mInterruptionBeganConn = Context::deviceManager()->getSignalInterruptionBegan().connect( [this] { disable(); } );
-	mInterruptionEndedConn = Context::deviceManager()->getSignalInterruptionEnded().connect( [this]( bool shouldResume ) { enable(); } );
+	mInterruptionEndedConn = Context::deviceManager()->getSignalInterruptionEnded().connect( [this]( bool resumeImmediately ) {
+		if( resumeImmediately ) {
+			enable();
+		}
+		else {
+			// Resume output once the app becomes active again.
+			auto app = app::App::get();
+			if( app ) {
+				mAppDidBecomeActiveConn = app->getSignalDidBecomeActive().connect( [this] {
+					mAppDidBecomeActiveConn.disconnect();
+					enable();
+				} );
+			}
+		}
+	} );
 
 	size_t deviceNumChannels = mDevice->getNumOutputChannels();
 

--- a/src/cinder/audio/OutputNode.cpp
+++ b/src/cinder/audio/OutputNode.cpp
@@ -26,8 +26,6 @@
 #include "cinder/audio/Utilities.h"
 #include "cinder/audio/Exception.h"
 
-#include "cinder/app/App.h"
-
 #include <string>
 
 using namespace std;
@@ -98,21 +96,7 @@ OutputDeviceNode::OutputDeviceNode( const DeviceRef &device, const Format &forma
 	mDidChangeConn = mDevice->getSignalParamsDidChange().connect( bind( &OutputDeviceNode::deviceParamsDidChange, this ) );
 
 	mInterruptionBeganConn = Context::deviceManager()->getSignalInterruptionBegan().connect( [this] { disable(); } );
-	mInterruptionEndedConn = Context::deviceManager()->getSignalInterruptionEnded().connect( [this]( bool resumeImmediately ) {
-		if( resumeImmediately ) {
-			enable();
-		}
-		else {
-			// Resume output once the app becomes active again.
-			auto app = app::App::get();
-			if( app ) {
-				mAppDidBecomeActiveConn = app->getSignalDidBecomeActive().connect( [this] {
-					mAppDidBecomeActiveConn.disconnect();
-					enable();
-				} );
-			}
-		}
-	} );
+	mInterruptionEndedConn = Context::deviceManager()->getSignalInterruptionEnded().connect( [this] { enable(); } );
 
 	size_t deviceNumChannels = mDevice->getNumOutputChannels();
 

--- a/src/cinder/audio/cocoa/DeviceManagerAudioSession.mm
+++ b/src/cinder/audio/cocoa/DeviceManagerAudioSession.mm
@@ -227,9 +227,7 @@ const DeviceRef& DeviceManagerAudioSession::getRemoteIODevice()
 
 void DeviceManagerAudioSession::activateSession()
 {
-	CI_LOG_V("Activating Session");
-
-	if( !mSessionNotificationHandler ) {
+	if( ! mSessionNotificationHandler ) {
 		mSessionNotificationHandler = [AudioSessionNotificationHandlerImpl new];
 		mSessionNotificationHandler->mDeviceManager = this;
 
@@ -242,7 +240,7 @@ void DeviceManagerAudioSession::activateSession()
 	bool didActivate = [globalSession setActive:YES error:&error];
 	CI_ASSERT( !error );
 
-	if( !didActivate )
+	if( ! didActivate )
 		throw AudioDeviceExc( "Failed to activate global AVAudioSession." );
 
 	mSessionIsActive = true;

--- a/src/cinder/audio/cocoa/DeviceManagerAudioSession.mm
+++ b/src/cinder/audio/cocoa/DeviceManagerAudioSession.mm
@@ -24,7 +24,6 @@
 #include "cinder/audio/cocoa/DeviceManagerAudioSession.h"
 #include "cinder/audio/Exception.h"
 #include "cinder/CinderAssert.h"
-#include "cinder/Log.h"
 
 #include "cinder/cocoa/CinderCocoa.h"
 
@@ -210,12 +209,7 @@ void DeviceManagerAudioSession::endInterruption( bool shouldResume )
 {
 	mSessionIsActive = true;
 
-	if( shouldResume ) {
-		CI_LOG_V("Resume after interruption");
-	}
-
-	// TODO(ryan): Somehow notify whether to resume or not.
-	mSignalInterruptionEnded.emit();
+	mSignalInterruptionEnded.emit( shouldResume );
 }
 
 


### PR DESCRIPTION
This adds handling for iOS interruptions (phone call, alarm, etc) and adds a fix for #997, a bug that was causing audio to glitch and drop out when the device slept, or another application was opened while audio was playing. In my tests audio now fades out smoothly when the app is backgrounded. There is no fade-in, but this is something users can add on a per-app basis.

I should mention that the interruption handling uses the iOS >= 6.0 API, as I've been told that 6.0 is going to be the new baseline.