### PR TITLE
Made GlslProg::findUniform( const std::string&, int* ) behavior closer to GlslProg::findUniform( int, int* )

### DIFF
--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -1020,7 +1020,9 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 	// first check if there is an exact name match with mUniforms and simply return it if we find one
 	for( const auto & uniform : mUniforms ) {
 		if( uniform.mName == name ) {
-			*resultLocation = uniform.mLoc;
+			if( resultLocation ) {
+				*resultLocation = uniform.mLoc;
+			}
 			return &uniform;
 		}
 	}
@@ -1068,7 +1070,7 @@ const GlslProg::Uniform* GlslProg::findUniform( const std::string &name, int *re
 		}
 	}
 
-	if( resultUniform ) {
+	if( resultLocation && resultUniform ) {
 		if( needsLocationOffset ) {
 			CI_ASSERT( requestedNameLeftSquareBracket != string::npos && requestedNameRightSquareBracket != string::npos );
 


### PR DESCRIPTION
Updated findUniform( const std::string &name, int *resultLocation ) to have the same behavior as const findUniform( int location, int *resultLocation ) const. Currently one of the two methods breaks when trying to pass nullptr, while the other just skip it. This PR addresses this issue.

If I understand [the method's comment](https://github.com/cinder/Cinder/blob/master/include/cinder/gl/GlslProg.h#L441) correctly, it sounds like this should be the intended/expected behavior.:
```c++
//! Returns a const pointer to the Uniform that matches \a name. Returns nullptr if the uniform doesn't exist. The uniform location (accounting for indices, like "example[2]") is stored in \a resultLocation if it's non-null.
const Uniform* findUniform( const std::string &name, int *resultLocation ) const;
```
