### PR TITLE
Updated Texture throughout to allow for passing dataformat

### DIFF
--- a/include/cinder/gl/Environment.h
+++ b/include/cinder/gl/Environment.h
@@ -67,10 +67,10 @@ class Environment {
 	//! Returns whether this platform supports Texture Level-of-Detail. \c true everywhere but ES 2, which requires \c GL_EXT_shader_texture_lod
 	virtual bool			supportsTextureLod() const = 0;
 
-	virtual void			allocateTexStorage1d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, bool immutable, GLint texImageDataType ) = 0;
-	virtual void			allocateTexStorage2d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataType ) = 0;
-	virtual void			allocateTexStorage3d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, bool immutable ) = 0;
-	virtual void			allocateTexStorageCubeMap( GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable ) = 0;	
+	virtual void			allocateTexStorage1d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, bool immutable, GLint texImageDataFormat, GLint texImageDataType ) = 0;
+	virtual void			allocateTexStorage2d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataFormat, GLint texImageDataType ) = 0;
+	virtual void			allocateTexStorage3d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, bool immutable, GLint texImageDataFormat, GLint texImageDataType ) = 0;
+	virtual void			allocateTexStorageCubeMap( GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataFormat, GLint texImageDataType ) = 0;
 
 	virtual void			objectLabel( GLenum identifier, GLuint name, GLsizei length, const char *label ) = 0;
 

