### PR TITLE
Added signals::ConnectionList

### DIFF
--- a/include/cinder/Signals.h
+++ b/include/cinder/Signals.h
@@ -145,10 +145,8 @@ class ScopedConnection : public Connection, private Noncopyable {
   public:
 	ScopedConnection();
 	~ScopedConnection();
-	ScopedConnection( const Connection &other );
 	ScopedConnection( ScopedConnection &&other );
 	ScopedConnection( Connection &&other );
-	ScopedConnection& operator=( const Connection &rhs );
 	ScopedConnection& operator=( ScopedConnection &&rhs );
 };
 

--- a/include/cinder/Signals.h
+++ b/include/cinder/Signals.h
@@ -148,6 +148,9 @@ class ScopedConnection : public Connection, private Noncopyable {
 	ScopedConnection( ScopedConnection &&other );
 	ScopedConnection( Connection &&other );
 	ScopedConnection& operator=( ScopedConnection &&rhs );
+
+  private:
+	bool	mShouldDisconnect = true; // only set to false when move assignment operator is invoked.
 };
 
 // ----------------------------------------------------------------------------------------------------

--- a/include/cinder/Signals.h
+++ b/include/cinder/Signals.h
@@ -152,6 +152,10 @@ class ScopedConnection : public Connection, private Noncopyable {
 	ScopedConnection& operator=( ScopedConnection &&rhs );
 };
 
