### PR TITLE
Updating freetype to allow for openssl use

### DIFF
--- a/src/freetype/base/ftobjs.c
+++ b/src/freetype/base/ftobjs.c
@@ -4129,18 +4129,18 @@
       err = FT_Bitmap_Convert( library, &slot->bitmap, &bitmap, 1 );
       if ( !err )
       {
-        MD5_CTX        ctx;
+        FT_MD5_CTX        ctx;
         unsigned char  md5[16];
         int            i;
         unsigned int   rows  = bitmap.rows;
         unsigned int   pitch = (unsigned int)bitmap.pitch;
 
 
-        MD5_Init( &ctx );
-        MD5_Update( &ctx, bitmap.buffer, rows * pitch );
-        MD5_Final( md5, &ctx );
+        FT_MD5_Init( &ctx );
+        FT_MD5_Update( &ctx, bitmap.buffer, rows * pitch );
+        FT_MD5_Final( md5, &ctx );
 
-        FT_TRACE3(( "MD5 checksum for %dx%d bitmap:\n"
+        FT_TRACE3(( "FT_MD5 checksum for %dx%d bitmap:\n"
                     "  ",
                     rows, pitch ));
         for ( i = 0; i < 16; i++ )

--- a/src/freetype/base/md5.c
+++ b/src/freetype/base/md5.c
@@ -1,6 +1,6 @@
 /*
  * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
- * MD5 Message-Digest Algorithm (RFC 1321).
+ * FT_MD5 Message-Digest Algorithm (RFC 1321).
  *
  * Homepage:
  * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
@@ -42,7 +42,7 @@
 #include "md5.h"
 
 /*
- * The basic MD5 functions.
+ * The basic FT_MD5 functions.
  *
  * F and G are optimized compared to their RFC 1321 definitions for
  * architectures that lack an AND-NOT instruction, just like in Colin Plumb's
@@ -55,7 +55,7 @@
 #define I(x, y, z)			((y) ^ ((x) | ~(z)))
 
 /*
- * The MD5 transformation for all four rounds.
+ * The FT_MD5 transformation for all four rounds.
  */
 #define STEP(f, a, b, c, d, x, t, s) \
 	(a) += f((b), (c), (d)) + (x) + (t); \
@@ -72,16 +72,16 @@
  */
 #if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
 #define SET(n) \
-	(*(MD5_u32plus *)&ptr[(n) * 4])
+	(*(FT_MD5_u32plus *)&ptr[(n) * 4])
 #define GET(n) \
 	SET(n)
 #else
 #define SET(n) \
 	(ctx->block[(n)] = \
-	(MD5_u32plus)ptr[(n) * 4] | \
-	((MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
-	((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
-	((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
+	(FT_MD5_u32plus)ptr[(n) * 4] | \
+	((FT_MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
+	((FT_MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
+	((FT_MD5_u32plus)ptr[(n) * 4 + 3] << 24))
 #define GET(n) \
 	(ctx->block[(n)])
 #endif
@@ -90,11 +90,11 @@
  * This processes one or more 64-byte data blocks, but does NOT update
  * the bit counters.  There are no alignment requirements.
  */
-static const void *body(MD5_CTX *ctx, const void *data, unsigned long size)
+static const void *body(FT_MD5_CTX *ctx, const void *data, unsigned long size)
 {
 	const unsigned char *ptr;
-	MD5_u32plus a, b, c, d;
-	MD5_u32plus saved_a, saved_b, saved_c, saved_d;
+	FT_MD5_u32plus a, b, c, d;
+	FT_MD5_u32plus saved_a, saved_b, saved_c, saved_d;
 
 	ptr = (const unsigned char *)data;
 
@@ -197,7 +197,7 @@ static const void *body(MD5_CTX *ctx, const void *data, unsigned long size)
 	return ptr;
 }
 
-void MD5_Init(MD5_CTX *ctx)
+void FT_MD5_Init(FT_MD5_CTX *ctx)
 {
 	ctx->a = 0x67452301;
 	ctx->b = 0xefcdab89;
@@ -208,9 +208,9 @@ void MD5_Init(MD5_CTX *ctx)
 	ctx->hi = 0;
 }
 
-void MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size)
+void FT_MD5_Update(FT_MD5_CTX *ctx, const void *data, unsigned long size)
 {
-	MD5_u32plus saved_lo;
+	FT_MD5_u32plus saved_lo;
 	unsigned long used, available;
 
 	saved_lo = ctx->lo;
@@ -242,7 +242,7 @@ void MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size)
 	memcpy(ctx->buffer, data, size);
 }
 
-void MD5_Final(unsigned char *result, MD5_CTX *ctx)
+void FT_MD5_Final(unsigned char *result, FT_MD5_CTX *ctx)
 {
 	unsigned long used, available;
 

--- a/src/freetype/base/md5.h
+++ b/src/freetype/base/md5.h
@@ -1,6 +1,6 @@
 /*
  * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
- * MD5 Message-Digest Algorithm (RFC 1321).
+ * FT_MD5 Message-Digest Algorithm (RFC 1321).
  *
  * Homepage:
  * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
@@ -25,21 +25,21 @@
 
 #ifdef HAVE_OPENSSL
 #include <openssl/md5.h>
-#elif !defined(_MD5_H)
-#define _MD5_H
+#elif !defined(_FT_MD5_H)
+#define _FT_MD5_H
 
 /* Any 32-bit or wider unsigned integer data type will do */
-typedef unsigned int MD5_u32plus;
+typedef unsigned int FT_MD5_u32plus;
 
 typedef struct {
-	MD5_u32plus lo, hi;
-	MD5_u32plus a, b, c, d;
+	FT_MD5_u32plus lo, hi;
+	FT_MD5_u32plus a, b, c, d;
 	unsigned char buffer[64];
-	MD5_u32plus block[16];
-} MD5_CTX;
+	FT_MD5_u32plus block[16];
+} FT_MD5_CTX;
 
-extern void MD5_Init(MD5_CTX *ctx);
-extern void MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size);
-extern void MD5_Final(unsigned char *result, MD5_CTX *ctx);
+extern void FT_MD5_Init(FT_MD5_CTX *ctx);
+extern void FT_MD5_Update(FT_MD5_CTX *ctx, const void *data, unsigned long size);
+extern void FT_MD5_Final(unsigned char *result, FT_MD5_CTX *ctx);
 
 #endif


### PR DESCRIPTION
- Function collisions defined in freetype inhibit linking against openssl.
- Functions renamed with FT_*, which is the fix upstream in Freetype.