### PR TITLE
String i/o improvements

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -31,6 +31,7 @@
 #include "cinder/Cinder.h"
 #include "cinder/Url.h"
 #include "cinder/DataSource.h"
+#include "cinder/DataTarget.h"
 #undef check
 #include <boost/lexical_cast.hpp>
 
@@ -53,6 +54,8 @@ std::vector<std::string> split( const std::string &str, const std::string &separ
 
 //! Loads the contents of \a dataSource and returns it as a std::string
 std::string loadString( const DataSourceRef &dataSource );
+void writeString( const fs::path &path, const std::string &str );
+void writeString( const DataTargetRef &dataTarget, const std::string &str );
 
 //! Suspends the execution of the current thread until \a milliseconds have passed. Supports sub-millisecond precision only on Mac OS X.
 void sleep( float milliseconds );

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -83,10 +83,10 @@ std::vector<std::string> split( const std::string &str, const std::string &separ
 
 string loadString( const DataSourceRef &dataSource )
 {
-	Buffer buffer( dataSource );
-	const char *data = static_cast<const char *>( buffer.getData() );
+	auto buffer = dataSource->getBuffer();
+	const char *data = static_cast<const char *>( buffer->getData() );
 
-	return string( data, data + buffer.getSize() );
+	return string( data, data + buffer->getSize() );
 }
 
 void sleep( float milliseconds )

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -89,6 +89,23 @@ string loadString( const DataSourceRef &dataSource )
 	return string( data, data + buffer->getSize() );
 }
 
+void writeString( const fs::path &path, const std::string &str )
+{
+	writeString( (DataTargetRef)writeFile( path ), str );
+}
+
+void writeString( const DataTargetRef &dataTarget, const std::string &str )
+{
+	fs::path outPath = dataTarget->getFilePath();
+	if( outPath.empty() ) {
+		throw ci::Exception( "writeString can only write to file." );
+	}
+
+	std::ofstream ofs( outPath.string(), std::ofstream::binary );
+	ofs << str;
+	ofs.close();
+}
+
 void sleep( float milliseconds )
 {
 	app::Platform::get()->sleep( milliseconds );

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -268,10 +268,10 @@ GlslProg::Format& GlslProg::Format::compute( const string &computeShader )
 void GlslProg::Format::setShaderSource( const DataSourceRef &dataSource, string *shaderSourceDest, fs::path *shaderPathDest )
 {
 	if( dataSource ) {
-		Buffer buffer( dataSource );
-		shaderSourceDest->resize( buffer.getSize() + 1 );
-		memcpy( (void *)shaderSourceDest->data(), buffer.getData(), buffer.getSize() );
-		(*shaderSourceDest)[buffer.getSize()] = 0;
+		auto buffer = dataSource->getBuffer();
+		const char *data = static_cast<const char *>( buffer->getData() );
+		*shaderSourceDest = string( data, data + buffer->getSize() );
+
 		if( dataSource->isFilePath() )
 			*shaderPathDest = dataSource->getFilePath();
 		else

--- a/test/unit/assets/test_load_write_string.txt
+++ b/test/unit/assets/test_load_write_string.txt
@@ -1,0 +1,2 @@
+Hey Hey
+Ho Ho

--- a/test/unit/src/Utilities.cpp
+++ b/test/unit/src/Utilities.cpp
@@ -1,0 +1,27 @@
+#include "catch.hpp"
+
+#include "cinder/Cinder.h"
+#include "cinder/Utilities.h"
+#include "cinder/app/App.h"
+
+using namespace std;
+using namespace ci;
+
+TEST_CASE( "Utilities" )
+{
+	SECTION( "string load / write" )
+	{
+		// Read the test string
+		string str1 = loadString( app::loadAsset( "test_load_write_string.txt" ) );
+
+		// Save it to disk
+		const fs::path outPath = app::getAppPath() / "test_out.txt"; 
+		writeString( outPath, str1 );
+
+		// Re-read it and compare the result;
+		string str2 = loadString( loadFile( outPath ) );
+
+		REQUIRE( str1.size() == str2.size() );
+		REQUIRE( str1 == str2 );
+	}
+}

--- a/test/unit/vc2013/unit.vcxproj
+++ b/test/unit/vc2013/unit.vcxproj
@@ -271,6 +271,7 @@
     <ClCompile Include="..\src\SystemTest.cpp" />
     <ClCompile Include="..\src\TestMain.cpp" />
     <ClCompile Include="..\src\UnicodeTest.cpp" />
+    <ClCompile Include="..\src\Utilities.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\audio\utils.h" />

--- a/test/unit/vc2013/unit.vcxproj.filters
+++ b/test/unit/vc2013/unit.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\src\audio\RingBufferUnit.cpp">
       <Filter>Source Files\audio</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\Utilities.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\catch.hpp">


### PR DESCRIPTION
- Added writeString() to Utilities.h (only works with file targets for now)
- loadString() uses one less malloc / copy
- fixed a stray NUL that was getting written to shader sources in GlslProg::Format::setShaderSource()
- added unit test for round trip `loadString()` / `writeString()`.

Todo:
- [ ] add unit tests' Utilities.cpp to cmake source list (android_linux branch).