--- a/include/cinder/gl/Texture.h
+++ b/include/cinder/gl/Texture.h
@@ -183,6 +183,10 @@ class TextureBase {
 		void	setDataType( GLint dataType ) { mDataType = dataType; }
 		//! Sets the Texture's data type format to be automatically selected based on the context.
 		void	setAutoDataType() { mDataType = -1; }
+		//! Sets the data format parameter used by glTexImage2D when glTexStorage2D is unavailable. Defaults to \c -1 which implies automatic determination.
+		void	setDataFormat( GLint dataFormat ) { mDataFormat = dataFormat; }
+		//! Sets the Texture's data format to be automatically selected based on the context.
+		void	setAutoDataFormat() { mDataFormat = -1; }
 		
 		// Specifies the texture comparison mode for currently bound depth textures.
 		void	setCompareMode( GLenum compareMode ) { mCompareMode = compareMode; }
@@ -227,6 +231,10 @@ class TextureBase {
 		GLint	getDataType() const { return mDataType; }
 		//! Returns whether the Texture's data type will be automatically selected based on the context.
 		bool	isAutoDataType() const { return mDataType == -1; }
+		//! Returns the Texture's internal format. A value of -1 implies automatic selection of the data format based on the context.
+		GLint	getDataFormat() const { return mDataFormat; }
+		//! Returns whether the Texture's data format will be automatically selected based on the context.
+		bool	isAutoDataFormat() const { return mDataFormat == -1; }
 		
 		//! Returns the horizontal wrapping behavior for the texture coordinates.
 		GLenum	getWrapS() const { return mWrapS; }
@@ -281,7 +289,7 @@ class TextureBase {
 		GLint				mMaxMipmapLevel;
 		bool				mImmutableStorage;
 		GLfloat				mMaxAnisotropy;
-		GLint				mInternalFormat, mDataType;
+		GLint				mInternalFormat, mDataType, mDataFormat;
 		bool				mSwizzleSpecified;
 		std::array<GLint,4>	mSwizzleMask;
 		bool				mBorderSpecified;
@@ -298,7 +306,7 @@ class TextureBase {
 	TextureBase();
 	TextureBase( GLenum target, GLuint textureId, GLint internalFormat );
 	
-	void			initParams( Format &format, GLint defaultInternalFormat, GLint defaultDataType );
+	void			initParams( Format &format, GLint defaultInternalFormat, GLint defaultDataType, GLint defaultDataFormat );
 
 	virtual void	printDims( std::ostream &os ) const = 0;
 	
@@ -437,7 +445,7 @@ class Texture1d : public TextureBase {
 	//! Constructs a Texture1d using the top row of \a surface
 	static Texture1dRef create( const Surface8u &surface, const Format &format = Format() );
 	//! Constructs a Texture1d using the data pointed to by \a data, in format \a dataFormat. For a dataType other than \c GL_UNSIGNED_CHAR use \a format.setDataType()
-	static Texture1dRef	create( const void *data, GLenum dataFormat, int width, const Format &format = Format() );
+	static Texture1dRef	create( const void *data, int width, const Format &format = Format() );
 	
 	//! Updates the Texture1d using the top row of \a surface.
 	void	update( const Surface8u &surface, int mipLevel = 0 );
@@ -454,7 +462,7 @@ class Texture1d : public TextureBase {
   protected:
   	Texture1d( GLint width, Format format );
 	Texture1d( const Surface8u &surface, Format format );
-	Texture1d( const void *data, GLenum dataFormat, int width, Format format );
+	Texture1d( const void *data, int width, Format format );
 
 	void	printDims( std::ostream &os ) const override;
 
@@ -512,7 +520,7 @@ class Texture2d : public TextureBase {
 	//! Constructs a texture of size(\a width, \a height) and allocates storage.
 	static Texture2dRef	create( int width, int height, const Format &format = Format() );
 	//! Constructs a texture of size(\a width, \a height). Pixel data is provided by \a data in format \a dataFormat (Ex: \c GL_RGB, \c GL_RGBA). Use \a format.setDataType() to specify a dataType other than \c GL_UNSIGNED_CHAR. Ignores \a format.loadTopDown().
-	static Texture2dRef	create( const void *data, GLenum dataFormat, int width, int height, const Format &format = Format() );
+	static Texture2dRef	create( const void *data, int width, int height, const Format &format = Format() );
 	//! Constructs a Texture based on the contents of \a surface.
 	static Texture2dRef	create( const Surface8u &surface, const Format &format = Format() );
 	//! Constructs a Texture based on the contents of \a channel. Sets swizzle mask to {R,R,R,1} where supported unless otherwise specified in \a format.
@@ -602,7 +610,7 @@ class Texture2d : public TextureBase {
   protected:
 
 	Texture2d( int width, int height, Format format = Format() );
-	Texture2d( const void *data, GLenum dataFormat, int width, int height, Format format = Format() );
+	Texture2d( const void *data, int width, int height, Format format = Format() );
 	Texture2d( const Surface8u &surface, Format format = Format() );
 	Texture2d( const Surface16u &surface, Format format = Format() );
 	Texture2d( const Surface32f &surface, Format format = Format() );
@@ -614,13 +622,13 @@ class Texture2d : public TextureBase {
 	Texture2d( const TextureData &data, Format format );
 	
 	void	printDims( std::ostream &os ) const override;
-	void	initParams( Format &format, GLint defaultInternalFormat, GLint defaultDataType );
+	void	initParams( Format &format, GLint defaultInternalFormat, GLint defaultDataFormat, GLint defaultDataType );
 	void	initMaxMipmapLevel();
 	template<typename T>
 	void	setData( const SurfaceT<T> &surface, bool createStorage, int mipLevel, const ivec2 &offset );
 	template<typename T>
 	void	setData( const ChannelT<T> &channel, bool createStorage, int mipLevel, const ivec2 &offset );
-	void	initData( const void *data, GLenum dataFormat, const Format &format );
+	void	initData( const void *data, const Format &format );
 	void	initData( const ImageSourceRef &imageSource, const Format &format );
 #if ! defined( CINDER_GL_ES )
 	void	initDataImageSourceWithPboImpl( const ImageSourceRef &imageSource, const Format &format, GLint dataFormat, GLint dataType, ImageIo::ChannelOrder channelOrder, bool isGray, const PboRef &pbo );

--- a/src/cinder/gl/EnvironmentCore.cpp
+++ b/src/cinder/gl/EnvironmentCore.cpp
@@ -43,10 +43,10 @@ class EnvironmentCore : public Environment {
 	bool	supportsTextureLod() const override;
 	void	objectLabel( GLenum identifier, GLuint name, GLsizei length, const char *label ) override;
 
-	void	allocateTexStorage1d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, bool immutable, GLint texImageDataType ) override;
-	void	allocateTexStorage2d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataType ) override;
-	void	allocateTexStorage3d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, bool immutable ) override;
-	void	allocateTexStorageCubeMap( GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable ) override;
+	void	allocateTexStorage1d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, bool immutable, GLint texImageDataFormat, GLint texImageDataType ) override;
+	void	allocateTexStorage2d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataFormat, GLint texImageDataType ) override;
+	void	allocateTexStorage3d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, bool immutable, GLint texImageDataFormat, GLint texImageDataType ) override;
+	void	allocateTexStorageCubeMap( GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataFormat, GLint texImageDataType ) override;
 	
 	std::string		generateVertexShader( const ShaderDef &shader ) override;
 	std::string		generateFragmentShader( const ShaderDef &shader ) override;
@@ -108,7 +108,7 @@ void EnvironmentCore::objectLabel( GLenum identifier, GLuint name, GLsizei lengt
 		(*objectLabelFn)( identifier, name, length, label );
 }
 
-void EnvironmentCore::allocateTexStorage1d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, bool immutable, GLint texImageDataType )
+void EnvironmentCore::allocateTexStorage1d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, bool immutable, GLint texImageDataFormat, GLint texImageDataType )
 {
 	static auto texStorage1DFn = glTexStorage1D;
 	if( texStorage1DFn && immutable )
@@ -118,11 +118,13 @@ void EnvironmentCore::allocateTexStorage1d( GLenum target, GLsizei levels, GLenu
 		TextureBase::getInternalFormatInfo( internalFormat, &dataFormat, &dataType );
 		if( texImageDataType != -1 )
 			dataType = texImageDataType;
+		if( texImageDataFormat != -1 )
+			dataFormat = texImageDataFormat;
 		glTexImage1D( target, 0, internalFormat, width, 0, dataFormat, dataType, nullptr );
 	}
 }
 
-void EnvironmentCore::allocateTexStorage2d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataType )
+void EnvironmentCore::allocateTexStorage2d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataFormat, GLint texImageDataType )
 {
 	static auto texStorage2DFn = glTexStorage2D;
 	if( texStorage2DFn && immutable )
@@ -132,11 +134,13 @@ void EnvironmentCore::allocateTexStorage2d( GLenum target, GLsizei levels, GLenu
 		TextureBase::getInternalFormatInfo( internalFormat, &dataFormat, &dataType );
 		if( texImageDataType != -1 )
 			dataType = texImageDataType;
+		if( texImageDataFormat != -1 )
+			dataFormat = texImageDataFormat;
 		glTexImage2D( target, 0, internalFormat, width, height, 0, dataFormat, dataType, nullptr );
 	}
 }
 
