### PR TITLE
Fix forgotton info querey in getMonitorBitsPerPixel()

### DIFF
--- a/src/cinder/app/msw/PlatformMsw.cpp
+++ b/src/cinder/app/msw/PlatformMsw.cpp
@@ -274,6 +274,7 @@ int getMonitorBitsPerPixel( HMONITOR hMonitor )
 	MONITORINFOEX mix;
 	memset( &mix, 0, sizeof( MONITORINFOEX ) );
 	mix.cbSize = sizeof( MONITORINFOEX );
+	::GetMonitorInfo(hMonitor, &mix);
 	HDC hMonitorDC = ::CreateDC( TEXT("DISPLAY"), mix.szDevice, NULL, NULL );
 	if( hMonitorDC ) {
 		result = ::GetDeviceCaps( hMonitorDC, BITSPIXEL );


### PR DESCRIPTION
The MONITORINFOEX structure never got filled with data in this function.

Disclaimer:
This fix is based on immitating the neighboring function `getMonitorName()` and what I could put together from the MSDN documentation of the other involved functions - I've no actual experience with the windows API.