### PR TITLE
(macosx) Fix window pos when on secondary display

### DIFF
--- a/include/cinder/app/cocoa/AppImplMac.h
+++ b/include/cinder/app/cocoa/AppImplMac.h
@@ -125,6 +125,7 @@
 - (cinder::DisplayRef)getDisplay;
 - (cinder::app::RendererRef)getRenderer;
 - (void*)getNative;
+- (void)updatePosRelativeToPrimaryDisplay;
 
 - (void)windowMovedNotification:(NSNotification *)notification;
 - (void)windowWillCloseNotification:(NSNotification *)notification;

--- a/src/cinder/app/cocoa/AppImplMac.mm
+++ b/src/cinder/app/cocoa/AppImplMac.mm
@@ -110,14 +110,19 @@ using namespace cinder::app;
 {
 	mApp->getRenderer()->makeCurrentContext();
 
+	// update positions for all windows, their frames might not have been correct when created.
+	for( WindowImplBasicCocoa* winIt in mWindows ) {
+		[winIt updatePosRelativeToPrimaryDisplay];
+	}
+
 	mApp->privateSetup__();
 	
-	// give all windows initial resizes
+	// call initial window resize signals
 	for( WindowImplBasicCocoa* winIt in mWindows ) {
 		[winIt->mCinderView makeCurrentContext];
 		[self setActiveWindow:winIt];
-		[winIt resize];
-	}	
+		winIt->mWindowRef->emitResize();
+	}
 	
 	// when available, make the first window the active window
 	[self setActiveWindow:[mWindows firstObject]];


### PR DESCRIPTION
This is in addition to #1489 to fix the window position during the app's initial resize() call.

~~The position still seems to be off during `App::setup()`, I'm not sure yet if that can be fixed.~~ fixed with 1cbee56.

Test app code: http://pastebin.com/BReFbN2C