-void EnvironmentCore::allocateTexStorage3d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, bool immutable )
+void EnvironmentCore::allocateTexStorage3d( GLenum target, GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, bool immutable, GLint texImageDataFormat, GLint texImageDataType )
 {
 	static auto texStorage3DFn = glTexStorage3D;
 	if( texStorage3DFn && immutable )
@@ -144,11 +148,15 @@ void EnvironmentCore::allocateTexStorage3d( GLenum target, GLsizei levels, GLenu
 	else {
 		GLenum dataFormat, dataType;
 		TextureBase::getInternalFormatInfo( internalFormat, &dataFormat, &dataType );
+		if( texImageDataType != -1 )
+			dataType = texImageDataType;
+		if( texImageDataFormat != -1 )
+			dataFormat = texImageDataFormat;
 		glTexImage3D( target, 0, internalFormat, width, height, depth, 0, dataFormat, dataType, nullptr );
 	}	
 }
 
-void EnvironmentCore::allocateTexStorageCubeMap( GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable )
+void EnvironmentCore::allocateTexStorageCubeMap( GLsizei levels, GLenum internalFormat, GLsizei width, GLsizei height, bool immutable, GLint texImageDataFormat, GLint texImageDataType )
 {
 	static auto texStorage2DFn = glTexStorage2D;
 	if( texStorage2DFn && immutable )
@@ -156,6 +164,10 @@ void EnvironmentCore::allocateTexStorageCubeMap( GLsizei levels, GLenum internal
 	else {
 		GLenum dataFormat, dataType;
 		TextureBase::getInternalFormatInfo( internalFormat, &dataFormat, &dataType );
+		if( texImageDataType != -1 )
+			dataType = texImageDataType;
+		if( texImageDataFormat != -1 )
+			dataFormat = texImageDataFormat;
 		for( int face = 0; face < 6; ++face )
 			glTexImage2D( GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, 0, internalFormat, width, height, 0, dataFormat, dataType, nullptr );
 	}

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -101,7 +101,7 @@ TextureBase::~TextureBase()
 }
 
 // Expects texture to be bound and mTarget,mTextureId and getWidth(), getHeight() and getDepth() functional
-void TextureBase::initParams( Format &format, GLint defaultInternalFormat, GLint defaultDataType )
+void TextureBase::initParams( Format &format, GLint defaultInternalFormat, GLint defaultDataFormat, GLint defaultDataType )
 {
 	// default is GL_REPEAT
 	if( format.mWrapS != GL_REPEAT )
@@ -135,6 +135,9 @@ void TextureBase::initParams( Format &format, GLint defaultInternalFormat, GLint
 
 	if( ( format.mDataType == -1 ) && ( defaultDataType > 0 ) )
 		format.mDataType = defaultDataType;
+
+	if( ( format.mDataFormat == -1 ) && ( defaultDataFormat > 0 ) )
+		format.mDataFormat = defaultDataFormat;
 
 	// Swizzle mask
 #if ! defined( CINDER_GL_ES )
@@ -662,6 +665,7 @@ TextureBase::Format::Format()
 	mImmutableStorage = false;
 	mInternalFormat = -1;
 	mDataType = -1;
+	mDataFormat = -1;
 	mMaxAnisotropy = -1.0f;
 	mSwizzleSpecified = false;
 	mSwizzleMask[0] = GL_RED; mSwizzleMask[1] = GL_GREEN; mSwizzleMask[2] = GL_BLUE; mSwizzleMask[3] = GL_ALPHA;
@@ -706,12 +710,12 @@ Texture1dRef Texture1d::create( const Surface8u &surface, const Format &format )
 		return Texture1dRef( new Texture1d( surface, format ) );
 }
 
-Texture1dRef Texture1d::create( const void *data, GLenum dataFormat, int width, const Format &format )
+Texture1dRef Texture1d::create( const void *data, int width, const Format &format )
 {
 	if( format.mDeleter )
-		return Texture1dRef( new Texture1d( data, dataFormat, width, format ), format.mDeleter );
+		return Texture1dRef( new Texture1d( data, width, format ), format.mDeleter );
 	else
-		return Texture1dRef( new Texture1d( data, dataFormat, width, format ) );
+		return Texture1dRef( new Texture1d( data, width, format ) );
 }
 
 Texture1d::Texture1d( GLint width, Format format )
@@ -720,10 +724,10 @@ Texture1d::Texture1d( GLint width, Format format )
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	TextureBase::initParams( format, GL_RGB, GL_UNSIGNED_BYTE );
+	TextureBase::initParams( format, GL_RGB, GL_RGB, GL_UNSIGNED_BYTE );
 
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	env()->allocateTexStorage1d( mTarget, format.mMaxMipmapLevel + 1, mInternalFormat, mWidth, format.isImmutableStorage(), format.getDataType() );
+	env()->allocateTexStorage1d( mTarget, format.mMaxMipmapLevel + 1, mInternalFormat, mWidth, format.isImmutableStorage(), format.getDataFormat(), format.getDataType() );
 }
 
 Texture1d::Texture1d( const Surface8u &surface, Format format )
@@ -732,25 +736,25 @@ Texture1d::Texture1d( const Surface8u &surface, Format format )
 	GLint dataFormat;
 	GLenum type;
 	SurfaceChannelOrderToDataFormatAndType<uint8_t>( surface.getChannelOrder(), &dataFormat, &type );
-
+	
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE );
+	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE );
 
 	ScopedTextureBind tbs( mTarget, mTextureId );
 	glTexImage1D( mTarget, 0, mInternalFormat, mWidth, 0, dataFormat, GL_UNSIGNED_BYTE, surface.getData() );
 }
 
