### PR TITLE
Fix early termination of glfw and add cleanup signal.

### DIFF
--- a/src/cinder/app/linux/AppImplLinuxGlfw.cpp
+++ b/src/cinder/app/linux/AppImplLinuxGlfw.cpp
@@ -272,6 +272,7 @@ AppImplLinux::AppImplLinux( AppLinux *aApp, const AppLinux::Settings &settings )
 
 AppImplLinux::~AppImplLinux()
 {
+	::glfwTerminate();
 }
 
 AppLinux *AppImplLinux::getApp()
@@ -346,11 +347,10 @@ void AppImplLinux::run()
 	}
 
   terminate:
+	mApp->emitCleanup();
 	// Destroy the main window - this should resolve to
 	// a call for ::glfwDestroyWindow( ... );
 	mMainWindow.reset();
-
-	::glfwTerminate();
 }
 
 RendererRef AppImplLinux::findSharedRenderer( const RendererRef &searchRenderer )


### PR DESCRIPTION
This fixes cases where calls to glfw where issued after the library had been terminated ( test with the FlickrTestMultiThreaded sample ) and also adds the missing `cleanup()` signal before app termination.
