### PR TITLE
Correcting path that unit tests run out of.  #1672

### DIFF
--- a/test/unit/proj/cmake/CMakeLists.txt
+++ b/test/unit/proj/cmake/CMakeLists.txt
@@ -34,9 +34,9 @@ target_compile_definitions(
 )
 
 if( APPLE )
-	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/UnitTests.app/Contents/MacOS )
+	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/UnitTests/UnitTests.app/Contents/MacOS )
 else()
-	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE} )
+	set( TESTBINDIR ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/UnitTests )
 endif()
 
 add_test(


### PR DESCRIPTION
This should resolve #1672
Let me know if this is the proper way or if I should be pulling `UnitTests` out of the CMAKE project name, etc.