### PR TITLE
Start and stop animation only when the app active state changes

### DIFF
--- a/src/cinder/app/cocoa/AppImplCocoaTouch.mm
+++ b/src/cinder/app/cocoa/AppImplCocoaTouch.mm
@@ -45,20 +45,16 @@ using namespace cinder::app;
 	mApp->privateSetup__();
 	mAppImpl->mSetupHasFired = YES;
 
-	[mAppImpl startAnimation];
-
 	return YES;
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
-	[mAppImpl stopAnimation];
 	mApp->emitDidEnterBackground();
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
 {
-	[mAppImpl startAnimation];
 	mApp->emitWillEnterForeground();
 }
 


### PR DESCRIPTION
Both `applicationDidEnterBackground` and `applicationWillEnterForeground` are called when the app is not in an active state. This change limits start/stopAnimation to being called when the app is visible to the user. This eliminates some glitches that occur when resuming a background app, which were due to the update/draw methods being called when the app was not visible.
### Resuming CubeApp before:

![resume_active_before](https://cloud.githubusercontent.com/assets/27721/19826619/22474762-9d44-11e6-8356-077648ab8dd4.gif)
### Resuming CubeApp after:

![resume_active_after](https://cloud.githubusercontent.com/assets/27721/19826620/259dfdb6-9d44-11e6-884a-c2a601beb641.gif)
