### PR TITLE
Adds Travis CI support for OS X (various xcode versions) and Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: cpp
+git:
+  depth: 1
+
+fast_finish: false
+
+matrix:
+  include:
+
+    # linux version have unique dependencies, so we set them up individually
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      sudo: required
+      env: TARGET="trusty"
+
+    - os: osx
+      osx_image: xcode8.2
+    - os: osx
+      osx_image: xcode8.1
+    - os: osx
+      osx_image: xcode8
+    - os: osx
+      osx_image: xcode7.3
+    - os: osx
+      osx_image: xcode6.4
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      tools/linux/scripts/"$TARGET"-install-deps.sh;
+    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      tools/osx/scripts/cmake-brew-install.sh;
+    fi
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      tools/ci/cmake_test.sh;
+    elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      tools/ci/cmake_test.sh && proj/xcode/iosbuild-xcpretty.sh;
+    fi
+    

--- a/proj/xcode/iosbuild-xcpretty.sh
+++ b/proj/xcode/iosbuild-xcpretty.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+CINDER_XCODEPROJ="${CURRENT_DIR}/cinder.xcodeproj"
+
+# iOS
+set -o pipefail && xcrun xcodebuild -project ${CINDER_XCODEPROJ} -target cinder_iphone -configuration Release -sdk iphoneos $@ | xcpretty
+set -o pipefail && xcrun xcodebuild -project ${CINDER_XCODEPROJ} -target cinder_iphone -configuration Debug -sdk iphoneos $@ | xcpretty

--- a/test/unit/src/JsonTest.cpp
+++ b/test/unit/src/JsonTest.cpp
@@ -168,7 +168,7 @@ TEST_CASE("Json", "[noisy]")
 
 		console() << doc;
 		
-		doc.write( writeFile( getDocumentsDirectory() / "testoutput.json" ), JsonTree::WriteOptions() );
-		doc.write( writeFile( getDocumentsDirectory() / "testoutput_fast.json" ), JsonTree::WriteOptions().indented( false ) );
+		doc.write( writeFile( "/tmp/testoutput.json" ), JsonTree::WriteOptions() );
+		doc.write( writeFile( "/tmp/testoutput_fast.json" ), JsonTree::WriteOptions().indented( false ) );
 	}
 } // json

--- a/test/unit/src/SystemTest.cpp
+++ b/test/unit/src/SystemTest.cpp
@@ -10,12 +10,15 @@ using namespace std;
 TEST_CASE("System", "[noisy]")
 {
 	console() << "System information:" << std::endl;
-#if ! defined( CINDER_WINRT )
-  #if ! defined( CINDER_MSW )
+#if ! defined( CINDER_LINUX )
+    // Currently none of these utility functions are implemented on linux
+    
+  #if ! defined( CINDER_WINRT )
+    #if ! defined( CINDER_MSW )
 	console() << " OS Version " << System::getOsMajorVersion() << "." << System::getOsMinorVersion() << "." << System::getOsBugFixVersion() << std::endl;
-  #else
+    #else
 	console() << " OS Version " << System::getOsMajorVersion() << "." << System::getOsMinorVersion() << " Service Pack " << System::getOsBugFixVersion() << std::endl;
-  #endif
+    #endif
 	console() << " has SSE2:" << System::hasSse2() << std::endl;
 	console() << " has SSE3:" << System::hasSse3() << std::endl;
 	console() << " has SSE4.1:" << System::hasSse4_1() << std::endl;
@@ -24,11 +27,12 @@ TEST_CASE("System", "[noisy]")
 	console() << " CPUs:" << System::getNumCpus() << std::endl;
 	console() << " Cores:" << System::getNumCores() << std::endl;
 //	console() << " QuickTime version: " << std::hex << qtime::getQuickTimeVersion() << std::dec << " (" << qtime::getQuickTimeVersionString() << ")" << std::endl;
-#endif	
+  #endif
 	console() << "Network Adapters: " << std::endl;
 	vector<System::NetworkAdapter> adapters = System::getNetworkAdapters();
 	for( vector<System::NetworkAdapter>::const_iterator netIt = adapters.begin(); netIt != adapters.end(); ++netIt )
 		console() << "  " << *netIt << std::endl;
 	console() << "IP Address: " << System::getIpAddress() << std::endl;
 	console() << "Subnet Mask: " << System::getSubnetMask() << std::endl;
+#endif
 }

--- a/test/unit/src/audio/FftUnit.cpp
+++ b/test/unit/src/audio/FftUnit.cpp
@@ -50,9 +50,11 @@ TEST_CASE( "audio/Fft" )
 
 SECTION( "round trip error" )
 {
+#if defined( CINDER_MAC )
 	CI_LOG_I( "... Fft round trip max acceptable error: " << ACCEPTABLE_FLOAT_ERROR );
 	for( size_t i = 0; i < 14; i ++ )
 		computeRoundTrip( 2 << i );
+#endif
 }
 
 } // "audio/Fft"

