### PR TITLE
Fix format string for wide string buffer

### DIFF
--- a/src/videoInput/videoInput.cpp
+++ b/src/videoInput/videoInput.cpp
@@ -330,10 +330,9 @@ void videoDevice::NukeDownstream(IBaseFilter *pBF){
 
 void videoDevice::destroyGraph(){
 	HRESULT hr = NULL;
- 	int FuncRetval=0;
- 	int NumFilters=0;
+	int FuncRetval=0;
+	int NumFilters=0;
 
-	int i = 0;
 	while (hr == NOERROR)	
 	{
 		IEnumFilters * pEnum = 0;
@@ -351,31 +350,18 @@ void videoDevice::destroyGraph(){
 			hr = pFilter->QueryFilterInfo(&FilterInfo);
 			FilterInfo.pGraph->Release();
 
-			int count = 0;
-			WCHAR buffer[255];
-			memset(buffer, 0, 255 * sizeof(WCHAR));
-						
-			while( FilterInfo.achName[count] != 0x00 ) 
-			{
-				buffer[count] = FilterInfo.achName[count];
-				count++;
-			}
-			
-			if(verbose)printf("SETUP: removing filter %S...\n", buffer);
+			if(verbose)printf("SETUP: removing filter %S...\n", FilterInfo.achName);
 			hr = pGraph->RemoveFilter(pFilter);
 			if (FAILED(hr)) { if(verbose)printf("SETUP: pGraph->RemoveFilter() failed. \n"); return; }
-			if(verbose)printf("SETUP: filter removed %S  \n",buffer);
-			
+			if(verbose)printf("SETUP: filter removed %S  \n", FilterInfo.achName);
+
 			pFilter->Release();
 			pFilter = NULL;
 		}
 		else break;
 		pEnum->Release();
 		pEnum = NULL;
-		i++;
 	}
-
- return;
 }
 
 

--- a/src/videoInput/videoInput.cpp
+++ b/src/videoInput/videoInput.cpp
@@ -364,7 +364,7 @@ void videoDevice::destroyGraph(){
 			if(verbose)printf("SETUP: removing filter %S...\n", buffer);
 			hr = pGraph->RemoveFilter(pFilter);
 			if (FAILED(hr)) { if(verbose)printf("SETUP: pGraph->RemoveFilter() failed. \n"); return; }
-			if(verbose)printf("SETUP: filter removed %s  \n",buffer);
+			if(verbose)printf("SETUP: filter removed %S  \n",buffer);
 			
 			pFilter->Release();
 			pFilter = NULL;


### PR DESCRIPTION
Fixes bug mentioned in #1599 and removes some unnecessary code in the sourrounding function. 

The actual fix is contained in the first commit (just replacing ` s`with `S`)
The second commit is removing an unnecessary temporary string buffer  