### PR TITLE
CameraUI should clear connections when changing window

### DIFF
--- a/include/cinder/CameraUi.h
+++ b/include/cinder/CameraUi.h
@@ -100,7 +100,7 @@ class CameraUi {
 	app::WindowRef			mWindow;
 	bool					mEnabled;
 	int						mSignalPriority;
-	std::vector<ci::signals::Connection>	mMouseConnections;
+	std::vector<ci::signals::Connection>	mConnections;
 	signals::Signal<void()>	mSignalCameraChange;
 };
 

--- a/src/cinder/CameraUi.cpp
+++ b/src/cinder/CameraUi.cpp
@@ -69,22 +69,22 @@ CameraUi& CameraUi::operator=( const CameraUi &rhs )
 //! Connects to mouseDown, mouseDrag, mouseWheel and resize signals of \a window, with optional priority \a signalPriority
 void CameraUi::connect( const app::WindowRef &window, int signalPriority )
 {
-	if( ! mMouseConnections.empty() ) {
+	if( ! mConnections.empty() ) {
 		disconnect();
 	}
 
 	mWindow = window;
 	mSignalPriority = signalPriority;
 	if( window ) {
-		mMouseConnections.push_back( window->getSignalMouseDown().connect( signalPriority,
+		mConnections.push_back( window->getSignalMouseDown().connect( signalPriority,
 			[this]( app::MouseEvent &event ) { mouseDown( event ); } ) );
-		mMouseConnections.push_back( window->getSignalMouseUp().connect( signalPriority,
+		mConnections.push_back( window->getSignalMouseUp().connect( signalPriority,
 			[this]( app::MouseEvent &event ) { mouseUp( event ); } ) );
-		mMouseConnections.push_back( window->getSignalMouseDrag().connect( signalPriority,
+		mConnections.push_back( window->getSignalMouseDrag().connect( signalPriority,
 			[this]( app::MouseEvent &event ) { mouseDrag( event ); } ) );
-		mMouseConnections.push_back( window->getSignalMouseWheel().connect( signalPriority,
+		mConnections.push_back( window->getSignalMouseWheel().connect( signalPriority,
 			[this]( app::MouseEvent &event ) { mouseWheel( event ); } ) );
-		mMouseConnections.push_back( window->getSignalResize().connect( signalPriority,
+		mConnections.push_back( window->getSignalResize().connect( signalPriority,
 			[this]() {
 				setWindowSize( mWindow->getSize() );
 				if( mCamera )
@@ -99,9 +99,9 @@ void CameraUi::connect( const app::WindowRef &window, int signalPriority )
 //! Disconnects all signal handlers
 void CameraUi::disconnect()
 {
-	for( auto &conn : mMouseConnections )
+	for( auto &conn : mConnections )
 		conn.disconnect();
-	mMouseConnections.clear();
+	mConnections.clear();
 
 	mWindow.reset();
 }

--- a/src/cinder/CameraUi.cpp
+++ b/src/cinder/CameraUi.cpp
@@ -70,8 +70,7 @@ CameraUi& CameraUi::operator=( const CameraUi &rhs )
 void CameraUi::connect( const app::WindowRef &window, int signalPriority )
 {
 	if( ! mMouseConnections.empty() ) {
-		for( auto &conn : mMouseConnections )
-			conn.disconnect();
+		disconnect();
 	}
 
 	mWindow = window;
@@ -93,9 +92,7 @@ void CameraUi::connect( const app::WindowRef &window, int signalPriority )
 			}
 		) );
 	}
-	else
-		disconnect();
-		
+
 	mLastAction = ACTION_NONE;
 }
 
@@ -104,6 +101,7 @@ void CameraUi::disconnect()
 {
 	for( auto &conn : mMouseConnections )
 		conn.disconnect();
+	mMouseConnections.clear();
 
 	mWindow.reset();
 }


### PR DESCRIPTION
Seemed cleanest to just centralize this in `disconnect()`. 

Fixes #1635 

Side note but what do people think about renaming `mMouseConnections` to just `mConnections`? I think the current name is a bit misleading since it has the window resize connection in there too. 

