### PR TITLE
Cmake osc tuio build fix

### DIFF
--- a/blocks/OSC/proj/cmake/OSCConfig.cmake
+++ b/blocks/OSC/proj/cmake/OSCConfig.cmake
@@ -8,4 +8,16 @@ if( NOT TARGET OSC )
 
 	target_include_directories( OSC PUBLIC "${OSC_SOURCE_PATH}" )
 	target_include_directories( OSC SYSTEM BEFORE PUBLIC "${CINDER_PATH}/include" )
+
+	if( NOT TARGET cinder )
+		    include( "${CINDER_PATH}/proj/cmake/configure.cmake" )
+		    find_package( cinder REQUIRED PATHS
+		        "${CINDER_PATH}/${CINDER_LIB_DIRECTORY}"
+		        "$ENV{CINDER_PATH}/${CINDER_LIB_DIRECTORY}" )
+	endif()
+	target_link_libraries( OSC  PRIVATE cinder )
+	
 endif()
+
+
+

--- a/blocks/TUIO/proj/cmake/TUIOConfig.cmake
+++ b/blocks/TUIO/proj/cmake/TUIOConfig.cmake
@@ -6,9 +6,16 @@ if( NOT TARGET TUIO )
 	target_compile_options( TUIO PUBLIC "-std=c++11" )
 	target_include_directories( TUIO PUBLIC "${TUIO_SOURCE_PATH}" )
 
+	if( NOT TARGET cinder )
+	    include( "${CINDER_PATH}/proj/cmake/configure.cmake" )
+	    find_package( cinder REQUIRED PATHS
+	        "${CINDER_PATH}/${CINDER_LIB_DIRECTORY}"
+	        "$ENV{CINDER_PATH}/${CINDER_LIB_DIRECTORY}" )
+	endif()
+
 	# Add OSC block as a dependency
 	get_filename_component( OSC_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../OSC/proj/cmake" ABSOLUTE )
 	find_package( OSC REQUIRED PATHS "${OSC_MODULE_PATH}" )
 	add_dependencies( TUIO OSC )
-	target_link_libraries( TUIO OSC )
+	target_link_libraries( TUIO PUBLIC OSC PRIVATE cinder)
 endif()

--- a/blocks/TUIO/samples/TuioListener/proj/cmake/CMakeLists.txt
+++ b/blocks/TUIO/samples/TuioListener/proj/cmake/CMakeLists.txt
@@ -9,7 +9,7 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/TUIOListenerApp.cpp
+	SOURCES     ${APP_PATH}/src/TuioListenerApp.cpp
 	CINDER_PATH ${CINDER_PATH}
 	BLOCKS		TUIO
 )


### PR DESCRIPTION

This fixes _unresolved linker errors_ for OSC and TUIO examples. As well as a typo fix to build the TuioListener example. 