-Texture1d::Texture1d( const void *data, GLenum dataFormat, int width, Format format )
+Texture1d::Texture1d( const void *data, int width, Format format )
 	: mWidth( width )
 {
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	TextureBase::initParams( format, GL_RGB, GL_UNSIGNED_BYTE );
+	TextureBase::initParams( format, GL_RGB, GL_RGB, GL_UNSIGNED_BYTE );
 
-	glTexImage1D( mTarget, 0, mInternalFormat, mWidth, 0, dataFormat, format.getDataType(), data );
+	glTexImage1D( mTarget, 0, mInternalFormat, mWidth, 0, format.getDataFormat(), format.getDataType(), data );
 }
 
 void Texture1d::update( const Surface8u &surface, int mipLevel )
@@ -791,12 +795,12 @@ Texture2dRef Texture2d::create( int width, int height, const Format &format )
 		return TextureRef( new Texture( width, height, format ) );
 }
 
-Texture2dRef Texture2d::create( const void *data, GLenum dataFormat, int width, int height, const Format &format )
+Texture2dRef Texture2d::create( const void *data, int width, int height, const Format &format )
 {
 	if( format.mDeleter )
-		return TextureRef( new Texture( data, dataFormat, width, height, format ), format.mDeleter );
+		return TextureRef( new Texture( data, width, height, format ), format.mDeleter );
 	else
-		return TextureRef( new Texture( data, dataFormat, width, height, format ) );
+		return TextureRef( new Texture( data, width, height, format ) );
 }
 
 Texture2dRef Texture2d::create( const Surface8u &surface, const Format &format )
