### PR TITLE
CMake: Fix Cinder dynamic lib target on OS X.

### DIFF
--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -69,12 +69,6 @@ if( ( NOT CINDER_LINUX ) AND ( NOT CINDER_ANDROID ) )
 	)
 endif()
 
-if( ( NOT CINDER_MSW ) AND ( NOT CINDER_ANDROID ) )
-	list( APPEND SRC_SET_CINDER
-		${CINDER_SRC_DIR}/cinder/UrlImplCurl.cpp
-	)
-endif()
-
 list( APPEND CINDER_SRC_FILES   ${SRC_SET_CINDER} )
 source_group( "cinder" FILES    ${SRC_SET_CINDER} )
 

--- a/proj/cmake/platform_linux.cmake
+++ b/proj/cmake/platform_linux.cmake
@@ -46,6 +46,9 @@ list( APPEND SRC_SET_CINDER_VIDEO_LINUX
     ${CINDER_SRC_DIR}/cinder/linux/Movie.cpp
 )
 
+# Curl 
+list( APPEND SRC_SET_CINDER_LINUX ${CINDER_SRC_DIR}/cinder/UrlImplCurl.cpp )
+
 # Relevant source files depending on target GL.
 if( NOT CINDER_GL_ES_2_RPI )
 	if( CINDER_GL_ES )

--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -93,6 +93,7 @@ find_library( COREVIDEO_FRAMEWORK CoreVideo REQUIRED )
 find_library( ACCELERATE_FRAMEWORK Accelerate REQUIRED )
 find_library( IOSURFACE_FRAMEWORK IOSurface REQUIRED )
 find_library( IOKIT_FRAMEWORK IOKit REQUIRED )
+find_library( CURL_LIB curl REQUIRED )
 
 # Option for using GStreamer under OS X.
 if( CINDER_MAC )
@@ -121,6 +122,7 @@ list( APPEND CINDER_LIBS_DEPENDS
     ${ACCELERATE_FRAMEWORK}
     ${IOSURFACE_FRAMEWORK}
     ${IOKIT_FRAMEWORK}
+    ${CURL_LIB}
 )
 
 source_group( "cinder\\cocoa"           FILES ${SRC_SET_COCOA} )

--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -93,7 +93,6 @@ find_library( COREVIDEO_FRAMEWORK CoreVideo REQUIRED )
 find_library( ACCELERATE_FRAMEWORK Accelerate REQUIRED )
 find_library( IOSURFACE_FRAMEWORK IOSurface REQUIRED )
 find_library( IOKIT_FRAMEWORK IOKit REQUIRED )
-find_library( CURL_LIB curl REQUIRED )
 
 # Option for using GStreamer under OS X.
 if( CINDER_MAC )
@@ -122,7 +121,6 @@ list( APPEND CINDER_LIBS_DEPENDS
     ${ACCELERATE_FRAMEWORK}
     ${IOSURFACE_FRAMEWORK}
     ${IOKIT_FRAMEWORK}
-    ${CURL_LIB}
 )
 
 source_group( "cinder\\cocoa"           FILES ${SRC_SET_COCOA} )


### PR DESCRIPTION
This allows Cinder to build as a dynamic library on OS X using CMake. Tested with BasicApp and DeferredShadingAdvanced.

To test configure with `cmake .. -DBUILD_SHARED_LIBS=1` when building Cinder and from then on continue as usual.