### PR TITLE
Expose native touch event

### DIFF
--- a/include/cinder/app/TouchEvent.h
+++ b/include/cinder/app/TouchEvent.h
@@ -76,10 +76,7 @@ class TouchEvent : public Event {
 	TouchEvent()
 		: Event()
 	{}
-	TouchEvent( const WindowRef &win, const std::vector<Touch> &touches )
-		: Event( win ), mTouches( touches ), mNative( nullptr )
-	{}
-	TouchEvent( const WindowRef &win, const std::vector<Touch> &touches, void *native )
+	TouchEvent( const WindowRef &win, const std::vector<Touch> &touches, void *native = nullptr )
 		: Event( win ), mTouches( touches ), mNative( native )
 	{}
 	

--- a/include/cinder/app/TouchEvent.h
+++ b/include/cinder/app/TouchEvent.h
@@ -77,7 +77,7 @@ class TouchEvent : public Event {
 		: Event()
 	{}
 	TouchEvent( const WindowRef &win, const std::vector<Touch> &touches )
-	: Event( win ), mTouches( touches ), mNative( nullptr )
+		: Event( win ), mTouches( touches ), mNative( nullptr )
 	{}
 	TouchEvent( const WindowRef &win, const std::vector<Touch> &touches, void *native )
 		: Event( win ), mTouches( touches ), mNative( native )
@@ -92,7 +92,7 @@ class TouchEvent : public Event {
   private:
 	std::vector<Touch>		mTouches;
 	bool					mHandled;
-	void		            *mNative;
+	void					*mNative;
 };
 
 inline std::ostream& operator<<( std::ostream &out, const TouchEvent::Touch &touch )

--- a/include/cinder/app/TouchEvent.h
+++ b/include/cinder/app/TouchEvent.h
@@ -77,17 +77,22 @@ class TouchEvent : public Event {
 		: Event()
 	{}
 	TouchEvent( const WindowRef &win, const std::vector<Touch> &touches )
-		: Event( win ), mTouches( touches )
+	: Event( win ), mTouches( touches ), mNative( nullptr )
+	{}
+	TouchEvent( const WindowRef &win, const std::vector<Touch> &touches, void *native )
+		: Event( win ), mTouches( touches ), mNative( native )
 	{}
 	
 	//! Returns a std::vector of Touch descriptors associated with this event
 	const std::vector<Touch>&	getTouches() const { return mTouches; }
 	//! Returns a std::vector of Touch descriptors associated with this event
 	std::vector<Touch>&			getTouches() { return mTouches; }
-
+	//! Returns a pointer to the OS-native object. This is a UIEvent* on Cocoa Touch, a NSEvent* on OSX, and a nullptr on MSW.
+	const void*	                getNative() const { return mNative; }
   private:
 	std::vector<Touch>		mTouches;
 	bool					mHandled;
+	void		            *mNative;
 };
 
 inline std::ostream& operator<<( std::ostream &out, const TouchEvent::Touch &touch )

--- a/src/cinder/app/cocoa/CinderViewCocoaTouch.mm
+++ b/src/cinder/app/cocoa/CinderViewCocoaTouch.mm
@@ -170,7 +170,7 @@ static bool sIsEaglLayer;
 		}
 		[self updateActiveTouches];
 		if( ! touchList.empty() ) {
-			TouchEvent touchEvent( [mDelegate getWindowRef], touchList );
+			TouchEvent touchEvent( [mDelegate getWindowRef], touchList, event );
 			[mDelegate touchesBegan:&touchEvent];
 		}
 	}
@@ -196,7 +196,7 @@ static bool sIsEaglLayer;
 		}
 		[self updateActiveTouches];
 		if( ! touchList.empty() ) {
-			TouchEvent touchEvent( [mDelegate getWindowRef], touchList );
+			TouchEvent touchEvent( [mDelegate getWindowRef], touchList, event );
 			[mDelegate touchesMoved:&touchEvent];
 		}
 	}
@@ -223,7 +223,7 @@ static bool sIsEaglLayer;
 		}
 		[self updateActiveTouches];
 		if( ! touchList.empty() ) {
-			TouchEvent touchEvent( [mDelegate getWindowRef], touchList );
+			TouchEvent touchEvent( [mDelegate getWindowRef], touchList, event );
 			[mDelegate touchesEnded:&touchEvent];
 		}
 	}

--- a/src/cinder/app/cocoa/CinderViewMac.mm
+++ b/src/cinder/app/cocoa/CinderViewMac.mm
@@ -570,7 +570,7 @@ using namespace cinder::app;
 	}
 	[self updateActiveTouches:event];
 	if( mDelegate && ( ! touchList.empty() ) ) {
-		cinder::app::TouchEvent touchEvent( [mDelegate getWindowRef], touchList );
+		cinder::app::TouchEvent touchEvent( [mDelegate getWindowRef], touchList, event );
 		[mDelegate touchesBegan:&touchEvent];
 	}
 }
@@ -590,7 +590,7 @@ using namespace cinder::app;
 	}
 	[self updateActiveTouches:event];
 	if( mDelegate && ( ! touchList.empty() ) ) {
-		cinder::app::TouchEvent touchEvent( [mDelegate getWindowRef], touchList );
+		cinder::app::TouchEvent touchEvent( [mDelegate getWindowRef], touchList, event );
 		[mDelegate touchesMoved:&touchEvent];
 	}
 }
@@ -612,7 +612,7 @@ using namespace cinder::app;
 
 	[self updateActiveTouches:event];
 	if( mDelegate && ( ! touchList.empty() ) ) {
-		cinder::app::TouchEvent touchEvent( [mDelegate getWindowRef], touchList );
+		cinder::app::TouchEvent touchEvent( [mDelegate getWindowRef], touchList, event );
 		[mDelegate touchesEnded:&touchEvent];
 	}
 }
@@ -634,7 +634,7 @@ using namespace cinder::app;
 
 	[self updateActiveTouches:event];
 	if( mDelegate && ( ! touchList.empty() ) ) {
-		cinder::app::TouchEvent touchEvent( [mDelegate getWindowRef], touchList );
+		cinder::app::TouchEvent touchEvent( [mDelegate getWindowRef], touchList, event );
 		[mDelegate touchesEnded:&touchEvent];
 	}
 }


### PR DESCRIPTION
Access is already exposed to the native touch (UITouch*) on iOS through TouchEvent::Touch::getNative().  This is useful for getting the force/pressure data for the apple pencil and other data.  In addition, I'd like to be able to get the UIEvent as well in order to be able to call predictedTouchesForTouch and coalescedTouchesForTouch at the application level.  Multi-touch is very laggy on iOS, which breaks the illusion of direct manipulation.  The predictive touches help out a lot.