### PR TITLE
simplify rand

### DIFF
--- a/include/cinder/Rand.h
+++ b/include/cinder/Rand.h
@@ -38,7 +38,10 @@ class Rand {
 	{}
 
 	//! Re-seeds the random generator
-	void seed( uint32_t seedValue );
+	void seed( uint32_t seedValue )
+	{
+		mBase.seed(seedValue);
+	}
 
 	//! returns a random boolean value
 	bool nextBool()
@@ -154,10 +157,16 @@ class Rand {
 
 	// STATICS
 	//! Resets the static random generator to a random seed based on the clock
-	static void randomize();
+	static void randomize()
+	{
+		sBase.seed(std::random_device{}());
+	}
 
 	//! Resets the static random generator to the specific seed \a seedValue
-	static void	randSeed( uint32_t seedValue );
+	static void	randSeed( uint32_t seedValue )
+	{
+		sBase.seed(seedValue);
+	}
 
 	//! returns a random boolean value
 	static bool randBool()

--- a/include/cinder/Rand.h
+++ b/include/cinder/Rand.h
@@ -5,9 +5,9 @@
  Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright notice, this list of conditions and
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
 	the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
 	the following disclaimer in the documentation and/or other materials provided with the distribution.
 
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
@@ -25,27 +25,27 @@
 #include <random>
 #include "cinder/Vector.h"
 
-namespace cinder {	
-	
+namespace cinder {
+
 class Rand {
  public:
 	Rand()
 		: mBase( 214u ), mHaveNextNextGaussian( false )
 	{}
-	
+
 	Rand( uint32_t seed )
 		: mBase( seed ), mHaveNextNextGaussian( false )
 	{}
 
 	//! Re-seeds the random generator
 	void seed( uint32_t seedValue );
-	
+
 	//! returns a random boolean value
 	bool nextBool()
 	{
 		return mBase() & 1;
 	}
-	
+
 	//! returns a random integer in the range [-2147483648,2147483647]
 	int32_t nextInt()
 	{
@@ -57,7 +57,7 @@ class Rand {
 	{
 		return mBase();
 	}
-	
+
 	//! returns a random integer in the range [0,v)
 	int32_t nextInt( int32_t v )
 	{
@@ -71,31 +71,31 @@ class Rand {
 		if( v == 0 ) return 0;
 		return mBase() % v;
 	}
-	
+
 	//! returns a random integer in the range [a,b)
 	int32_t nextInt( int32_t a, int32_t b )
 	{
 		return nextInt( b - a ) + a;
 	}
-	
+
 	//! returns a random float in the range [0.0f,1.0f)
 	float nextFloat()
 	{
 		return mFloatGen(mBase);
 	}
-	
+
 	//! returns a random float in the range [0.0f,v)
 	float nextFloat( float v )
 	{
 		return mFloatGen(mBase) * v;
 	}
-	
+
 	//! returns a random float in the range [a,b)
 	float nextFloat( float a, float b )
 	{
 		return mFloatGen(mBase) * ( b - a ) + a;
 	}
-	
+
 	//! returns a random float in the range [a,b] or the range [-b,-a)
 	float posNegFloat( float a, float b )
 	{
@@ -104,32 +104,32 @@ class Rand {
 		else
 			return -nextFloat( a, b );
 	}
-	
-	//! returns a random vec3 that represents a point on the unit sphere	
+
+	//! returns a random vec3 that represents a point on the unit sphere
 	vec3 nextVec3()
 	{
 		float phi = nextFloat( (float)M_PI * 2.0f );
 		float costheta = nextFloat( -1.0f, 1.0f );
-		
-		float rho = math<float>::sqrt( 1.0f - costheta * costheta ); 
+
+		float rho = math<float>::sqrt( 1.0f - costheta * costheta );
 		float x = rho * math<float>::cos( phi );
 		float y = rho * math<float>::sin( phi );
 		float z = costheta;
-		
+
 		return vec3( x, y, z );
 	}
 
-	//! returns a random vec2 that represents a point on the unit circle	
+	//! returns a random vec2 that represents a point on the unit circle
 	vec2 nextVec2()
 	{
 		float theta = nextFloat( (float)M_PI * 2.0f );
 		return vec2( math<float>::cos( theta ), math<float>::sin( theta ) );
 	}
-    
-    //! returns a random float via Gaussian distribution
-    float nextGaussian()
-    {
-        if( mHaveNextNextGaussian ) {
+
+	//! returns a random float via Gaussian distribution
+	float nextGaussian()
+	{
+		if( mHaveNextNextGaussian ) {
 			mHaveNextNextGaussian = false;
 			return mNextNextGaussian;
 		}
@@ -144,27 +144,27 @@ class Rand {
 			while( s >= 1.0f || s == 0.0f );
 
 			float m = math<float>::sqrt(-2.0f * math<float>::log(s)/s);
-            
+
 			mNextNextGaussian       = v2 * m;
 			mHaveNextNextGaussian   = true;
 
-            return v1 * m;
-        }
-    }    
-	
+			return v1 * m;
+		}
+	}
+
 	// STATICS
 	//! Resets the static random generator to a random seed based on the clock
 	static void randomize();
-	
+
 	//! Resets the static random generator to the specific seed \a seedValue
 	static void	randSeed( uint32_t seedValue );
-	
+
 	//! returns a random boolean value
 	static bool randBool()
 	{
 		return sBase() & 1;
 	}
-	
+
 	//! returns a random integer in the range [-2147483648,2147483647]
 	static int32_t randInt()
 	{
@@ -176,7 +176,7 @@ class Rand {
 	{
 		return sBase();
 	}
-	
+
 	//! returns a random integer in the range [0,v)
 	static int32_t randInt( int32_t v )
 	{
@@ -190,31 +190,31 @@ class Rand {
 		if( v == 0 ) return 0;
 		else return sBase() % v;
 	}
-	
+
 	//! returns a random integer in the range [a,b)
 	static int32_t randInt( int32_t a, int32_t b )
 	{
 		return randInt( b - a ) + a;
 	}
-	
+
 	//! returns a random float in the range [0.0f,1.0f)
 	static float randFloat()
 	{
 		return sFloatGen(sBase);
 	}
-	
+
 	//! returns a random float in the range [0.0f,v)
 	static float randFloat( float v )
 	{
 		return sFloatGen(sBase) * v;
 	}
-	
+
 	//! returns a random float in the range [a,b)
 	static float randFloat( float a, float b )
 	{
 		return sFloatGen(sBase) * ( b - a ) + a;
 	}
-	
+
 	//! returns a random float in the range [a,b) or the range [-b,-a)
 	static float randPosNegFloat( float a, float b )
 	{
@@ -223,18 +223,18 @@ class Rand {
 		else
 			return -randFloat( a, b );
 	}
-	
+
 	//! returns a random vec3 that represents a point on the unit sphere
 	static vec3 randVec3()
 	{
 		float phi = randFloat( (float)M_PI * 2.0f );
 		float costheta = randFloat( -1.0f, 1.0f );
-		
-		float rho = math<float>::sqrt( 1.0f - costheta * costheta ); 
+
+		float rho = math<float>::sqrt( 1.0f - costheta * costheta );
 		float x = rho * math<float>::cos( phi );
 		float y = rho * math<float>::sin( phi );
 		float z = costheta;
-		
+
 		return vec3( x, y, z );
 	}
 
@@ -244,10 +244,10 @@ class Rand {
 		float theta = randFloat( (float)M_PI * 2.0f );
 		return vec2( math<float>::cos( theta ), math<float>::sin( theta ) );
 	}
-    
-    //! returns a random float via Gaussian distribution; refactor later
-    static float randGaussian() 
-    {
+
+	//! returns a random float via Gaussian distribution; refactor later
+	static float randGaussian()
+	{
 		static bool  sHaveNextNextGaussian = false;
 		static float sNextNextGaussian;
 
@@ -269,17 +269,17 @@ class Rand {
 
 			sNextNextGaussian       = v2 * m;
 			sHaveNextNextGaussian   = true;
-            
+
 			return v1 * m;
 		}
 	}
-	
+
   private:
 	std::mt19937 mBase;
-	std::uniform_real_distribution<float>	mFloatGen;	
-    float	mNextNextGaussian;    
-    bool	mHaveNextNextGaussian;
-    
+	std::uniform_real_distribution<float>	mFloatGen;
+	float	mNextNextGaussian;
+	bool	mHaveNextNextGaussian;
+
 	static std::mt19937 sBase;
 	static std::uniform_real_distribution<float> sFloatGen;
 };
@@ -318,6 +318,6 @@ inline vec3 randVec3() { return Rand::randVec3(); }
 inline vec2 randVec2() { return Rand::randVec2(); }
 
 //! returns a random float via Gaussian distribution
-inline float randGaussian() { return Rand::randGaussian(); }    
+inline float randGaussian() { return Rand::randGaussian(); }
 
 } // namespace cinder

--- a/include/cinder/Rand.h
+++ b/include/cinder/Rand.h
@@ -29,12 +29,10 @@ namespace cinder {
 
 class Rand {
  public:
-	Rand()
-		: mBase( 214u ), mHaveNextNextGaussian( false )
-	{}
+	Rand() = default;
 
 	Rand( uint32_t seed )
-		: mBase( seed ), mHaveNextNextGaussian( false )
+		: mBase( seed )
 	{}
 
 	//! Re-seeds the random generator
@@ -132,31 +130,11 @@ class Rand {
 	//! returns a random float via Gaussian distribution
 	float nextGaussian()
 	{
-		if( mHaveNextNextGaussian ) {
-			mHaveNextNextGaussian = false;
-			return mNextNextGaussian;
-		}
-		else {
-			float v1, v2, s;
-			do {
-				v1 = 2.0f * nextFloat() - 1.0f;
-				v2 = 2.0f * nextFloat() - 1.0f;
-
-				s = v1 * v1 + v2 * v2;
-			}
-			while( s >= 1.0f || s == 0.0f );
-
-			float m = math<float>::sqrt(-2.0f * math<float>::log(s)/s);
-
-			mNextNextGaussian       = v2 * m;
-			mHaveNextNextGaussian   = true;
-
-			return v1 * m;
-		}
+		return mNormDist(mBase);
 	}
 
 	// STATICS
-	//! Resets the static random generator to a random seed based on the clock
+	//! Resets the static random generator to a random seed
 	static void randomize()
 	{
 		sBase.seed(std::random_device{}());
@@ -254,40 +232,17 @@ class Rand {
 		return vec2( math<float>::cos( theta ), math<float>::sin( theta ) );
 	}
 
-	//! returns a random float via Gaussian distribution; refactor later
+	//! returns a random float via Gaussian distribution
 	static float randGaussian()
 	{
-		static bool  sHaveNextNextGaussian = false;
-		static float sNextNextGaussian;
-
-		if( sHaveNextNextGaussian ) {
-			sHaveNextNextGaussian = false;
-			return sNextNextGaussian;
-		}
-		else {
-			float v1, v2, s;
-			do {
-				v1 = 2.0f * sFloatGen(sBase) - 1.0f;
-				v2 = 2.0f * sFloatGen(sBase) - 1.0f;
-
-				s = v1 * v1 + v2 * v2;
-			}
-			while( s >= 1.0f || s == 0.0f );
-
-			float m = math<float>::sqrt(-2.0f * math<float>::log(s)/s);
-
-			sNextNextGaussian       = v2 * m;
-			sHaveNextNextGaussian   = true;
-
-			return v1 * m;
-		}
+		static std::normal_distribution<float> dist{};
+		return dist(sBase);
 	}
 
   private:
 	std::mt19937 mBase;
 	std::uniform_real_distribution<float>	mFloatGen;
-	float	mNextNextGaussian;
-	bool	mHaveNextNextGaussian;
+	std::normal_distribution<float>			mNormDist;
 
 	static std::mt19937 sBase;
 	static std::uniform_real_distribution<float> sFloatGen;

--- a/src/cinder/Rand.cpp
+++ b/src/cinder/Rand.cpp
@@ -29,19 +29,4 @@ namespace cinder {
 std::mt19937 Rand::sBase( 310u );
 std::uniform_real_distribution<float> Rand::sFloatGen;
 
-void Rand::randomize()
-{
-	sBase.seed(std::random_device{}());
-}
-
-void Rand::randSeed( uint32_t seed )
-{
-	sBase.seed(seed);
-}
-
-void Rand::seed( uint32_t seedValue )
-{
-	mBase.seed( seedValue );
-}
-
 } // ci

--- a/src/cinder/Rand.cpp
+++ b/src/cinder/Rand.cpp
@@ -23,12 +23,6 @@
 */
 
 #include "cinder/Rand.h"
-#if defined( CINDER_COCOA )
-#	include <mach/mach.h>
-#	include <mach/mach_time.h>
-#elif (defined( CINDER_MSW ) || defined( CINDER_WINRT ))
-#	include <windows.h>
-#endif
 
 namespace cinder {
 	
@@ -37,13 +31,7 @@ std::uniform_real_distribution<float> Rand::sFloatGen;
 
 void Rand::randomize()
 {
-#if defined( CINDER_COCOA )
-	sBase = std::mt19937( (uint32_t)( mach_absolute_time() & 0xFFFFFFFF ) );
-#elif defined( CINDER_WINRT)
-	sBase = std::mt19937( static_cast<unsigned long>(::GetTickCount64()) );
-#else
-	sBase = std::mt19937( ::GetTickCount() );
-#endif
+	sBase.seed(std::random_device{}());
 }
 
 void Rand::randSeed( uint32_t seed )

--- a/src/cinder/Rand.cpp
+++ b/src/cinder/Rand.cpp
@@ -25,7 +25,7 @@
 #include "cinder/Rand.h"
 
 namespace cinder {
-	
+
 std::mt19937 Rand::sBase( 310u );
 std::uniform_real_distribution<float> Rand::sFloatGen;
 
@@ -36,12 +36,12 @@ void Rand::randomize()
 
 void Rand::randSeed( uint32_t seed )
 {
-	sBase = std::mt19937( seed );
+	sBase.seed(seed);
 }
 
 void Rand::seed( uint32_t seedValue )
 {
-	mBase = std::mt19937( seedValue );
+	mBase.seed( seedValue );
 }
 
 } // ci


### PR DESCRIPTION
This PR simplifies the implementation of `ci::Rand` and the free functions in Rand.h. Mainly by
- Replacing the OS-specific seeding methods by std::random_device
- Replacing the hand-roled gaussian distribution reneration functions by `std::normal_distribution`.

I've run a few microbenchmarks to verify that this doesn't degrade the performance of the random number generation on my particular platform (VS2015 U3, Win10), but I can revert a particular change if someone knows for a fact that the stanard library facilities were not used for a particular reason.