### PR TITLE
PolyLine3d doesn't really work

### DIFF
--- a/include/cinder/PolyLine.h
+++ b/include/cinder/PolyLine.h
@@ -99,8 +99,5 @@ class PolyLineT {
 typedef PolyLineT<vec2>		PolyLine2;
 typedef PolyLineT<vec2>		PolyLine2f;
 typedef PolyLineT<dvec2>	PolyLine2d;
-typedef PolyLineT<vec3>		PolyLine3;
-typedef PolyLineT<vec3>		PolyLine3f;
-typedef PolyLineT<dvec3>	PolyLine3d;
 
 } // namespace cinder

--- a/include/cinder/gl/draw.h
+++ b/include/cinder/gl/draw.h
@@ -51,7 +51,8 @@ void draw( const Texture2dRef &texture, const Rectf &dstRect );
 void draw( const Texture2dRef &texture, const Area &srcArea, const Rectf &dstRect );
 void draw( const Texture2dRef &texture, const vec2 &dstOffset = vec2() );
 void draw( const PolyLine2 &polyLine );
-void draw( const PolyLine3 &polyLine );
+//! Draws a line connecting \a points \a isClosed will connect the first and last points if they are not equal.
+void draw( const std::vector<vec3> &points, bool isClosed = false );
 //! Draws a Path2d \a pathd using approximation scale \a approximationScale. 1.0 corresponds to screenspace, 2.0 is double screen resolution, etc
 void draw( const Path2d &path, float approximationScale = 1.0f );
 //! Draws a Shaped2d \a shaped using approximation scale \a approximationScale. 1.0 corresponds to screenspace, 2.0 is double screen resolution, etc

--- a/src/cinder/gl/draw.cpp
+++ b/src/cinder/gl/draw.cpp
@@ -391,7 +391,7 @@ void draw( const PolyLine2 &polyLine )
 	ctx->popVao();
 }
 
-void draw( const PolyLine3 &polyLine )
+void draw( const std::vector<vec3> &points, bool isClosed )
 {
 	auto ctx = context();
 	const GlslProg* curGlslProg = ctx->getGlslProg();
@@ -400,7 +400,6 @@ void draw( const PolyLine3 &polyLine )
 		return;
 	}
 	
-	const vector<vec3> &points = polyLine.getPoints();
 	VboRef arrayVbo = ctx->getDefaultArrayVbo( sizeof(vec3) * points.size() );
 	arrayVbo->bufferSubData( 0, sizeof(vec3) * points.size(), points.data() );
 
@@ -415,7 +414,7 @@ void draw( const PolyLine3 &polyLine )
 
 	ctx->getDefaultVao()->replacementBindEnd();
 	ctx->setDefaultShaderVars();
-	ctx->drawArrays( ( polyLine.isClosed() ) ? GL_LINE_LOOP : GL_LINE_STRIP, 0, (GLsizei)points.size() );
+	ctx->drawArrays( ( isClosed ) ? GL_LINE_LOOP : GL_LINE_STRIP, 0, (GLsizei)points.size() );
 	ctx->popVao();
 }
 

--- a/test/unit/src/PolyLineTest.cpp
+++ b/test/unit/src/PolyLineTest.cpp
@@ -179,3 +179,4 @@ TEST_CASE("PolyLine2f")
 		CHECK( poly.calcCentroid() == vec2( 0.5, 0.5 ) );
 	}
 }
+


### PR DESCRIPTION
Demonstrates a linking bug I've encountered:
```
Undefined symbols for architecture x86_64:
  "cinder::PolyLineT<glm::tvec3<float, (glm::precision)0> >::reverse()", referenced from:
      ____C_A_T_C_H____T_E_S_T____11() in PolyLineTest.o
  "cinder::PolyLineT<glm::tvec3<float, (glm::precision)0> >::reversed() const", referenced from:
      ____C_A_T_C_H____T_E_S_T____11() in PolyLineTest.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

[According to Travis](https://travis-ci.org/cinder/Cinder/builds/187942442) this only affects the Xcode builds.

If anyone know why that's happening I'd be happy to add the fix to this PR.