### PR TITLE
A fix for an issue where indices were incompletely copied over from g…

### DIFF
--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -536,7 +536,7 @@ void Target::generateIndicesForceLines( Primitive primitive, size_t numInputIndi
 
 void Target::copyIndexData( const uint32_t *source, size_t numIndices, uint32_t *target )
 {
-	memcpy( target, source, numIndices * sizeof(float) );
+	memcpy( target, source, numIndices * sizeof(uint32_t) );
 }
 
 void Target::copyIndexData( const uint32_t *source, size_t numIndices, uint16_t *target )

--- a/src/cinder/gl/draw.cpp
+++ b/src/cinder/gl/draw.cpp
@@ -544,7 +544,7 @@ class DefaultVboTarget : public geom::Target {
 			return;
 
 		mIndexType = GL_UNSIGNED_INT;
-		mElementVbo->bufferSubData( 0, numIndices * requiredBytesPerIndex, sourceData );
+		mElementVbo->bufferSubData( 0, numIndices * 4, sourceData );
 	}
 
 	const geom::Source*		mSource;


### PR DESCRIPTION
…eom::Source when being drawn with gl::draw

This issue was causing certain geom::Source classes, which may specify less than 4 bytes per index in their copyIndices calls, to be incorrectly rendered when passed to gl::draw(). Namely, the Cube, Icosahedron, and Extrude classes.

gl::draw(geom::Source &) constructs a DefaultVboTarget into which the geom::Source is loaded. However, without index type conversion like in VboMeshGeomTarget, the indices are incompletely copied, ending up garbled.

This seemed to me like the most straightforward solution to the problem. It wouldn’t be the first copyIndices impl to totally ignore requiredBytesPerIndex. In fact, only VboMeshGeomTarget::copyIndices actually uses this parameter.