@@ -889,16 +893,16 @@ Texture2d::Texture2d( int width, int height, Format format )
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
 #if ! defined( CINDER_GL_ES_2 )
-	initParams( format, GL_RGBA8, GL_UNSIGNED_BYTE );
+	initParams( format, GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE );
 #else
-	initParams( format, GL_RGBA, GL_UNSIGNED_BYTE );
+	initParams( format, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE );
 #endif
 
 	initMaxMipmapLevel();
-	env()->allocateTexStorage2d( mTarget, mMaxMipmapLevel + 1, mInternalFormat, width, height, format.isImmutableStorage(), format.getDataType() );
+	env()->allocateTexStorage2d( mTarget, mMaxMipmapLevel + 1, mInternalFormat, width, height, format.isImmutableStorage(), format.getDataFormat(), format.getDataType() );
 }
 
-Texture2d::Texture2d( const void *data, GLenum dataFormat, int width, int height, Format format )
+Texture2d::Texture2d( const void *data, int width, int height, Format format )
 	: mActualSize( width, height ),
 	mCleanBounds( 0, 0, width, height ),
 	mTopDown( false )
@@ -906,12 +910,12 @@ Texture2d::Texture2d( const void *data, GLenum dataFormat, int width, int height
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	initParams( format, GL_RGBA, GL_UNSIGNED_BYTE );
+	initParams( format, GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE );
 
 	if( format.mLoadTopDown )
 		CI_LOG_W( "Ignoring request for loadTopDown" );
 
-	initData( data, dataFormat, format );
+	initData( data, format );
 }
 
 Texture2d::Texture2d( const Surface8u &surface, Format format )
@@ -922,7 +926,7 @@ Texture2d::Texture2d( const Surface8u &surface, Format format )
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE );
+	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE );
 	setData<uint8_t>( surface, true, 0, ivec2( 0, 0 ) );
 }
 
@@ -935,13 +939,13 @@ Texture2d::Texture2d( const Channel8u &channel, Format format )
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
 #if defined( CINDER_GL_ES )
-	initParams( format, GL_LUMINANCE, GL_UNSIGNED_BYTE );
+	initParams( format, GL_LUMINANCE, GL_LUNIMANCE, GL_UNSIGNED_BYTE );
 #else
 	if( ! format.mSwizzleSpecified ) {
 		std::array<int,4> swizzleMask = { GL_RED, GL_RED, GL_RED, GL_ONE };
 		format.setSwizzleMask( swizzleMask );
 	}
-	initParams( format, GL_RED, GL_UNSIGNED_BYTE );
+	initParams( format, GL_RED, GL_RED, GL_UNSIGNED_BYTE );
 #endif
 	setData<uint8_t>( channel, true, 0, ivec2( 0, 0 ) );
 }
@@ -955,9 +959,9 @@ Texture2d::Texture2d( const Surface16u &surface, Format format )
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
 #if defined( CINDER_GL_ES )
-	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_UNSIGNED_SHORT );
+	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_UNSIGNED_SHORT );
 #else
-	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_UNSIGNED_SHORT );
+	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_UNSIGNED_SHORT );
 #endif
 
 	setData<uint16_t>( surface, true, 0, ivec2( 0, 0 ) );
@@ -972,13 +976,13 @@ Texture2d::Texture2d( const Channel16u &channel, Format format )
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
 #if defined( CINDER_GL_ES )
-	initParams( format, GL_LUMINANCE, GL_UNSIGNED_SHORT );
+	initParams( format, GL_LUMINANCE, GL_LUMINANCE, GL_UNSIGNED_SHORT );
 #else
 	if( ! format.mSwizzleSpecified ) {
 		std::array<int,4> swizzleMask = { GL_RED, GL_RED, GL_RED, GL_ONE };
 		format.setSwizzleMask( swizzleMask );
 	}
