### PR TITLE
PolyLine template cleanups

### DIFF
--- a/src/cinder/PolyLine.cpp
+++ b/src/cinder/PolyLine.cpp
@@ -55,7 +55,7 @@ bool PolyLineT<T>::isClockwise( bool *isColinear ) const
 	// ...then get the next and previous point
 	size_t prev = ( smallest == 0 )    ? last : ( smallest - 1 );
 	size_t next = ( smallest == last ) ? 0    : ( smallest + 1 );
-	vec2 a = mPoints[next], b = mPoints[smallest], c = mPoints[prev];
+	T a = mPoints[next], b = mPoints[smallest], c = mPoints[prev];
 
 	// The sign of the determinate indicates the orientation:
 	//   positive is clockwise
@@ -175,7 +175,7 @@ bool PolyLineT<T>::contains( const vec2 &pt ) const
 		crossings += linearCrossings( &(mPoints[s]), pt );
 	}
 
-	vec2 temp[2];
+	T temp[2];
 	temp[0] = mPoints[mPoints.size()-1];
 	temp[1] = mPoints[0];
 	crossings += linearCrossings( &(temp[0]), pt );
@@ -200,7 +200,7 @@ double PolyLineT<T>::calcArea() const
 template<typename T>
 T PolyLineT<T>::calcCentroid() const
 {
-	dvec2 result( 0 );
+	T result( 0 );
 
 	const size_t numPoints = mPoints.size();
 	double area = 0;

--- a/test/unit/src/PolyLineTest.cpp
+++ b/test/unit/src/PolyLineTest.cpp
@@ -8,89 +8,174 @@ using namespace ci;
 using namespace ci::app;
 using namespace std;
 
-TEST_CASE("PolyLine", "Orientation")
+TEST_CASE("PolyLine2f")
 {
-	SECTION("Just two points")
+	SECTION("reverse")
 	{
-		vector<vec2> input({
-			vec2( 294.641, 105.359 ),
-			vec2( 387.617, 12.3833 ),
-		});
+		vector<vec2> input( { vec2( 1, 2 ), vec2( 3, 4 ) } );
+		PolyLine2f p1( input );
 
-		PolyLine2f p1 = PolyLine2f( input );
-		bool colinear;
-		REQUIRE( ! p1.isClockwise() );
-		REQUIRE( ! p1.isClockwise( &colinear ) );
-		REQUIRE( colinear );
+		p1.reverse();
+		CHECK( p1.getPoints()[0] == input[1] );
+		CHECK( p1.getPoints()[1] == input[0] );
 
-		REQUIRE( ! p1.isCounterclockwise() );
-		REQUIRE( ! p1.isCounterclockwise( &colinear ) );
-		REQUIRE( colinear );
+		PolyLine2f p2 = p1.reversed();
+		CHECK( p2.getPoints()[0] == input[0] );
+		CHECK( p2.getPoints()[1] == input[1] );
 	}
 
-	SECTION("Three in a row")
+	SECTION("Orientation")
 	{
-		vector<vec2> input({
-			vec2( 0, 0 ),
-			vec2( 100, 0 ),
-			vec2( -29, 0 )
-		});
-		PolyLine2f p1 = PolyLine2f( input );
-		bool colinear;
+		SECTION("Just two points")
+		{
+			vector<vec2> input({
+				vec2( 294.641, 105.359 ),
+				vec2( 387.617, 12.3833 ),
+			});
 
-		REQUIRE( ! p1.isClockwise() );
-		REQUIRE( ! p1.isClockwise( &colinear ) );
-		REQUIRE( colinear );
+			PolyLine2f p1 = PolyLine2f( input );
+			bool colinear;
+			REQUIRE_FALSE( p1.isClockwise() );
+			REQUIRE_FALSE( p1.isClockwise( &colinear ) );
+			REQUIRE( colinear );
 
-		REQUIRE( ! p1.isCounterclockwise() );
-		REQUIRE( ! p1.isCounterclockwise( &colinear ) );
-		REQUIRE( colinear );
+			REQUIRE_FALSE( p1.isCounterclockwise() );
+			REQUIRE_FALSE( p1.isCounterclockwise( &colinear ) );
+			REQUIRE( colinear );
+		}
+
+		SECTION("Three in a row")
+		{
+			vector<vec2> input({
+				vec2( 0, 0 ),
+				vec2( 100, 0 ),
+				vec2( -29, 0 )
+			});
+			PolyLine2f p1 = PolyLine2f( input );
+			bool colinear;
+
+			REQUIRE_FALSE( p1.isClockwise() );
+			REQUIRE_FALSE( p1.isClockwise( &colinear ) );
+			REQUIRE( colinear );
+
+			REQUIRE_FALSE( p1.isCounterclockwise() );
+			REQUIRE_FALSE( p1.isCounterclockwise( &colinear ) );
+			REQUIRE( colinear );
+		}
+
+		SECTION("Open polygon")
+		{
+			vector<vec2> input({
+				vec2( 294.641, 105.359 ),
+				vec2( 387.617, 12.3833 ),
+				vec2( 412.967, 2.96674 ),
+				vec2( 417.987, -7.98667 ),
+				vec2( 386.023, -94.0354 )
+			});
+
+			bool colinear;
+
+			PolyLine2f p1 = PolyLine2f( input );
+
+			REQUIRE( p1.isClockwise() );
+			REQUIRE( p1.isClockwise( &colinear ) );
+			REQUIRE_FALSE( colinear );
+
+			reverse( input.begin(), input.end() );
+			PolyLine2f p2 = PolyLine2f( input );
+
+			REQUIRE_FALSE( p2.isClockwise() );
+			REQUIRE_FALSE( p2.isClockwise( &colinear ) );
+			REQUIRE_FALSE( colinear );
+		}
+
+		SECTION("Closed polygon")
+		{
+			vector<vec2> input({
+				vec2( 294.641, 105.359 ),
+				vec2( 387.617, 12.3833 ),
+				vec2( 412.967, 2.96674 ),
+				vec2( 417.987, -7.98667 ),
+				vec2( 386.023, -94.0354 ),
+				vec2( 294.641, 105.359 )
+			});
+			bool colinear;
+
+			PolyLine2f p1 = PolyLine2f( input );
+
+			REQUIRE( p1.isClockwise() );
+			REQUIRE( p1.isClockwise( &colinear ) );
+			REQUIRE_FALSE( colinear );
+
+			reverse( input.begin(), input.end() );
+			PolyLine2f p2 = PolyLine2f( input );
+
+			REQUIRE_FALSE( p2.isClockwise() );
+			REQUIRE_FALSE( p2.isClockwise( &colinear ) );
+			REQUIRE_FALSE( colinear );
+		}
 	}
 
-	SECTION("Open Polygon")
+	SECTION("contains")
 	{
-		vector<vec2> input({
-			vec2( 294.641, 105.359 ),
-			vec2( 387.617, 12.3833 ),
-			vec2( 412.967, 2.96674 ),
-			vec2( 417.987, -7.98667 ),
-			vec2( 386.023, -94.0354 )
-		});
-		PolyLine2f p1 = PolyLine2f( input );
-		reverse( input.begin(), input.end() );
-		PolyLine2f p2 = PolyLine2f( input );
-		bool colinear;
+		SECTION("simple polygon")
+		{
+			// Square
+			PolyLine2f poly( { vec2( 0, 0 ), vec2( 0, 1 ), vec2( 1, 1 ), vec2( 1, 0 ), vec2( 0, 0 ) } );
 
-		REQUIRE( p1.isClockwise() );
-		REQUIRE( p1.isClockwise( &colinear ) );
-		REQUIRE( ! colinear );
+			SECTION("points inside")
+			{
+				CHECK( poly.contains( vec2( 0.25, 0.5 ) ) );
+				CHECK( poly.contains( vec2( 0.5, 0.25 ) ) );
+			}
 
-		REQUIRE( ! p2.isClockwise() );
-		REQUIRE( ! p2.isClockwise( &colinear ) );
-		REQUIRE( ! colinear );
+			SECTION("point outside")
+			{
+				CHECK_FALSE( poly.contains( vec2( -0.5, 0.25 ) ) );
+			}
+
+			SECTION("point on vertex")
+			{
+				CHECK_FALSE( poly.contains( vec2( 0, 0 ) ) );
+			}
+
+			SECTION("point on edge")
+			{
+				CHECK_FALSE( poly.contains( vec2( 0, 0.5 ) ) );
+			}
+		}
+
+		SECTION("self intersecting polygon")
+		{
+			// Infinity sign: |><|
+			PolyLine2f poly( { vec2( 0, 0 ), vec2( 0, 1 ), vec2( 1, 0 ), vec2( 1, 1 ), vec2( 0, 0 ) } );
+
+			SECTION("point inside")
+			{
+				CHECK( poly.contains( vec2( 0.25, 0.5 ) ) );
+			}
+
+			SECTION("point outside")
+			{
+				CHECK_FALSE( poly.contains( vec2( 0.5, 0.25 ) ) );
+			}
+
+			SECTION("point on vertex")
+			{
+				CHECK_FALSE( poly.contains( vec2( 0, 1 ) ) );
+			}
+
+			SECTION("point on edge")
+			{
+				CHECK_FALSE( poly.contains( vec2( 0.25, 0.25 ) ) );
+			}
+		}
 	}
 
-	SECTION("Closed Polygon")
+	SECTION("calcCentroid")
 	{
-		vector<vec2> input({
-			vec2( 294.641, 105.359 ),
-			vec2( 387.617, 12.3833 ),
-			vec2( 412.967, 2.96674 ),
-			vec2( 417.987, -7.98667 ),
-			vec2( 386.023, -94.0354 ),
-			vec2( 294.641, 105.359 )
-		});
-		PolyLine2f p1 = PolyLine2f( input );
-		bool colinear;
-		reverse( input.begin(), input.end() );
-		PolyLine2f p2 = PolyLine2f( input );
+		PolyLine2f poly( { vec2( 0, 0 ), vec2( 0, 1 ), vec2( 1, 1 ), vec2( 1, 0 ) } );
 
-		REQUIRE( p1.isClockwise() );
-		REQUIRE( p1.isClockwise( &colinear ) );
-		REQUIRE( ! colinear );
-
-		REQUIRE( ! p2.isClockwise() );
-		REQUIRE( ! p2.isClockwise( &colinear ) );
-		REQUIRE( ! colinear );
+		CHECK( poly.calcCentroid() == vec2( 0.5, 0.5 ) );
 	}
 }


### PR DESCRIPTION
I split some of the 2D fixes out of #1698 so they can go in while we discuss the 3D parts. I add some quick tests for the methods I was touching.

The tests has a bunch of space indenting that I cleaned up so probably easiest to see what's changing there by [ignoring whitespace](https://github.com/cinder/Cinder/pull/1706/files?w=1)