### PR TITLE
Fix for MSW MessageBox crash.

### DIFF
--- a/src/cinder/app/msw/AppImplMsw.cpp
+++ b/src/cinder/app/msw/AppImplMsw.cpp
@@ -961,7 +961,8 @@ LRESULT CALLBACK WndProc(	HWND	mWnd,			// Handle For This Window
 		}
 		break;
 		case WM_PAINT:
-			impl->draw();
+			if( impl->getAppImpl()->setupHasBeenCalled() )
+				impl->draw();
 		break;
 		case WM_TOUCH:
 			impl->onTouch( mWnd, wParam, lParam );


### PR DESCRIPTION
On my machine (running Windows 10), when I have a bug in my app's ```setup()``` function, Windows creates a ```MessageBox``` to show the error. This generates a ```WM_PAINT``` event which in turn calls the app's ```draw()``` function. Uninitialized member variables might then throw a new error, crashing the application. This is rather confusing. As a fix, I properly check if ```setup()``` has been called before calling ```draw()```. That way, the initial error message for which a ```MessageBox``` was created is shown, making debugging a lot easier.