-	initParams( format, GL_RED, GL_UNSIGNED_SHORT );
+	initParams( format, GL_RED, GL_RED, GL_UNSIGNED_SHORT );
 #endif
 
 	setData<uint16_t>( channel, true, 0, ivec2( 0, 0 ) );
@@ -993,9 +997,9 @@ Texture2d::Texture2d( const Surface32f &surface, Format format )
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
 #if defined( CINDER_GL_ES_2 )
-	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_FLOAT );
+	initParams( format, surface.hasAlpha() ? GL_RGBA : GL_RGB, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_FLOAT );
 #else
-	initParams( format, surface.hasAlpha() ? GL_RGBA32F : GL_RGB32F, GL_FLOAT );
+	initParams( format, surface.hasAlpha() ? GL_RGBA32F : GL_RGB32F, surface.hasAlpha() ? GL_RGBA : GL_RGB, GL_FLOAT );
 #endif
 
 	setData<float>( surface, true, 0, ivec2( 0, 0 ) );
@@ -1010,13 +1014,13 @@ Texture2d::Texture2d( const Channel32f &channel, Format format )
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
 #if defined( CINDER_GL_ES_2 )
-	initParams( format, GL_LUMINANCE, GL_FLOAT );
+	initParams( format, GL_LUMINANCE, GL_LUMINANCE, GL_FLOAT );
 #else
 	if( ! format.mSwizzleSpecified ) {
 		std::array<int,4> swizzleMask = { GL_RED, GL_RED, GL_RED, GL_ONE };
 		format.setSwizzleMask( swizzleMask );
 	}
-	initParams( format, GL_RED, GL_FLOAT );
+	initParams( format, GL_RED, GL_RED, GL_FLOAT );
 #endif
 
 	setData<float>( channel, true, 0, ivec2( 0, 0 ) );
@@ -1087,7 +1091,7 @@ Texture2d::Texture2d( const ImageSourceRef &imageSource, Format format )
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	initParams( format, defaultInternalFormat, 0 /* unused */ );
+	initParams( format, defaultInternalFormat, 0 /* unused */, 0 );
 	initData( imageSource, format );
 }
 
@@ -1104,7 +1108,7 @@ Texture2d::Texture2d( const TextureData &data, Format format )
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	initParams( format, 0 /* unused */, 0 /* unused */ );
+	initParams( format, 0 /* unused */, 0 /* unused */, 0 /* unused */ );
 	
 	replace( data );
 
@@ -1186,12 +1190,12 @@ void Texture2d::setData( const ChannelT<T> &original, bool createStorage, int mi
 		glGenerateMipmap( mTarget );
 }
 
