### PR TITLE
Distance to curve.

### DIFF
--- a/include/cinder/CinderMath.h
+++ b/include/cinder/CinderMath.h
@@ -289,6 +289,39 @@ int solveCubic( T a, T b, T c, T d, T result[3] );
 //! Returns the closest point to \a testPoint on the boundary of the ellipse defined by \a center, \a axisA and \a axisB. Algorithm due to David Eberly, http://www.geometrictools.com/Documentation/DistancePointEllipseEllipsoid.pdf
 glm::vec2 getClosestPointEllipse( const glm::vec2& center, const glm::vec2& axisA, const glm::vec2& axisB, const glm::vec2& testPoint );
 
+//! Returns the closest point to \a testPoint on the linear curve defined by the 2 \a controlPoints.
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointLinear( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> &testPoint );
+//! Returns the closest point to \a testPoint on the linear curve defined by the control points \a p0 and \a p1.
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointLinear( const glm::tvec2<T, glm::defaultp> &p0, const glm::tvec2<T, glm::defaultp> &p1, const glm::tvec2<T, glm::defaultp> &testPoint )
+{
+	glm::tvec2<T, glm::defaultp> controlPoints[] = { p0, p1 };
+	return getClosestPointLinear<T>( controlPoints, testPoint );
+}
+
+//! Returns the closest point to \a testPoint on the linear curve defined by the 3 \a controlPoints. Algorithm due to Olivier Besson, http://blog.gludion.com/2009/08/distance-to-quadratic-bezier-curve.html
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointQuadratic( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> &testPoint );
+//! Returns the closest point to \a testPoint on the linear curve defined by the control points \a p0, \a p1 and \a p2. Algorithm due to Olivier Besson, http://blog.gludion.com/2009/08/distance-to-quadratic-bezier-curve.html
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointQuadratic( const glm::tvec2<T, glm::defaultp> &p0, const glm::tvec2<T, glm::defaultp> &p1, const glm::tvec2<T, glm::defaultp> &p2, const glm::tvec2<T, glm::defaultp> &testPoint )
+{
+	glm::tvec2<T, glm::defaultp> controlPoints[] = { p0, p1, p2 };
+	return getClosestPointQuadratic<T>( controlPoints, testPoint );
+}
+
+//! Returns the closest point to \a testPoint on the cubic curve defined by the 4 \a controlPoints. Algorithm due to Philip J. Schneider, https://github.com/erich666/GraphicsGems/blob/master/gems/NearestPoint.c
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointCubic( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> &testPoint );
+//! Returns the closest point to \a testPoint on the cubic curve defined by the control points \a p0, \a p1, \a p2 and \a p3. Algorithm due to Philip J. Schneider, https://github.com/erich666/GraphicsGems/blob/master/gems/NearestPoint.c
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointCubic( const glm::tvec2<T, glm::defaultp> &p0, const glm::tvec2<T, glm::defaultp> &p1, const glm::tvec2<T, glm::defaultp> &p2, const glm::tvec2<T, glm::defaultp> &p3, const glm::tvec2<T, glm::defaultp> &testPoint )
+{
+	glm::tvec2<T, glm::defaultp> controlPoints[] = { p0, p1, p2, p3 };
+	return getClosestPointCubic<T>( controlPoints, testPoint );
+}
+
 union half_float
 {
 	uint16_t u;

--- a/include/cinder/CinderMath.h
+++ b/include/cinder/CinderMath.h
@@ -289,10 +289,10 @@ int solveCubic( T a, T b, T c, T d, T result[3] );
 //! Returns the closest point to \a testPoint on the boundary of the ellipse defined by \a center, \a axisA and \a axisB. Algorithm due to David Eberly, http://www.geometrictools.com/Documentation/DistancePointEllipseEllipsoid.pdf
 glm::vec2 getClosestPointEllipse( const glm::vec2& center, const glm::vec2& axisA, const glm::vec2& axisB, const glm::vec2& testPoint );
 
-//! Returns the closest point to \a testPoint on the linear curve defined by the 2 \a controlPoints.
+//! Returns the closest point to \a testPoint on the line defined by the 2 \a controlPoints.
 template<typename T>
 glm::tvec2<T, glm::defaultp> getClosestPointLinear( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> &testPoint );
-//! Returns the closest point to \a testPoint on the linear curve defined by the control points \a p0 and \a p1.
+//! Returns the closest point to \a testPoint on the line defined by the control points \a p0 and \a p1.
 template<typename T>
 glm::tvec2<T, glm::defaultp> getClosestPointLinear( const glm::tvec2<T, glm::defaultp> &p0, const glm::tvec2<T, glm::defaultp> &p1, const glm::tvec2<T, glm::defaultp> &testPoint )
 {
@@ -300,10 +300,10 @@ glm::tvec2<T, glm::defaultp> getClosestPointLinear( const glm::tvec2<T, glm::def
 	return getClosestPointLinear<T>( controlPoints, testPoint );
 }
 
-//! Returns the closest point to \a testPoint on the linear curve defined by the 3 \a controlPoints. Algorithm due to Olivier Besson, http://blog.gludion.com/2009/08/distance-to-quadratic-bezier-curve.html
+//! Returns the closest point to \a testPoint on the quadratic curve defined by the 3 \a controlPoints. Algorithm due to Olivier Besson, http://blog.gludion.com/2009/08/distance-to-quadratic-bezier-curve.html
 template<typename T>
 glm::tvec2<T, glm::defaultp> getClosestPointQuadratic( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> &testPoint );
-//! Returns the closest point to \a testPoint on the linear curve defined by the control points \a p0, \a p1 and \a p2. Algorithm due to Olivier Besson, http://blog.gludion.com/2009/08/distance-to-quadratic-bezier-curve.html
+//! Returns the closest point to \a testPoint on the quadratic curve defined by the control points \a p0, \a p1 and \a p2. Algorithm due to Olivier Besson, http://blog.gludion.com/2009/08/distance-to-quadratic-bezier-curve.html
 template<typename T>
 glm::tvec2<T, glm::defaultp> getClosestPointQuadratic( const glm::tvec2<T, glm::defaultp> &p0, const glm::tvec2<T, glm::defaultp> &p1, const glm::tvec2<T, glm::defaultp> &p2, const glm::tvec2<T, glm::defaultp> &testPoint )
 {

--- a/include/cinder/Path2d.h
+++ b/include/cinder/Path2d.h
@@ -114,8 +114,13 @@ class Path2d {
 
 	//! Returns the minimum distance from point \a pt to the path
 	float	calcDistance( const vec2 &pt ) const;
-	//! Returns the minimum distance from point \a pt to segment \a segment.
+	//! Returns the minimum distance from point \a pt to segment \a segment
 	float	calcDistance( const vec2 &pt, size_t segment ) const { return calcDistance( pt, segment, 0 ); }
+
+	//! Returns the point on the path closest to \a pt.
+	vec2	calcClosestPoint( const vec2 &pt ) const;
+	//! Returns the point on segment \a segment that is closest to \a pt
+	vec2	calcClosestPoint( const vec2 &pt, size_t segment ) const { return calcClosestPoint( pt, segment, 0 ); }
 
 	//! Calculates the length of the Path2d
 	float	calcLength() const;
@@ -151,8 +156,11 @@ class Path2d {
 	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>. The \a firstPoint parameter can be used as an optimization if known.
 	vec2	getSegmentTangent( size_t segment, size_t firstPoint, float t ) const;
 	
-	//! Returns the minimum distance from point \a pt to segment \a segment. The \a firstPoint parameter can be used as an optimization if known.
+	//! Returns the minimum distance from point \a pt to segment \a segment. The \a firstPoint parameter can be used as an optimization if known, otherwise pass 0.
 	float	calcDistance( const vec2 &pt, size_t segment, size_t firstPoint ) const;
+
+	//! Returns the point on segment \a segment that is closest to \a pt. The \a firstPoint parameter can be used as an optimization if known, otherwise pass 0.
+	vec2	calcClosestPoint( const vec2 &pt, size_t segment, size_t firstPoint ) const;
 	
 	std::vector<vec2>			mPoints;
 	std::vector<SegmentType>	mSegments;

--- a/include/cinder/Path2d.h
+++ b/include/cinder/Path2d.h
@@ -67,11 +67,11 @@ class Path2d {
 	//! Returns the point on the curve at parameter \a t, which lies in the range <tt>[0,1]</tt>
 	vec2	getPosition( float t ) const;
 	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>
-	vec2	getSegmentPosition( size_t segment, float t ) const { return getSegmentPosition( segment, 0, t ); }
+	vec2	getSegmentPosition( size_t segment, float t ) const;
 	//! Returns the tangent on the curve at parameter \a t, which lies in the range <tt>[0,1]</tt>
 	vec2	getTangent( float t ) const;
 	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>
-	vec2	getSegmentTangent( size_t segment, float t ) const { return getSegmentTangent( segment, 0, t ); }
+	vec2	getSegmentTangent( size_t segment, float t ) const;
 
 	//! Stores into \a segment the segment # associated with \a t, and if \a relativeT is not NULL, the t relative to its segment, in the range <tt>[0,1]</tt>
 	void	getSegmentRelativeT( float t, size_t *segment, float *relativeT ) const;
@@ -150,11 +150,6 @@ class Path2d {
   private:
 	void	arcHelper( const vec2 &center, float radius, float startRadians, float endRadians, bool forward );
 	void	arcSegmentAsCubicBezier( const vec2 &center, float radius, float startRadians, float endRadians );
-
-	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>. The \a firstPoint parameter can be used as an optimization if known.
-	vec2	getSegmentPosition( size_t segment, size_t firstPoint, float t ) const;
-	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>. The \a firstPoint parameter can be used as an optimization if known.
-	vec2	getSegmentTangent( size_t segment, size_t firstPoint, float t ) const;
 	
 	//! Returns the minimum distance from point \a pt to segment \a segment. The \a firstPoint parameter can be used as an optimization if known, otherwise pass 0.
 	float	calcDistance( const vec2 &pt, size_t segment, size_t firstPoint ) const;

--- a/include/cinder/Path2d.h
+++ b/include/cinder/Path2d.h
@@ -153,12 +153,6 @@ class Path2d {
 	
 	//! Returns the minimum distance from point \a pt to segment \a segment. The \a firstPoint parameter can be used as an optimization if known.
 	float	calcDistance( const vec2 &pt, size_t segment, size_t firstPoint ) const;
-	//! The \a firstPoint parameter can be used as an optimization if known.
-	float	calcDistanceLinear( const vec2 &pt, size_t segment, size_t firstPoint ) const;
-	//! The \a firstPoint parameter can be used as an optimization if known.
-	float	calcDistanceQuadratic( const vec2 &pt, size_t segment, size_t firstPoint ) const;
-	//! The \a firstPoint parameter can be used as an optimization if known.
-	float	calcDistanceCubic( const vec2 &pt, size_t segment, size_t firstPoint ) const;
 	
 	std::vector<vec2>			mPoints;
 	std::vector<SegmentType>	mSegments;

--- a/include/cinder/Path2d.h
+++ b/include/cinder/Path2d.h
@@ -117,9 +117,9 @@ class Path2d {
 	//! Returns the minimum distance from point \a pt to segment \a segment
 	float	calcDistance( const vec2 &pt, size_t segment ) const { return calcDistance( pt, segment, 0 ); }
 
-	//! Returns the point on the path closest to \a pt.
+	//! Returns the point on the path closest to point \a pt.
 	vec2	calcClosestPoint( const vec2 &pt ) const;
-	//! Returns the point on segment \a segment that is closest to \a pt
+	//! Returns the point on segment \a segment that is closest to point \a pt
 	vec2	calcClosestPoint( const vec2 &pt, size_t segment ) const { return calcClosestPoint( pt, segment, 0 ); }
 
 	//! Calculates the length of the Path2d

--- a/include/cinder/Path2d.h
+++ b/include/cinder/Path2d.h
@@ -67,11 +67,11 @@ class Path2d {
 	//! Returns the point on the curve at parameter \a t, which lies in the range <tt>[0,1]</tt>
 	vec2	getPosition( float t ) const;
 	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>
-	vec2	getSegmentPosition( size_t segment, float t ) const;
+	vec2	getSegmentPosition( size_t segment, float t ) const { return getSegmentPosition( segment, 0, t ); }
 	//! Returns the tangent on the curve at parameter \a t, which lies in the range <tt>[0,1]</tt>
 	vec2	getTangent( float t ) const;
 	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>
-	vec2	getSegmentTangent( size_t segment, float t ) const;
+	vec2	getSegmentTangent( size_t segment, float t ) const { return getSegmentTangent( segment, 0, t ); }
 
 	//! Stores into \a segment the segment # associated with \a t, and if \a relativeT is not NULL, the t relative to its segment, in the range <tt>[0,1]</tt>
 	void	getSegmentRelativeT( float t, size_t *segment, float *relativeT ) const;
@@ -112,6 +112,11 @@ class Path2d {
 	//! Returns whether the point \a pt is contained within the boundaries of the path
 	bool	contains( const vec2 &pt ) const;
 
+	//! Returns the minimum distance from point \a pt to the path
+	float	calcDistance( const vec2 &pt ) const;
+	//! Returns the minimum distance from point \a pt to segment \a segment.
+	float	calcDistance( const vec2 &pt, size_t segment ) const { return calcDistance( pt, segment, 0 ); }
+
 	//! Calculates the length of the Path2d
 	float	calcLength() const;
 	//! Calculates the length of a specific segment in the range [\a minT,\a maxT], where \a minT and \a maxT range from 0 to 1 and are relative to the segment
@@ -140,6 +145,20 @@ class Path2d {
   private:
 	void	arcHelper( const vec2 &center, float radius, float startRadians, float endRadians, bool forward );
 	void	arcSegmentAsCubicBezier( const vec2 &center, float radius, float startRadians, float endRadians );
+
+	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>. The \a firstPoint parameter can be used as an optimization if known.
+	vec2	getSegmentPosition( size_t segment, size_t firstPoint, float t ) const;
+	//! Returns the point in segment # \a segment in the range <tt>[0,getNumSegments())</tt> at parameter \a t in the range <tt>[0,1]</tt>. The \a firstPoint parameter can be used as an optimization if known.
+	vec2	getSegmentTangent( size_t segment, size_t firstPoint, float t ) const;
+	
+	//! Returns the minimum distance from point \a pt to segment \a segment. The \a firstPoint parameter can be used as an optimization if known.
+	float	calcDistance( const vec2 &pt, size_t segment, size_t firstPoint ) const;
+	//! The \a firstPoint parameter can be used as an optimization if known.
+	float	calcDistanceLinear( const vec2 &pt, size_t segment, size_t firstPoint ) const;
+	//! The \a firstPoint parameter can be used as an optimization if known.
+	float	calcDistanceQuadratic( const vec2 &pt, size_t segment, size_t firstPoint ) const;
+	//! The \a firstPoint parameter can be used as an optimization if known.
+	float	calcDistanceCubic( const vec2 &pt, size_t segment, size_t firstPoint ) const;
 	
 	std::vector<vec2>			mPoints;
 	std::vector<SegmentType>	mSegments;

--- a/include/cinder/Shape2d.h
+++ b/include/cinder/Shape2d.h
@@ -75,6 +75,16 @@ class Shape2d {
 	Rectf	calcBoundingBox() const;
 	//! Returns the precise bounding box of the Shape's curves. Slower to calculate than calcBoundingBox().
 	Rectf	calcPreciseBoundingBox() const;
+	//! Returns the minimum distance from the shape to point \a pt.
+	float	calcDistance( const vec2 &pt ) const;
+	//! Returns the minimum distance from the shape to point \a pt. For points outside the shape, the distance is negative.
+	float	calcSignedDistance( const vec2 &pt ) const
+	{
+		if( contains( pt ) )
+			return calcDistance( pt );
+		else
+			return -calcDistance( pt );
+	}
 
 	//! Returns whether the point \a pt is contained within the boundaries of the shape
 	bool	contains( const vec2 &pt ) const;

--- a/include/cinder/Shape2d.h
+++ b/include/cinder/Shape2d.h
@@ -85,6 +85,8 @@ class Shape2d {
 		else
 			return -calcDistance( pt );
 	}
+	//! Returns the point on the shape that is closest to point \a pt.
+	vec2	calcClosestPoint( const vec2 &pt ) const;
 
 	//! Returns whether the point \a pt is contained within the boundaries of the shape
 	bool	contains( const vec2 &pt ) const;

--- a/src/cinder/CinderMath.cpp
+++ b/src/cinder/CinderMath.cpp
@@ -49,6 +49,7 @@
 
 #include "cinder/CinderMath.h"
 #include <algorithm>
+#include <vector>
 
 using namespace glm;
 
@@ -314,6 +315,291 @@ vec2 getClosestPointEllipse( const vec2& center, const vec2& axisA, const vec2& 
 
 	return result;
 }
+
+namespace {
+
+//! Given a point and a Bezier curve, generate a 5th-degree Bezier - format equation whose solution finds the point on the curve nearest the user - defined point.
+template<typename T>
+std::vector<glm::tvec2<T, glm::defaultp>> convertToBezierForm( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> &testPoint )
+{
+	static const T z[3][4] = { { T(1.0), T(0.6), T(0.3), T(0.1) },{ T(0.4), T(0.6), T(0.6), T(0.4) },{ T(0.1), T(0.3), T(0.6), T(1.0) } };
+
+	// Determine the c's -- these are vectors created by subtracting point P from each of the control points.
+	glm::tvec2<T, glm::defaultp> c[4];
+	c[0] = controlPoints[0] - testPoint;
+	c[1] = controlPoints[1] - testPoint;
+	c[2] = controlPoints[2] - testPoint;
+	c[3] = controlPoints[3] - testPoint;
+
+	// Determine the d's -- these are vectors created by subtracting each control point from the next.
+	glm::tvec2<T, glm::defaultp> d[3];
+	d[0] = ( controlPoints[1] - controlPoints[0] ) * T{3};
+	d[1] = ( controlPoints[2] - controlPoints[1] ) * T{3};
+	d[2] = ( controlPoints[3] - controlPoints[2] ) * T{3};
+
+	// Create the c,d table -- this is a table of dot products of the c's and d's.
+	T cdTable[3][4];
+	for( int row = 0; row <= 2; row++ ) {
+		for( int column = 0; column <= 3; column++ ) {
+			cdTable[row][column] = glm::dot( d[row], c[column] );
+		}
+	}
+
+	// Now, apply the z's to the dot products, on the skew diagonal. Also, set up the x-values, making these "points".
+	std::vector<glm::tvec2<T, glm::defaultp>> w( 6 );
+	for( int i = 0; i <= 5; i++ ) {
+		w[i].y = 0.0;
+		w[i].x = (T)( i ) / 5;
+	}
+
+	const int n = 3;
+	const int m = 2;
+	for( int k = 0; k <= n + m; k++ ) {
+		int lb = glm::max( 0, k - m );
+		int ub = glm::min( k, n );
+		for( int i = lb; i <= ub; i++ ) {
+			int j = k - i;
+			w[i + j].y += cdTable[j][i] * z[j][i];
+		}
+	}
+
+	return w;
+}
+
+//! Count the number of times a Bezier control polygon crosses the x-axis. This number is >= the number of roots.
+template<typename T>
+int crossingCount( const glm::tvec2<T, glm::defaultp> *controlPoints, int degree )
+{
+	int n = 0;
+
+	T sign = glm::sign( controlPoints[0].y );
+	for( int i = 1; i <= degree; i++ ) {
+		T s = glm::sign( controlPoints[i].y );
+		if( sign != s )
+			n++;
+		sign = s;
+	}
+
+	return n;
+}
+
+//! Check if the control polygon of a Bezier curve is flat enough for recursive subdivision to bottom out.
+template<typename T>
+int controlPolygonFlatEnough( const glm::tvec2<T, glm::defaultp> *controlPoints, int degree )
+{
+	// Derive the implicit equation for line connecting first and last control points.
+	T a = controlPoints[0].y - controlPoints[degree].y;
+	T b = controlPoints[degree].x - controlPoints[0].x;
+	T c = controlPoints[0].x * controlPoints[degree].y - controlPoints[degree].x * controlPoints[0].y;
+
+	T max_distance_above{0};
+	T max_distance_below{0};
+
+	for( int i = 1; i < degree; i++ ) {
+		T value = a * controlPoints[i].x + b * controlPoints[i].y + c;
+		max_distance_above = glm::max( max_distance_above, value );
+		max_distance_below = glm::min( max_distance_below, value );
+	}
+
+	// Implicit equation for zero line.
+	const T a1{0};
+	const T b1{1};
+	const T c1{0};
+
+	// Implicit equation for "above" line.
+	T a2 = a;
+	T b2 = b;
+	T c2 = c - max_distance_above;
+
+	T intercept_1 = ( b1 * c2 - b2 * c1 ) / ( a1 * b2 - a2 * b1 );
+
+	// Implicit equation for "below" line.
+	a2 = a;
+	b2 = b;
+	c2 = c - max_distance_below;
+
+	T intercept_2 = ( b1 * c2 - b2 * c1 ) / ( a1 * b2 - a2 * b1 );
+
+	// Compute intercepts of bounding box.
+	T error = glm::max( intercept_1, intercept_2 ) - glm::min( intercept_1, intercept_2 );
+
+	static const T kEpsilon = std::numeric_limits<T>::epsilon();
+	return ( error < kEpsilon ) ? 1 : 0;
+}
+
+//! Compute intersection of chord from first control point to last with x-axis.
+template<typename T>
+T computeXIntercept( const glm::tvec2<T, glm::defaultp> &p0, const glm::tvec2<T, glm::defaultp> &p3 )
+{
+	glm::tvec2<T, glm::defaultp> d = p3 - p0;
+	return ( d.x * p0.y - d.y * p0.x ) / ( -d.y );
+}
+
+// Evaluate a Bezier curve at a particular parameter value. Fill in control points for resulting sub-curves if "left" and "right" are non-null.
+template<typename T>
+glm::tvec2<T, glm::defaultp> bezier( const glm::tvec2<T, glm::defaultp> *controlPoints, int degree, T t, glm::tvec2<T, glm::defaultp> *left, glm::tvec2<T, glm::defaultp> *right )
+{
+	glm::tvec2<T, glm::defaultp> v[6][6];
+
+	// Copy control points.
+	for( int j = 0; j <= degree; j++ ) {
+		v[0][j] = controlPoints[j];
+	}
+
+	// Triangle computation.
+	for( int i = 1; i <= degree; i++ ) {
+		for( int j = 0; j <= degree - i; j++ ) {
+			v[i][j].x = ( 1.0f - t ) * v[i - 1][j].x + t * v[i - 1][j + 1].x;
+			v[i][j].y = ( 1.0f - t ) * v[i - 1][j].y + t * v[i - 1][j + 1].y;
+		}
+	}
+
+	if( left != nullptr ) {
+		for( int j = 0; j <= degree; j++ ) {
+			left[j] = v[j][0];
+		}
+	}
+	if( right != nullptr ) {
+		for( int j = 0; j <= degree; j++ ) {
+			right[j] = v[degree - j][j];
+		}
+	}
+
+	return ( v[degree][0] );
+}
+
+//! Given a 5th-degree equation in Bernstein-Bezier form, find all of the roots in the interval[0, 1]. Return the number of roots found.
+template<typename T>
+int findRoots( const glm::tvec2<T, glm::defaultp> *controlPoints, int degree, T *t, int depth )
+{
+	switch( crossingCount( controlPoints, degree ) ) {
+		case 0: { // No solutions here.
+			return 0;
+		}
+		case 1: { // Unique solution
+			// Stop recursion when the tree is deep enough. If deep enough, return 1 solution at midpoint.
+			const int kMaxDepth = 64;
+			if( depth >= kMaxDepth ) {
+				t[0] = ( controlPoints[0].x + controlPoints[5].x ) / T{2};
+				return 1;
+			}
+			if( controlPolygonFlatEnough<T>( controlPoints, degree ) ) {
+				t[0] = computeXIntercept<T>( controlPoints[0], controlPoints[degree] );
+				return 1;
+			}
+			break;
+		}
+	}
+
+	// Otherwise, solve recursively after subdividing control polygon.
+	glm::tvec2<T, glm::defaultp> left[6], right[6];
+	bezier<T>( controlPoints, degree, 0.5f, left, right );
+	
+	T left_t[6], right_t[6];
+	int left_count = findRoots<T>( left, degree, left_t, depth + 1 );
+	int right_count = findRoots<T>( right, degree, right_t, depth + 1 );
+
+	// Gather solutions together.
+	for( int i = 0; i < left_count; i++ ) {
+		t[i] = left_t[i];
+	}
+	for( int i = 0; i < right_count; i++ ) {
+		t[i + left_count] = right_t[i];
+	}
+
+	// Send back total number of solutions.
+	return ( left_count + right_count );
+}
+
+} // anonymous namespace for closestPointCubic
+
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointLinear( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> & testPoint )
+{
+	T d = glm::distance2( controlPoints[1], controlPoints[0] );
+	if( d > T{0} ) {
+		T t = glm::clamp( glm::dot( testPoint - controlPoints[0], controlPoints[1] - controlPoints[0] ) / d, T{0}, T{1} );
+		return controlPoints[0] + t * ( controlPoints[1] - controlPoints[0] );
+	}
+	else {
+		return controlPoints[0];
+	}
+}
+template glm::tvec2<float, glm::defaultp> getClosestPointLinear( const glm::tvec2<float, glm::defaultp> *controlPoints, const glm::tvec2<float, glm::defaultp> & testPoint );
+template glm::tvec2<double, glm::defaultp> getClosestPointLinear( const glm::tvec2<double, glm::defaultp> *controlPoints, const glm::tvec2<double, glm::defaultp> & testPoint );
+
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointQuadratic( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> & testPoint )
+{
+	glm::tvec2<T, glm::defaultp> closest;
+
+	glm::tvec2<T, glm::defaultp> M = controlPoints[0] - testPoint;
+	glm::tvec2<T, glm::defaultp> A = controlPoints[1] - controlPoints[0];
+	glm::tvec2<T, glm::defaultp> B = controlPoints[2] - controlPoints[1] - A;
+	T a = glm::dot( B, B );
+	T b = 3 * glm::dot( A, B );
+	T c = 2 * glm::dot( A, A ) + glm::dot( M, B );
+	T d = glm::dot( M, A );
+	T t[3];
+	int solutions = solveCubic<T>( a, b, c, d, t );
+
+	T distance2 = std::numeric_limits<T>::max();
+	for( int i = 0; i < 3; ++i ) {
+		T u = glm::clamp( t[i], T{0}, T{1} );
+		T v = T{1} - u;
+		glm::tvec2<T, glm::defaultp> p = controlPoints[0] * ( v*v ) + controlPoints[1] * ( T{2} * u*v ) + controlPoints[2] * ( u*u );
+
+		T d = glm::distance2( testPoint, p );
+		if( d < distance2 ) {
+			closest = p;
+			distance2 = d;
+		}
+	}
+
+	return closest;
+}
+template glm::tvec2<float, glm::defaultp> getClosestPointQuadratic( const glm::tvec2<float, glm::defaultp> *controlPoints, const glm::tvec2<float, glm::defaultp> & testPoint );
+template glm::tvec2<double, glm::defaultp> getClosestPointQuadratic( const glm::tvec2<double, glm::defaultp> *controlPoints, const glm::tvec2<double, glm::defaultp> & testPoint );
+
+template<typename T>
+glm::tvec2<T, glm::defaultp> getClosestPointCubic( const glm::tvec2<T, glm::defaultp> *controlPoints, const glm::tvec2<T, glm::defaultp> & testPoint )
+{
+	// Convert problem to 5th-degree Bezier form.
+	auto w = convertToBezierForm<T>( controlPoints, testPoint );
+
+	// Find all possible roots of 5th-degree equation.
+	T t_candidate[5];
+	int n_solutions = findRoots<T>( w.data(), 5, t_candidate, 0 );
+
+	// Compare distances of P to all candidates, and to t=0, and t=1.
+	T t{ 0 };
+	{
+		// Check distance to beginning of curve, where t = 0.
+		T dist = glm::distance2( testPoint, controlPoints[0] );
+
+		// Find distances for candidate points.
+		for( int i = 0; i < n_solutions; i++ ) {
+			glm::tvec2<T, glm::defaultp> p = bezier<T>( controlPoints, 3, t_candidate[i], nullptr, nullptr );
+			T new_dist = glm::distance2( testPoint, p );
+			if( new_dist < dist ) {
+				dist = new_dist;
+				t = t_candidate[i];
+			}
+		}
+
+		// Finally, look at distance to end point, where t = 1.0.
+		T new_dist = glm::distance2( testPoint, controlPoints[3] );
+		if( new_dist < dist ) {
+			dist = new_dist;
+			t = T{ 1 };
+		}
+	}
+
+	// Return the point on the curve at parameter value t.
+	return ( bezier<T>( controlPoints, 3, t, nullptr, nullptr ) );
+}
+template glm::tvec2<float, glm::defaultp> getClosestPointCubic<float>( const glm::tvec2<float, glm::defaultp> *controlPoints, const glm::tvec2<float, glm::defaultp> & testPoint );
+template glm::tvec2<double, glm::defaultp> getClosestPointCubic<double>( const glm::tvec2<double, glm::defaultp> *controlPoints, const glm::tvec2<double, glm::defaultp> & testPoint );
 
 union float32_t
 {

--- a/src/cinder/Path2d.cpp
+++ b/src/cinder/Path2d.cpp
@@ -23,6 +23,7 @@
 */
 
 
+#include "cinder/CinderMath.h"
 #include "cinder/Path2d.h"
 
 #include <algorithm>
@@ -1002,12 +1003,13 @@ float Path2d::calcDistance( const vec2 &pt, size_t segment, size_t firstPoint ) 
 
 	switch( mSegments[segment] ) {
 		case CUBICTO:
-			return calcDistanceCubic( pt, segment, firstPoint );
+			return glm::distance( pt, getClosestPointCubic( &mPoints[firstPoint], pt ) );
 		case QUADTO:
-			return calcDistanceQuadratic( pt, segment, firstPoint );
+			return glm::distance( pt, getClosestPointQuadratic( &mPoints[firstPoint], pt ) );
 		case LINETO:
+			return glm::distance( pt, getClosestPointLinear( &mPoints[firstPoint], pt ) );
 		case CLOSE:
-			return calcDistanceLinear( pt, segment, firstPoint );
+			return glm::distance( pt, getClosestPointLinear( mPoints[firstPoint], mPoints[0], pt ) );
 		default:
 			return FLT_MAX;
 	}
@@ -1161,105 +1163,6 @@ float Path2d::segmentSolveTimeForDistance( size_t segment, float segmentLength, 
 	// If we failed to converge, hopefully 'p' is close enough
 	
 	return ( p + segment ) / (float)mSegments.size();
-}
-
-float Path2d::calcDistanceLinear( const vec2 &pt, size_t segment, size_t firstPoint ) const
-{
-	if( firstPoint == 0 ) {
-		for( size_t s = 0; s < segment; ++s )
-			firstPoint += sSegmentTypePointCounts[mSegments[s]];
-	}
-
-	const auto &p0 = mPoints[firstPoint + 0];
-	const auto &p1 = mPoints[(firstPoint + 1) % mPoints.size()]; // Allow CLOSE segments.
-	
-	float l = glm::distance2( p1, p0 );
-	if( l > 0.0f ) {
-		float t = glm::clamp( glm::dot( pt - p0, p1 - p0 ) / l, 0.0f, 1.0f );
-		return glm::distance( pt, p0 + t * ( p1 - p0 ) );
-	}
-	else {
-		return glm::distance( pt, p0 );
-	}
-}
-
-float Path2d::calcDistanceQuadratic( const vec2 &pt, size_t segment, size_t firstPoint ) const
-{
-	if( firstPoint == 0 ) {
-		for( size_t s = 0; s < segment; ++s )
-			firstPoint += sSegmentTypePointCounts[mSegments[s]];
-	}
-
-	// see: http://blog.gludion.com/2009/08/distance-to-quadratic-bezier-curve.html
-	const auto &p0 = mPoints[firstPoint + 0];
-	const auto &p1 = mPoints[firstPoint + 1];
-	const auto &p2 = mPoints[firstPoint + 2];
-	auto M = p0 - pt;
-	auto A = p1 - p0;
-	auto B = p2 - p1 - A;
-	float a = glm::dot( B, B );
-	float b = 3 * glm::dot( A, B );
-	float c = 2 * glm::dot( A, A ) + glm::dot( M, B );
-	float d = glm::dot( M, A );
-	float t[3];
-	int solutions = solveCubic( a, b, c, d, t );
-
-	float distance2 = FLT_MAX;
-	for( int i = 0; i < 3; ++i ) {
-		auto p = getSegmentPosition( segment, firstPoint, glm::clamp( t[i], 0.0f, 1.0f ) );
-		distance2 = glm::min( distance2, glm::distance2( pt, p ) );
-	}
-
-	return glm::sqrt( distance2 );
-}
-
-float Path2d::calcDistanceCubic( const vec2 &pt, size_t segment, size_t firstPoint ) const
-{
-	if( firstPoint == 0 ) {
-		for( size_t s = 0; s < segment; ++s )
-			firstPoint += sSegmentTypePointCounts[mSegments[s]];
-	}
-
-	const auto &p0 = mPoints[firstPoint + 0];
-	const auto &p1 = mPoints[firstPoint + 1];
-	const auto &p2 = mPoints[firstPoint + 2];
-	const auto &p3 = mPoints[firstPoint + 3];
-
-	auto M = p0 - pt;
-	auto A = p1 - p0;
-	auto B = p2 - p1 - A;
-	auto C = ( p3 - p2 ) - ( p2 - p1 ) - B;
-
-	// First guess.
-	float distance2 = glm::min( glm::distance2( pt, p0 ), glm::distance2( pt, p3 ) );
-	
-	// Apply Newton's method to optimize.
-	const int kSearchPrecision = 64;
-	const int kSearchSteps = 4;
-	for( int i = 0; i <= kSearchPrecision; ++i ) {
-		float t = (float)i / kSearchPrecision;
-		for( int step = 0;; ++step ) {
-			// Obtain position on curve.
-			//float u = 1 - t;
-			//float t2 = t * t;
-			//float u2 = u * u;
-			auto P = getSegmentPosition( segment, firstPoint, t );// p0 * ( u * u2 ) + p1 * ( 3 * t * u2 ) + p2 * ( 3 * t2 * u ) + p3 * ( t * t2 );
-
-			// Calculate distance.
-			distance2 = glm::min( glm::distance2( pt, P ), distance2 );
-
-			if( step == kSearchSteps )
-				break;
-
-			auto d1 = 3.0f * C * t * t + 6.0f * B * t + 3.0f * A;
-			auto d2 = 6.0f * C * t + 6.0f * B;
-			t -= glm::dot( P, d1 ) / ( glm::dot( d1, d1 ) + glm::dot( P, d2 ) );
-			if( t < 0 || t > 1 )
-				break;
-		}
-	}
-
-	return glm::sqrt( distance2 );
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cinder/Path2d.cpp
+++ b/src/cinder/Path2d.cpp
@@ -996,6 +996,30 @@ float Path2d::calcDistance( const vec2 &pt ) const
 
 float Path2d::calcDistance( const vec2 &pt, size_t segment, size_t firstPoint ) const
 {
+	return glm::distance( pt, calcClosestPoint( pt, segment, firstPoint ) );
+}
+
+vec2 Path2d::calcClosestPoint( const vec2 &pt ) const
+{
+	vec2 result;
+	float distance2 = FLT_MAX;
+
+	size_t firstPoint = 0;
+	for( size_t s = 0; s < mSegments.size(); ++s ) {
+		vec2 p = calcClosestPoint( pt, s, firstPoint );
+		float d = glm::distance2( pt, p );
+		if( d < distance2 ) {
+			result = p;
+			distance2 = d;
+		}
+		firstPoint += sSegmentTypePointCounts[mSegments[s]];
+	}
+
+	return result;
+}
+
+vec2 Path2d::calcClosestPoint( const vec2 &pt, size_t segment, size_t firstPoint ) const
+{
 	if( firstPoint == 0 ) {
 		for( size_t s = 0; s < segment; ++s )
 			firstPoint += sSegmentTypePointCounts[mSegments[s]];
@@ -1003,15 +1027,15 @@ float Path2d::calcDistance( const vec2 &pt, size_t segment, size_t firstPoint ) 
 
 	switch( mSegments[segment] ) {
 		case CUBICTO:
-			return glm::distance( pt, getClosestPointCubic( &mPoints[firstPoint], pt ) );
+			return getClosestPointCubic( &mPoints[firstPoint], pt );
 		case QUADTO:
-			return glm::distance( pt, getClosestPointQuadratic( &mPoints[firstPoint], pt ) );
+			return getClosestPointQuadratic( &mPoints[firstPoint], pt );
 		case LINETO:
-			return glm::distance( pt, getClosestPointLinear( &mPoints[firstPoint], pt ) );
+			return getClosestPointLinear( &mPoints[firstPoint], pt );
 		case CLOSE:
-			return glm::distance( pt, getClosestPointLinear( mPoints[firstPoint], mPoints[0], pt ) );
+			return getClosestPointLinear( mPoints[firstPoint], mPoints[0], pt );
 		default:
-			return FLT_MAX;
+			return vec2();
 	}
 }
 

--- a/src/cinder/Path2d.cpp
+++ b/src/cinder/Path2d.cpp
@@ -404,36 +404,33 @@ vec2 Path2d::getTangent( float t ) const
 	return getSegmentTangent( seg, subSeg );
 }
 
-vec2 Path2d::getSegmentPosition( size_t segment, size_t firstPoint, float t ) const
+vec2 Path2d::getSegmentPosition( size_t segment, float t ) const
 {
 	if( mSegments.empty() )
 		return vec2();
 
-	if( firstPoint == 0 ) {
-		for( size_t s = 0; s < segment; ++s )
-			firstPoint += sSegmentTypePointCounts[mSegments[s]];
-	}
+	size_t firstPoint = 0;
+	for( size_t s = 0; s < segment; ++s )
+		firstPoint += sSegmentTypePointCounts[mSegments[s]];
 	switch( mSegments[segment] ) {
 		case CUBICTO: {
-			float t2 = t * t;
-			float u = 1 - t;
-			float u2 = u * u;
-			return mPoints[firstPoint]*(u*u2) + mPoints[firstPoint+1]*(3*t*u2) + mPoints[firstPoint+2]*(3*t2*u) + mPoints[firstPoint+3]*(t2*t);
+			float t1 = 1 - t;
+			return mPoints[firstPoint]*(t1*t1*t1) + mPoints[firstPoint+1]*(3*t*t1*t1) + mPoints[firstPoint+2]*(3*t*t*t1) + mPoints[firstPoint+3]*(t*t*t);
 		}
 		break;
 		case QUADTO: {
-			float u = 1 - t;
-			return mPoints[firstPoint]*(u*u) + mPoints[firstPoint+1]*(2*t*u) + mPoints[firstPoint+2]*(t*t);
+			float t1 = 1 - t;
+			return mPoints[firstPoint]*(t1*t1) + mPoints[firstPoint+1]*(2*t*t1) + mPoints[firstPoint+2]*(t*t);
 		}
 		break;
 		case LINETO: {
-			float u = 1 - t;
-			return mPoints[firstPoint]*u + mPoints[firstPoint+1]*t;
+			float t1 = 1 - t;
+			return mPoints[firstPoint]*t1 + mPoints[firstPoint+1]*t;
 		}
 		break;
 		case CLOSE: {
-			float u = 1 - t;
-			return mPoints[firstPoint]*u + mPoints[0]*t;
+			float t1 = 1 - t;
+			return mPoints[firstPoint]*t1 + mPoints[0]*t;
 		}
 		break;
 		default:
@@ -441,15 +438,14 @@ vec2 Path2d::getSegmentPosition( size_t segment, size_t firstPoint, float t ) co
 	}
 }
 
-vec2 Path2d::getSegmentTangent( size_t segment, size_t firstPoint, float t ) const
+vec2 Path2d::getSegmentTangent( size_t segment, float t ) const
 {
 	if( mSegments.empty() )
 		return vec2();
-	
-	if( firstPoint == 0 ) {
-		for( size_t s = 0; s < segment; ++s )
-			firstPoint += sSegmentTypePointCounts[mSegments[s]];
-	}
+
+	size_t firstPoint = 0;
+	for( size_t s = 0; s < segment; ++s )
+		firstPoint += sSegmentTypePointCounts[mSegments[s]];
 	switch( mSegments[segment] ) {
 		case CUBICTO:
 			return calcCubicBezierDerivative( &mPoints[firstPoint], t );

--- a/src/cinder/Shape2d.cpp
+++ b/src/cinder/Shape2d.cpp
@@ -132,6 +132,16 @@ Rectf Shape2d::calcPreciseBoundingBox() const
 	return result;
 }
 
+float Shape2d::calcDistance( const vec2 & pt ) const
+{
+	float distance = FLT_MAX;
+	for( vector<Path2d>::const_iterator contIt = mContours.begin(); contIt != mContours.end(); ++contIt ) {
+		distance = math<float>::min( distance, contIt->calcDistance( pt ) );
+	}
+
+	return distance;
+}
+
 bool Shape2d::contains( const vec2 &pt ) const
 {
 	int numPathsInside = 0;

--- a/src/cinder/Shape2d.cpp
+++ b/src/cinder/Shape2d.cpp
@@ -142,6 +142,23 @@ float Shape2d::calcDistance( const vec2 & pt ) const
 	return distance;
 }
 
+vec2 Shape2d::calcClosestPoint( const vec2 & pt ) const
+{
+	vec2 result;
+	float distance2 = FLT_MAX;
+
+	for( vector<Path2d>::const_iterator contIt = mContours.begin(); contIt != mContours.end(); ++contIt ) {
+		vec2 p = contIt->calcClosestPoint( pt );
+		float d = glm::distance2( pt, p );
+		if( d < distance2 ) {
+			result = p;
+			distance2 = d;
+		}
+	}
+
+	return result;
+}
+
 bool Shape2d::contains( const vec2 &pt ) const
 {
 	int numPathsInside = 0;

--- a/test/ShapeTest/include/Resources.h
+++ b/test/ShapeTest/include/Resources.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "cinder/CinderResources.h"
+
+//#define RES_MY_RES			CINDER_RESOURCE( ../resources/, image_name.png, 128, IMAGE )
+
+
+
+
+

--- a/test/ShapeTest/src/ShapeTestApp.cpp
+++ b/test/ShapeTest/src/ShapeTestApp.cpp
@@ -1,0 +1,164 @@
+#include "cinder/Font.h"
+#include "cinder/app/App.h"
+#include "cinder/app/RendererGl.h"
+#include "cinder/gl/gl.h"
+
+using namespace ci;
+using namespace ci::app;
+using namespace std;
+
+class ShapeTestApp : public App {
+  public:
+	void setup();
+	void draw();
+
+	void mouseMove( MouseEvent event ) override;
+	void mouseDown( MouseEvent event ) override;
+	void mouseDrag( MouseEvent event ) override;
+	void mouseWheel( MouseEvent event ) override;
+
+	void keyDown( KeyEvent event ) override;
+
+	void setRandomFont();
+	void setRandomGlyph();
+
+	void reposition( const vec2 &point );
+	void calculate();
+	void calculateModelMatrix();
+
+	Font           mFont;
+	Shape2d        mShape;
+	vector<string> mFontNames;
+	int            mFontSize;
+	float          mZoom;
+	float          mDistance;
+	vec2           mMouse, mClick;
+	vec2           mClosest;
+	vec2           mAnchor, mPosition, mOriginal;
+	mat4           mModelMatrix;
+	bool           mIsInside;
+};
+
+void ShapeTestApp::setup()
+{
+	mPosition = getWindowCenter() * vec2( 0.8f, 1.2f );
+	mDistance = 0;
+	mZoom = 1;
+	mIsInside = false;
+
+	mFontNames = Font::getNames();
+	mFontSize = 256;
+	mFont = Font( "Times", (float)mFontSize );
+	mShape = mFont.getGlyphShape( mFont.getGlyphChar( 'A' ) );
+
+	calculate();
+}
+
+void ShapeTestApp::setRandomFont()
+{
+	// select a random font from those available on the system
+	mFont = Font( mFontNames[rand() % mFontNames.size()], (float)mFontSize );
+	setRandomGlyph();
+}
+
+void ShapeTestApp::setRandomGlyph()
+{
+	size_t glyphIndex = rand() % mFont.getNumGlyphs();
+	try {
+		mShape = mFont.getGlyphShape( glyphIndex );
+	}
+	catch( FontGlyphFailureExc & ) {
+		console() << "Looks like glyph " << glyphIndex << " doesn't exist in this font." << std::endl;
+	}
+}
+
+void ShapeTestApp::draw()
+{
+	gl::clear();
+	gl::pushModelView();
+	gl::setModelMatrix( mModelMatrix );
+
+	gl::color( mIsInside ? Color( 0.4f, 0.8f, 0.0f ) : Color( 0.8f, 0.4f, 0.0f ) );
+	gl::draw( mShape );
+
+	gl::popModelView();
+
+	gl::color( 0, 1, 1 );
+	gl::drawSolidCircle( mClosest, 5 );
+
+	gl::color( 1, 1, 0 );
+	gl::drawStrokedCircle( mMouse, mDistance );
+}
+
+void ShapeTestApp::mouseMove( MouseEvent event )
+{
+	mMouse = event.getPos(); 
+	
+	calculate();
+}
+
+void ShapeTestApp::mouseDown( MouseEvent event )
+{
+	reposition( event.getPos() );
+
+	mClick = event.getPos();
+	mOriginal = mPosition;
+
+	calculate();
+}
+
+void ShapeTestApp::mouseDrag( MouseEvent event )
+{
+	mPosition = mOriginal + vec2( event.getPos() ) - mClick;
+	mMouse = event.getPos();
+
+	calculate();
+}
+
+void ShapeTestApp::mouseWheel( MouseEvent event )
+{
+	reposition( event.getPos() );
+
+	mMouse = event.getPos();
+	mZoom *= 1.0f + 0.1f * event.getWheelIncrement();
+
+	calculate();
+}
+
+void ShapeTestApp::keyDown( KeyEvent event )
+{
+	setRandomGlyph();
+
+	calculate();
+}
+
+void ShapeTestApp::reposition( const vec2 &mouse )
+{
+	// Convert mouse to object space.
+	mat4 invModelMatrix = glm::inverse( mModelMatrix );
+	vec2 anchor = vec2( invModelMatrix * vec4( mouse, 0, 1 ) );
+
+	// Calculate new position, anchor and scale.
+	mPosition += vec2( mModelMatrix * vec4( anchor - mAnchor, 0, 0 ) );
+	mAnchor = anchor;
+}
+
+void ShapeTestApp::calculate()
+{
+	calculateModelMatrix();
+
+	auto local = vec2( glm::inverse( mModelMatrix ) * vec4( mMouse, 0, 1 ) );
+	mIsInside = mShape.contains( local );
+	mClosest = vec2( mModelMatrix * vec4( mShape.calcClosestPoint( local ), 0, 1 ) );
+	mDistance = glm::distance( mClosest, mMouse );
+}
+
+void ShapeTestApp::calculateModelMatrix()
+{
+	// Update model matrix.
+	mModelMatrix = glm::translate( vec3( mPosition, 0 ) );
+	mModelMatrix *= glm::scale( vec3( mZoom ) );
+	mModelMatrix *= glm::translate( vec3( -mAnchor, 0 ) );
+}
+
+CINDER_APP( ShapeTestApp, RendererGl )

--- a/test/ShapeTest/vc2013/Resources.rc
+++ b/test/ShapeTest/vc2013/Resources.rc
@@ -1,0 +1,3 @@
+#include "../include/Resources.h"
+
+1	ICON	"..\\..\\..\\samples\\data\\cinder_app_icon.ico"

--- a/test/ShapeTest/vc2013/ShapeTest.sln
+++ b/test/ShapeTest/vc2013/ShapeTest.sln
@@ -1,0 +1,20 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ShapeTest", "ShapeTest.vcxproj", "{D94FB576-2BFC-44E0-89F4-E2843A7601DD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D94FB576-2BFC-44E0-89F4-E2843A7601DD}.Debug|Win32.ActiveCfg = Debug|Win32
+		{D94FB576-2BFC-44E0-89F4-E2843A7601DD}.Debug|Win32.Build.0 = Debug|Win32
+		{D94FB576-2BFC-44E0-89F4-E2843A7601DD}.Release|Win32.ActiveCfg = Release|Win32
+		{D94FB576-2BFC-44E0-89F4-E2843A7601DD}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/test/ShapeTest/vc2013/ShapeTest.vcxproj
+++ b/test/ShapeTest/vc2013/ShapeTest.vcxproj
@@ -1,0 +1,118 @@
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D94FB576-2BFC-44E0-89F4-E2843A7601DD}</ProjectGuid>
+    <RootNamespace>ShapeTest</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\include;"..\..\..\include"</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>"..\..\..\include";..\include</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder-$(PlatformToolset)_d.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>"..\..\..\lib\msw\$(PlatformTarget)"</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <TargetMachine>MachineX86</TargetMachine>
+      <IgnoreSpecificDefaultLibraries>LIBCMT;LIBCPMT</IgnoreSpecificDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\include;"..\..\..\include"</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>"..\..\..\include";..\include</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder-$(PlatformToolset).lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>"..\..\..\lib\msw\$(PlatformTarget)"</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateMapFile>true</GenerateMapFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding />
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Resources.rc" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup>
+    <ClCompile Include="..\src\ShapeTestApp.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\Resources.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/test/ShapeTest/vc2013/ShapeTest.vcxproj.filters
+++ b/test/ShapeTest/vc2013/ShapeTest.vcxproj.filters
@@ -1,0 +1,37 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\ShapeTestApp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ShapeTestApp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClInclude Include="..\include\Resources.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\Resources.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Resources.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/test/ShapeTest/xcode/Info.plist
+++ b/test/ShapeTest/xcode/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string>CinderApp.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015 __MyCompanyName__. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/test/ShapeTest/xcode/ShapeTest.xcodeproj/project.pbxproj
+++ b/test/ShapeTest/xcode/ShapeTest.xcodeproj/project.pbxproj
@@ -1,0 +1,341 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720219952D00008149E2 /* AVFoundation.framework */; };
+		006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720319952D00008149E2 /* CoreMedia.framework */; };
+		0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0091D8F80E81B9330029341E /* OpenGL.framework */; };
+		00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784AF0FF439BC000DE1D7 /* Accelerate.framework */; };
+		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
+		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
+		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995581B128DF400A5C623 /* IOKit.framework */; };
+		00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995591B128DF400A5C623 /* IOSurface.framework */; };
+		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
+		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		48CAD85B76D343D1AB638C80 /* ShapeTest_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 53B8262415144B639B5D4A93 /* ShapeTest_Prefix.pch */; };
+		525A567F0CA3430590BEFC75 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = C6C94BE9B879495496698868 /* CinderApp.icns */; };
+		647CC64893814D7D94B1297B /* Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = 112880D76DC74B13B3E1FF81 /* Resources.h */; };
+		CDF84D7291C848C3B068B34D /* ShapeTestApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8F8DA5E3624C44558A211DC4 /* ShapeTestApp.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		006D720219952D00008149E2 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		006D720319952D00008149E2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		0091D8F80E81B9330029341E /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
+		00B784AF0FF439BC000DE1D7 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		00B784B10FF439BC000DE1D7 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
+		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		00B995581B128DF400A5C623 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		00B995591B128DF400A5C623 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
+		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
+		8D1107320486CEB800E47090 /* ShapeTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShapeTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F8DA5E3624C44558A211DC4 /* ShapeTestApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../src/ShapeTestApp.cpp; sourceTree = "<group>"; name = ShapeTestApp.cpp; };
+		112880D76DC74B13B3E1FF81 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../include/Resources.h; sourceTree = "<group>"; name = Resources.h; };
+		C6C94BE9B879495496698868 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
+		9CCF90B255B440F4B829749E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
+		53B8262415144B639B5D4A93 /* ShapeTest_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ShapeTest_Prefix.pch; sourceTree = "<group>"; name = ShapeTest_Prefix.pch; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8D11072E0486CEB800E47090 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
+				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
+				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
+				0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */,
+				5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */,
+				00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */,
+				00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */,
+				00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */,
+				00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */,
+				00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */,
+				00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		080E96DDFE201D6D7F000001 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				8F8DA5E3624C44558A211DC4 /* ShapeTestApp.cpp */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				006D720219952D00008149E2 /* AVFoundation.framework */,
+				006D720319952D00008149E2 /* CoreMedia.framework */,
+				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
+				00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */,
+				00B784B10FF439BC000DE1D7 /* AudioUnit.framework */,
+				00B784B20FF439BC000DE1D7 /* CoreAudio.framework */,
+				5323E6B10EAFCA74003A9687 /* CoreVideo.framework */,
+				0091D8F80E81B9330029341E /* OpenGL.framework */,
+				1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */,
+				00B995581B128DF400A5C623 /* IOKit.framework */,
+				00B995591B128DF400A5C623 /* IOSurface.framework */,
+			);
+			name = "Linked Frameworks";
+			sourceTree = "<group>";
+		};
+		1058C7A2FEA54F0111CA2CBB /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				29B97324FDCFA39411CA2CEA /* AppKit.framework */,
+				29B97325FDCFA39411CA2CEA /* Foundation.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		19C28FACFE9D520D11CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8D1107320486CEB800E47090 /* ShapeTest.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		29B97314FDCFA39411CA2CEA /* ShapeTest */ = {
+			isa = PBXGroup;
+			children = (
+				01B97315FEAEA392516A2CEA /* Blocks */,
+				29B97315FDCFA39411CA2CEA /* Headers */,
+				080E96DDFE201D6D7F000001 /* Source */,
+				29B97317FDCFA39411CA2CEA /* Resources */,
+				29B97323FDCFA39411CA2CEA /* Frameworks */,
+				19C28FACFE9D520D11CA2CBB /* Products */,
+			);
+			name = ShapeTest;
+			sourceTree = "<group>";
+		};
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
+		29B97315FDCFA39411CA2CEA /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				112880D76DC74B13B3E1FF81 /* Resources.h */,
+				53B8262415144B639B5D4A93 /* ShapeTest_Prefix.pch */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		29B97317FDCFA39411CA2CEA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				C6C94BE9B879495496698868 /* CinderApp.icns */,
+				9CCF90B255B440F4B829749E /* Info.plist */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
+				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8D1107260486CEB800E47090 /* ShapeTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "ShapeTest" */;
+			buildPhases = (
+				8D1107290486CEB800E47090 /* Resources */,
+				8D11072C0486CEB800E47090 /* Sources */,
+				8D11072E0486CEB800E47090 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ShapeTest;
+			productInstallPath = "$(HOME)/Applications";
+			productName = ShapeTest;
+			productReference = 8D1107320486CEB800E47090 /* ShapeTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		29B97313FDCFA39411CA2CEA /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "ShapeTest" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 29B97314FDCFA39411CA2CEA /* ShapeTest */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8D1107260486CEB800E47090 /* ShapeTest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8D1107290486CEB800E47090 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				525A567F0CA3430590BEFC75 /* CinderApp.icns in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8D11072C0486CEB800E47090 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CDF84D7291C848C3B068B34D /* ShapeTestApp.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C01FCF4B08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = ShapeTest_Prefix.pch;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.libcinder.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = ShapeTest;
+				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		C01FCF4C08A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_FAST_MATH = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"NDEBUG=1",
+					"$(inherited)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = ShapeTest_Prefix.pch;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.libcinder.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = ShapeTest;
+				STRIP_INSTALLED_PRODUCT = YES;
+				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		C01FCF4F08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CINDER_PATH = "../../..";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+				CLANG_CXX_LIBRARY = "libc++";
+				ENABLE_TESTABILITY = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+			};
+			name = Debug;
+		};
+		C01FCF5008A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CINDER_PATH = "../../..";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++11";
+				CLANG_CXX_LIBRARY = "libc++";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				SDKROOT = macosx;
+				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "ShapeTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4B08A954540054247B /* Debug */,
+				C01FCF4C08A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "ShapeTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4F08A954540054247B /* Debug */,
+				C01FCF5008A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
+}

--- a/test/ShapeTest/xcode/ShapeTest_Prefix.pch
+++ b/test/ShapeTest/xcode/ShapeTest_Prefix.pch
@@ -1,0 +1,12 @@
+#if defined( __cplusplus )
+	#include "cinder/Cinder.h"
+	
+	#include "cinder/app/App.h"
+	
+	#include "cinder/gl/gl.h"
+	
+	#include "cinder/CinderMath.h"
+	#include "cinder/Matrix.h"
+	#include "cinder/Vector.h"
+	#include "cinder/Quaternion.h"
+#endif


### PR DESCRIPTION
With the current attention to text rendering and signed distance fields, I thought it would be a good idea to have proper functions in Cinder that will help us calculate distances from points to lines, quadratic curves and cubic curves. There was no functionality in `Path2d` or `Shape2d` for that yet.

In this PR, I have added proper, high quality algorithms to `CinderMath.h`. The `getClosestPointCubic()` method is quite involved, but compared to the implementation in Chlumsky's MSDFGEN library it is _between three and five times_ faster and _much_ more accurate. This will allow us to create much higher quality signed distance fields, without the need for additional libraries.

New methods in `Path2d` and `Shape2d` allow easy calculation of (signed) distances and/or finding the closest point to a shape or path.

To exercise the new functions, I have added a `ShapeTest` application to the test folder. It is similar to the `Triangulation` sample, but it focuses on distance calculations instead. 

Let me know what you think.
