### PR TITLE
A couple minor compute shader additions

### DIFF
--- a/include/cinder/gl/gl.h
+++ b/include/cinder/gl/gl.h
@@ -37,6 +37,7 @@
 #include "cinder/gl/Query.h"
 #include "cinder/gl/Shader.h"
 #include "cinder/gl/ShaderPreprocessor.h"
+#include "cinder/gl/Ssbo.h"
 #include "cinder/gl/Sync.h"
 #include "cinder/gl/Texture.h"
 #include "cinder/gl/TextureFont.h"

--- a/include/cinder/gl/wrapper.h
+++ b/include/cinder/gl/wrapper.h
@@ -346,7 +346,7 @@ void	readPixels( GLint x, GLint y, GLsizei width, GLsizei height, GLenum format,
 // Compute
 #if defined( CINDER_MSW ) && ! defined( CINDER_GL_ANGLE )
 //! Launches one or more compute work groups. Analogous to glDispatchCompute(). 
-inline void	dispatchCompute( GLuint numGroupsX, GLuint numGroupsY, GLuint numGroupsZ ) { glDispatchCompute( numGroupsX, numGroupsY, numGroupsZ ); }
+inline void	dispatchCompute( GLuint numGroupsX, GLuint numGroupsY = 1, GLuint numGroupsZ = 1 ) { glDispatchCompute( numGroupsX, numGroupsY, numGroupsZ ); }
 //! Defines a barrier ordering memory transactions. Analogous to glMemoryBarrier().
 inline void	memoryBarrier( GLbitfield barriers ) { glMemoryBarrier( barriers ); }
 


### PR DESCRIPTION
I added the defaults for `dispatchCompute()`'s numGroupsY and numGroupsX as it is the same as what happens in the compute shader's `layout( local_size_x = X​, ... )`, according to [this doc](https://www.opengl.org/wiki/Compute_Shader#Local_size).