+// ----------------------------------------------------------------------------------------------------
+// ConnectionList
+// ----------------------------------------------------------------------------------------------------
+
 //! Maintains a list of Connections and calls disconnect on them when it is destroyed. Non-copyable.
 class ConnectionList : private Noncopyable {
   public:
@@ -167,6 +171,10 @@ class ConnectionList : private Noncopyable {
   private:
 	std::vector<Connection>	mConnections;
 };
+
+// ----------------------------------------------------------------------------------------------------
+// Collectors
+// ----------------------------------------------------------------------------------------------------
 
 namespace detail {
 
@@ -224,6 +232,10 @@ struct CollectorInvocation<Collector, void( Args... )> : public SignalBase {
 		return collector();
 	}
 };
+
+// ----------------------------------------------------------------------------------------------------
+// SignalProto
+// ----------------------------------------------------------------------------------------------------
 
 //! SignalProto template, the parent class of Signal, specialised for the callback signature and collector.
 template<class Collector, class R, class... Args>

--- a/include/cinder/Signals.h
+++ b/include/cinder/Signals.h
@@ -121,6 +121,8 @@ class Connection {
   public:
 	Connection();
 	Connection( const std::shared_ptr<detail::Disconnector> &disconnector, detail::SignalLinkBase *link, int priority );
+	Connection( Connection &&other );
+	Connection& operator=( Connection &&rhs );
 
 	//! Disconnects this Connection from the callback chain. \a return true if a disconnection was made, false otherwise.
 	bool disconnect();
@@ -148,9 +150,6 @@ class ScopedConnection : public Connection, private Noncopyable {
 	ScopedConnection( ScopedConnection &&other );
 	ScopedConnection( Connection &&other );
 	ScopedConnection& operator=( ScopedConnection &&rhs );
-
-  private:
-	bool	mShouldDisconnect = true; // only set to false when move assignment operator is invoked.
 };
 
 // ----------------------------------------------------------------------------------------------------

--- a/include/cinder/Signals.h
+++ b/include/cinder/Signals.h
@@ -152,6 +152,22 @@ class ScopedConnection : public Connection, private Noncopyable {
 	ScopedConnection& operator=( ScopedConnection &&rhs );
 };
 
+//! Maintains a list of Connections and calls disconnect on them when it is destroyed. Non-copyable.
+class ConnectionList : private Noncopyable {
+  public:
+	~ConnectionList();
+
+	//! Add a Connection to the list
+	void add( Connection &&target );
+	//! Disconnects and clears all Connections.
+	void clear();
+	//! Same as add()
+	void operator+=( Connection &&target ) { add( std::move( target ) ); }
+
+  private:
+	std::vector<Connection>	mConnections;
+};
+
 namespace detail {
 
 //! The template implementation for callback list.

--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -83,11 +83,6 @@ ScopedConnection::~ScopedConnection()
 	disconnect();
 }
 
-ScopedConnection::ScopedConnection( const Connection &other )
-	: Connection( other )
-{
-}
-
 ScopedConnection::ScopedConnection( ScopedConnection &&other )
 	: Connection( std::move( other ) )
 {
@@ -96,13 +91,6 @@ ScopedConnection::ScopedConnection( ScopedConnection &&other )
 ScopedConnection::ScopedConnection( Connection &&other )
 	: Connection( std::move( other ) )
 {
-}
-
-ScopedConnection& ScopedConnection::operator=( const Connection &rhs )
-{
-	disconnect();
-	Connection::operator=( rhs );
-	return *this;
 }
 
 ScopedConnection& ScopedConnection::operator=( ScopedConnection &&rhs )

--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -125,6 +125,8 @@ void ConnectionList::clear()
 {
 	for( auto &conn : mConnections )
 		conn.disconnect();
+
+	mConnections.clear();
 }
 
 namespace detail {

--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -80,7 +80,8 @@ ScopedConnection::ScopedConnection()
 
 ScopedConnection::~ScopedConnection()
 {
-	disconnect();
+	if( mShouldDisconnect )
+		disconnect();
 }
 
 ScopedConnection::ScopedConnection( ScopedConnection &&other )
@@ -95,6 +96,9 @@ ScopedConnection::ScopedConnection( Connection &&other )
 
 ScopedConnection& ScopedConnection::operator=( ScopedConnection &&rhs )
 {
+	disconnect(); // first disconnect from existing
+	rhs.mShouldDisconnect = false; // mark that rhs shouldn't disconnect as it is about to be moved to this
+
 	Connection::operator=( std::move( rhs ) );
 	return *this;
 }

--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -118,7 +118,7 @@ ConnectionList::~ConnectionList()
 
 void ConnectionList::add( Connection &&target )
 {
-	mConnections.emplace_back( target );
+	mConnections.emplace_back( std::move( target ) );
 }
 
 void ConnectionList::clear()

--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -111,6 +111,22 @@ ScopedConnection& ScopedConnection::operator=( ScopedConnection &&rhs )
 	return *this;
 }
 
+ConnectionList::~ConnectionList()
+{
+	clear();
+}
+
+void ConnectionList::add( Connection &&target )
+{
+	mConnections.emplace_back( target );
+}
+
+void ConnectionList::clear()
+{
+	for( auto &conn : mConnections )
+		conn.disconnect();
+}
+
 namespace detail {
 
 Disconnector::Disconnector( SignalBase *signal )

--- a/test/unit/src/signals/SignalsTest.cpp
+++ b/test/unit/src/signals/SignalsTest.cpp
@@ -325,9 +325,42 @@ TEST_CASE( "signals/Signals" )
 		REQUIRE( accum == 2 );
 	}
 
-	SECTION("Signal result collection")
+	SECTION( "ConnectionList" )
 	{
-		SECTION("TestCollectorVector")
+		Signal<void ()> sig;
+		ConnectionList connections;
+
+		int accum = 0;
+		auto slot = [&] { accum++; };
+
+		connections += sig.connect( slot );
+		REQUIRE( sig.getNumSlots() == 1 );
+
+		{
+			ConnectionList connections2;
+
+			connections += sig.connect( slot );
+			connections2 += sig.connect( slot );
+
+			REQUIRE( sig.getNumSlots() == 3 );
+		}
+
+		REQUIRE( sig.getNumSlots() == 2 );
+
+		sig.emit();
+		REQUIRE( accum == 2 );
+
+		connections.clear();
+		REQUIRE( sig.getNumSlots() == 0 );
+
+		accum = 0;
+		sig.emit();
+		REQUIRE( accum == 0 );
+	}
+
+	SECTION( "Signal result collection" )
+	{
+		SECTION( "TestCollectorVector" )
 		{
 			auto handler1 = [] { return 1; };
 			auto handler42 = []  { return 42; };
@@ -528,4 +561,5 @@ TEST_CASE( "signals/Signals" )
 			REQUIRE( sum == 10 );
 		}
 	}
+
 } // Signals


### PR DESCRIPTION
Utility to easily maintain a bunch of connections, disconnecting them when container is destroyed. Tying connections to an object's scope is vital in making sure runtime reloads are safe, and this makes it much easier to do so as compared to keeping a bunch of `ScopedConnections` (the dreaded mConnTouchBegan, mConnTouchMove, mConnBlah... anti-pattern).

Convenient syntax looks like:

```cpp
ci::signals::ConnectionList mConnections;

...

mConnections += getSignalXXX().connect( [this] { ... }; );
mConnections += getSignalYYY().connect( [this] { ... }; );
```

Right now it only accepts an R-value reference to a `Connection`, I'm not sure if we need anything more than this.

- [x] Add unit test.