### PR TITLE
fix include utilities

### DIFF
--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -76,7 +76,7 @@ std::vector<std::string> split( const std::string &str, const std::string &separ
 {
 	vector<string> result;
 
-	boost::algorithm::split( result, str, boost::is_any_of(separators), 
+	boost::algorithm::split( result, str, boost::is_any_of(separators),
 		compress ? boost::token_compress_on : boost::token_compress_off );
 
 	return result;
@@ -117,39 +117,45 @@ vector<string> stackTrace()
 	return app::Platform::get()->stackTrace();
 }
 
-int16_t swapEndian( int16_t val ) { 
-	return (int16_t) (	(((uint16_t) (val) & (uint16_t) 0x00ffU) << 8) | 
+int16_t swapEndian( int16_t val )
+{
+	return (int16_t) (	(((uint16_t) (val) & (uint16_t) 0x00ffU) << 8) |
 						(((uint16_t) (val) & (uint16_t) 0xff00U) >> 8) );
 }
 
-uint16_t swapEndian( uint16_t val ) { 
-	return (uint16_t) (	(((uint16_t) (val) & (uint16_t) 0x00ffU) << 8) | 
+uint16_t swapEndian( uint16_t val )
+{
+	return (uint16_t) (	(((uint16_t) (val) & (uint16_t) 0x00ffU) << 8) |
 						(((uint16_t) (val) & (uint16_t) 0xff00U) >> 8) );
 }
 
-int32_t swapEndian( int32_t val ) { 
+int32_t swapEndian( int32_t val )
+{
 	return (int32_t)((((uint32_t) (val) & (uint32_t) 0x000000FFU) << 24) |
 					 (((uint32_t) (val) & (uint32_t) 0x0000FF00U) <<  8) |
 					 (((uint32_t) (val) & (uint32_t) 0x00FF0000U) >>  8) |
 					 (((uint32_t) (val) & (uint32_t) 0xFF000000U) >> 24));
 }
 
-uint32_t swapEndian( uint32_t val ) { 
+uint32_t swapEndian( uint32_t val )
+{
 	return (uint32_t)((((uint32_t) (val) & (uint32_t) 0x000000FFU) << 24) |
 					 (((uint32_t) (val) & (uint32_t) 0x0000FF00U) <<  8) |
 					 (((uint32_t) (val) & (uint32_t) 0x00FF0000U) >>  8) |
 					 (((uint32_t) (val) & (uint32_t) 0xFF000000U) >> 24));
 }
 
-float swapEndian( float val ) { 
+float swapEndian( float val )
+{
 	uint32_t temp = swapEndian( * reinterpret_cast<uint32_t*>( &val ) );
 	return *(reinterpret_cast<float*>( &temp ) );
 }
 
-double swapEndian( double val ) {
+double swapEndian( double val )
+{
 	union {
 		double d;
-		struct {  
+		struct {
 			uint32_t a;
 			uint32_t b;
 		} i;

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <vector>
+#include <fstream>
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string.hpp>
 


### PR DESCRIPTION
cinder/utilities.cpp should include the `fstream` header (leads to compilation eror on VS2015 U3)

This pr also makes a few small formatting changes:
- delete some trailing whitespaces
- the opening `{` of a function is always on a new line