-void Texture2d::initData( const void *data, GLenum dataFormat, const Format &format )
+void Texture2d::initData( const void *data, const Format &format )
 {
 	ScopedTextureBind tbs( mTarget, mTextureId );
 	
 	glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
-	glTexImage2D( mTarget, 0, mInternalFormat, mActualSize.x, mActualSize.y, 0, dataFormat, format.getDataType(), data );
+	glTexImage2D( mTarget, 0, mInternalFormat, mActualSize.x, mActualSize.y, 0, format.getDataFormat(), format.getDataType(), data );
     
 	if( mMipmapping ) {
 		initMaxMipmapLevel();
@@ -1297,7 +1301,8 @@ void Texture2d::initData( const ImageSourceRef &imageSource, const Format &forma
 	getInternalFormatInfo( mInternalFormat, &dataFormat, &dataType, nullptr, nullptr, nullptr );
 	if( ! format.isAutoDataType() )
 		dataType = format.getDataType();
-	
+	if( ! format.isAutoDataFormat() )
+		dataFormat = format.getDataFormat();
 	ScopedTextureBind tbs( mTarget, mTextureId );	
 	
 	glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
@@ -1440,10 +1445,10 @@ void Texture2d::printDims( std::ostream &os ) const
 	os << getWidth() << " x " << getHeight();
 }
 
-void Texture2d::initParams( Format &format, GLint defaultInternalFormat, GLint defaultDataType )
+void Texture2d::initParams( Format &format, GLint defaultInternalFormat, GLint defaultDataFormat, GLint defaultDataType )
 {
 	mTopDown = format.mLoadTopDown;
-	TextureBase::initParams( format, defaultInternalFormat, defaultDataType );
+	TextureBase::initParams( format, defaultInternalFormat, defaultDataFormat, defaultDataType );
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -1639,10 +1644,10 @@ Texture3d::Texture3d( GLint width, GLint height, GLint depth, Format format )
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	TextureBase::initParams( format, GL_RGB, GL_UNSIGNED_BYTE );
+	TextureBase::initParams( format, GL_RGB, GL_RGB, GL_UNSIGNED_BYTE );
 
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	env()->allocateTexStorage3d( mTarget, format.mMaxMipmapLevel + 1, mInternalFormat, mWidth, mHeight, mDepth, format.isImmutableStorage() );
+	env()->allocateTexStorage3d( mTarget, format.mMaxMipmapLevel + 1, mInternalFormat, mWidth, mHeight, mDepth, format.isImmutableStorage(), format.getDataFormat(), format.getDataType() );
 }
 
 Texture3d::Texture3d( const void *data, GLenum dataFormat, int width, int height, int depth, Format format )
@@ -1651,7 +1656,7 @@ Texture3d::Texture3d( const void *data, GLenum dataFormat, int width, int height
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	TextureBase::initParams( format, GL_RGB, GL_UNSIGNED_BYTE );
+	TextureBase::initParams( format, GL_RGB, GL_RGB, GL_UNSIGNED_BYTE );
 
 	glTexImage3D( mTarget, 0, mInternalFormat, mWidth, mHeight, mDepth, 0, dataFormat, format.getDataType(), data );
 }
@@ -1922,9 +1927,9 @@ TextureCubeMap::TextureCubeMap( int32_t width, int32_t height, Format format )
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );	
-	TextureBase::initParams( format, GL_RGB, GL_UNSIGNED_BYTE );
+	TextureBase::initParams( format, GL_RGB, GL_RGB, GL_UNSIGNED_BYTE );
 
-	env()->allocateTexStorageCubeMap( mMaxMipmapLevel + 1, mInternalFormat, width, height, format.isImmutableStorage() );	
+	env()->allocateTexStorageCubeMap( mMaxMipmapLevel + 1, mInternalFormat, width, height, format.isImmutableStorage(), format.getDataFormat(), format.getDataType() );	
 }
 
 template<typename T>
@@ -1938,7 +1943,7 @@ TextureCubeMap::TextureCubeMap( const SurfaceT<T> images[6], Format format )
 	if( std::is_same<T,float>::value )
 		dataType = GL_FLOAT;
 
-	TextureBase::initParams( format, ( images[0].hasAlpha() ) ? GL_RGBA : GL_RGB, dataType );
+	TextureBase::initParams( format, ( images[0].hasAlpha() ) ? GL_RGBA : GL_RGB, ( images[0].hasAlpha() ) ? GL_RGBA : GL_RGB, dataType );
 
 	mWidth = images[0].getWidth();
 	mHeight = images[0].getHeight();
@@ -1962,7 +1967,7 @@ TextureCubeMap::TextureCubeMap( const TextureData &data, Format format )
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
-	initParams( format, 0 /* unused */, 0 /* unused */ );
+	initParams( format, 0 /* unused */, 0 /* unused */, 0 /* unused */ );
 	
 	replace( data );
 

--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -308,7 +308,7 @@ TextureFont::TextureFont( const Font &font, const string &utf8Chars, const Forma
 			array<GLint,4> swizzleMask = { GL_RED, GL_RED, GL_RED, GL_GREEN };
 			textureFormat.setSwizzleMask( swizzleMask );
 #endif
-			mTextures.push_back( gl::Texture::create( lumAlphaData.get(), textureFormat.getInternalFormat(), mFormat.getTextureWidth(), mFormat.getTextureHeight(), textureFormat ) );
+			mTextures.push_back( gl::Texture::create( lumAlphaData.get(), mFormat.getTextureWidth(), mFormat.getTextureHeight(), textureFormat ) );
 			mTextures.back()->setTopDown( true );
 			ip::fill<uint8_t>( &channel, 0 );			
 			curOffset = ivec2( 0, 0 );


### PR DESCRIPTION
This pr allows the ability to set up fast path textures with dataType = GL_UNSIGNED_INT_8_8_8_8_REV and dataFormat = GL_BGRA. This form of texture format is not available without the changes made in the pr.