### PR TITLE
Use mStartDrawFn and mFinishDrawFn for CINDER_COCOA_TOUCH.

### DIFF
--- a/src/cinder/app/RendererGl.cpp
+++ b/src/cinder/app/RendererGl.cpp
@@ -161,12 +161,18 @@ EAGLContext* RendererGl::getEaglContext() const
 
 void RendererGl::startDraw()
 {
-	[mImpl makeCurrentContext:false];
+	if( mStartDrawFn )
+		mStartDrawFn( this );
+	else
+		[mImpl makeCurrentContext:false];
 }
 
 void RendererGl::finishDraw()
 {
-	[mImpl flushBuffer];
+	if( mFinishDrawFn )
+		mFinishDrawFn( this );
+	else
+		[mImpl flushBuffer];
 }
 
 void RendererGl::setFrameSize( int width, int height )


### PR DESCRIPTION
The CINDER_COCOA_TOUCH section of RendererGl is not using mStartDrawFn or mFinishDrawFn.  I'm assuming that it should be.  The fix makes it identical to the CINDER_MAC section. 