### PR TITLE
fix audio exception

### DIFF
--- a/include/cinder/audio/Exception.h
+++ b/include/cinder/audio/Exception.h
@@ -33,13 +33,12 @@ namespace cinder { namespace audio {
 //! General audio exception.
 class AudioExc : public Exception {
   public:
-	AudioExc( const std::string &description, int32_t errorCode = 0 ) : Exception( description )	{}
+	AudioExc( const std::string &description, int32_t errorCode = 0 ) : Exception( description ), mErrorCode( errorCode ) {}
 
 	//! Returns a platform-specific error code. Could return 0 (meaning none was available).
 	int32_t getCode() const						{ return mErrorCode; }
 
   protected:
-	std::string	mDescription;
 	int32_t		mErrorCode;
 };
 
@@ -64,7 +63,7 @@ class AudioFormatExc : public AudioExc {
 //! Audio exception related to file i/o.
 class AudioFileExc : public AudioExc {
   public:
-	AudioFileExc( const std::string &description, int32_t errorCode = 0 ) : AudioExc( description )	{}
+	AudioFileExc( const std::string &description, int32_t errorCode = 0 ) : AudioExc( description, errorCode )	{}
 };
 
 } } // namespace cinder::audio


### PR DESCRIPTION
Now the error code of `AudioExc` is actually set and the unused `mDescription` member (which is already present in the base class) is removed.