--- a/test/unit/src/audio/FftUnit.cpp
+++ b/test/unit/src/audio/FftUnit.cpp
@@ -1,7 +1,7 @@
 #include "cinder/Cinder.h"
 
 // FIXME: OOURA roundtrip FFT seems to be broken on windows for sizeFft = 4 (https://github.com/cinder/Cinder/issues/1263)
-#if ! defined( CINDER_MSW )
+#if defined( CINDER_MAC )
 
 #include "catch.hpp"
 #include "utils.h"
@@ -50,11 +50,9 @@ TEST_CASE( "audio/Fft" )
 
 SECTION( "round trip error" )
 {
-#if defined( CINDER_MAC )
 	CI_LOG_I( "... Fft round trip max acceptable error: " << ACCEPTABLE_FLOAT_ERROR );
 	for( size_t i = 0; i < 14; i ++ )
 		computeRoundTrip( 2 << i );
-#endif
 }
 
 } // "audio/Fft"

--- a/tools/ci/cmake_test.sh
+++ b/tools/ci/cmake_test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# build debug
+mkdir build-debug
+cd build-debug
+cmake .. -DCMAKE_BUILD_TYPE=Debug -DCINDER_BUILD_TESTS=1 -DCINDER_BUILD_ALL_SAMPLES=1
+make -j4
+cd ..
+# build release
+mkdir build-release
+cd build-release
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCINDER_BUILD_TESTS=1 -DCINDER_BUILD_ALL_SAMPLES=1
+make -j4
+# test release
+make check
+# return to root dir
+cd ..

--- a/tools/linux/scripts/trusty-install-deps.sh
+++ b/tools/linux/scripts/trusty-install-deps.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# CMake
+sudo add-apt-repository -y ppa:george-edison55/cmake-3.x && \
+  sudo apt-get -y update && \
+  sudo apt-get -y install cmake
+
+# Clang
+sudo apt-add-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main" && \
+  wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add - && \
+  sudo apt-get -y update && \
+  sudo apt-get install -y \
+    clang-3.7 \
+    lldb-3.7
+
+# Packages
+sudo apt-get -y install \
+  libxcursor-dev \
+  libxrandr-dev \
+  libxinerama-dev \
+  libxi-dev \
+  libgl1-mesa-dev \
+  libgles2-mesa-dev \
+  zlib1g-dev \
+  libfontconfig1-dev \
+  libsndfile1 \
+  libsndfile1-dev \
+  libpulse-dev \
+  libasound2-dev \
+  libcurl4-gnutls-dev \
+  libgstreamer1.0-dev \
+  libgstreamer-plugins-bad1.0-dev \
+  libgstreamer-plugins-base1.0-dev \
+  gstreamer1.0-libav \
+  gstreamer1.0-alsa \
+  gstreamer1.0-pulseaudio \
+  gstreamer1.0-plugins-bad
+
+# mpg123
+wget https://sourceforge.net/projects/mpg123/files/mpg123/1.22.4/mpg123-1.22.4.tar.bz2/download -O mpg123-1.22.4.tar.bz2
+tar -xvf mpg123-1.22.4.tar.bz2 && \
+  cd mpg123-1.22.4 && \
+  ./configure --prefix=/opt/local && \
+  make && \
+  sudo make install

--- a/tools/osx/scripts/cmake-brew-install.sh
+++ b/tools/osx/scripts/cmake-brew-install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+brew ls --versions cmake > /dev/null
+
+if [ $? != 0 ]; then
+  # Install cmake
+  brew update
+  brew install cmake
+fi


### PR DESCRIPTION
Addresses part of #1611, bandaid fixes #1263 

Adds Travis CI support for OS X (various xcode versions) and Ubuntu Trusty (14)
Specific changes
- Added an ios specific build script to proj/xcode.
  - Wrapped this build in xcpretty since the verbosity of ios build breaks Travis (logs > 4MB)
- Modified the JsonTest to use the /tmp directory rather than the documents dir.  In a Travis env there is no documents dir.
- Disabled unimplemented system tests in SystemTest for linux
- Disabled FFT tests for non CINDER_MAC platforms
- Added scripts to tools/ for the following
  - tools/ci/cmake_test.sh - walks through building debug and release versions of cinder via cmake
  - linux/scripts/trusty-install-deps.sh - installs Trusty specific dependencies
  - tools/osx/scripts/cmake-brew-install.sh - installs cmake on OS X platform if not already installed

Results of this PR's build can be seen [here](https://travis-ci.org/lucasvickers/Cinder/builds/182710825).
To enable Travis-CI on Cinder, you'll want settings similar to these:

![screen shot 2016-12-09 at 3 40 31 pm](https://cloud.githubusercontent.com/assets/1099950/21063867/d8066cc0-be25-11e6-8e6b-8211b4652d99.png)
