### PR TITLE
[warnings] Comment unused parameters in cinder/audio v2

### DIFF
--- a/include/cinder/audio/Buffer.h
+++ b/include/cinder/audio/Buffer.h
@@ -277,6 +277,7 @@ std::unique_ptr<T, FreeDeleter<T> > makeAlignedArray( size_t size, size_t alignm
 	// unnecessary at the moment anyway, so it is commented out until fixed
 	//ptr = std::align( alignment, size, ptr, size );
 	//CI_ASSERT( ptr );
+	(void)alignment;
 	
 	return std::unique_ptr<T, FreeDeleter<T> >( static_cast<T *>( ptr ) );
 }

--- a/include/cinder/audio/Context.h
+++ b/include/cinder/audio/Context.h
@@ -81,7 +81,7 @@ class Context : public std::enable_shared_from_this<Context> {
 	bool isEnabled() const		{ return mEnabled; }
 
 	//! Called by \a node when it's connections have changed, default implementation is empty.
-	virtual void connectionsDidChange( const NodeRef &node ) {} 
+	virtual void connectionsDidChange( const NodeRef & /*node*/ ) {}
 
 	//! Returns the samplerate of this Context, which is governed by the current OutputNode.
 	size_t		getSampleRate()				{ return getOutput()->getOutputSampleRate(); }

--- a/include/cinder/audio/Context.h
+++ b/include/cinder/audio/Context.h
@@ -80,8 +80,8 @@ class Context : public std::enable_shared_from_this<Context> {
 	//! Returns whether or not this \a Context is current enabled and processing audio.
 	bool isEnabled() const		{ return mEnabled; }
 
-	//! Called by \a node when it's connections have changed, default implementation is empty.
-	virtual void connectionsDidChange( const NodeRef & /*node*/ ) {}
+	//! Called by \a node when it's connections have changed. Default implementation is empty.
+	virtual void connectionsDidChange( const NodeRef &node );
 
 	//! Returns the samplerate of this Context, which is governed by the current OutputNode.
 	size_t		getSampleRate()				{ return getOutput()->getOutputSampleRate(); }

--- a/include/cinder/audio/Node.h
+++ b/include/cinder/audio/Node.h
@@ -174,16 +174,18 @@ class Node : public std::enable_shared_from_this<Node>, private Noncopyable {
 
   protected:
 
-	//! Called before audio buffers need to be used. There is always a valid Context at this point.
+	//! Called before audio buffers need to be used. There is always a valid Context at this point. Default implementation is empty.
 	virtual void initialize()				{}
-	//! Called once the contents of initialize are no longer relevant, i.e. connections have changed. \note Not guaranteed to be called at Node destruction.
+	//! Called once the contents of initialize are no longer relevant, i.e. connections have changed. Default implementation is empty.
+	//! \note Not guaranteed to be called at Node destruction.
 	virtual void uninitialize()				{}
-	//! Callled when this Node should enable processing. Initiated from Node::enable().
+	//! Callled when this Node should enable processing. Initiated from Node::enable(). Default implementation is empty.
 	virtual void enableProcessing()			{}
-	//! Callled when this Node should disable processing. Initiated from Node::disable().
+	//! Callled when this Node should disable processing. Initiated from Node::disable(). Default implementation is empty.
 	virtual void disableProcessing()		{}
 	//! Override to perform audio processing on \t buffer. Default implementation is empty.
 	virtual void process( Buffer *buffer );
+	//! Override to customize how input Nodes are summed into the internal summing buffer. You usually don't need to do this.
 	virtual void sumInputs();
 
 	//! Default implementation returns true if numChannels matches our format.

--- a/include/cinder/audio/Node.h
+++ b/include/cinder/audio/Node.h
@@ -182,9 +182,8 @@ class Node : public std::enable_shared_from_this<Node>, private Noncopyable {
 	virtual void enableProcessing()			{}
 	//! Callled when this Node should disable processing. Initiated from Node::disable().
 	virtual void disableProcessing()		{}
-	//! Override to perform audio processing on \t buffer.
-	virtual void process( Buffer * /*buffer*/ )	{}
-
+	//! Override to perform audio processing on \t buffer. Default implementation is empty.
+	virtual void process( Buffer *buffer );
 	virtual void sumInputs();
 
 	//! Default implementation returns true if numChannels matches our format.

--- a/include/cinder/audio/Node.h
+++ b/include/cinder/audio/Node.h
@@ -183,7 +183,7 @@ class Node : public std::enable_shared_from_this<Node>, private Noncopyable {
 	//! Callled when this Node should disable processing. Initiated from Node::disable().
 	virtual void disableProcessing()		{}
 	//! Override to perform audio processing on \t buffer.
-	virtual void process( Buffer *buffer )	{}
+	virtual void process( Buffer * /*buffer*/ )	{}
 
 	virtual void sumInputs();
 

--- a/src/cinder/audio/ChannelRouterNode.cpp
+++ b/src/cinder/audio/ChannelRouterNode.cpp
@@ -62,7 +62,7 @@ const ChannelRouterNodeRef& operator>>( const NodeRef &input, const ChannelRoute
 	return route.getOutputRouter();
 }
 
-bool ChannelRouterNode::supportsInputNumChannels( size_t numChannels ) const
+bool ChannelRouterNode::supportsInputNumChannels( size_t /*numChannels*/ ) const
 {
 	return true;
 }

--- a/src/cinder/audio/Context.cpp
+++ b/src/cinder/audio/Context.cpp
@@ -178,6 +178,10 @@ void Context::setEnabled( bool b )
 		disable();
 }
 
+void Context::connectionsDidChange( const NodeRef & /*node*/ )
+{
+}
+
 void Context::initializeAllNodes()
 {
 	set<NodeRef> traversedNodes;

--- a/src/cinder/audio/FileOggVorbis.cpp
+++ b/src/cinder/audio/FileOggVorbis.cpp
@@ -169,7 +169,7 @@ int SourceFileOggVorbis::seekFn( void *datasource, ogg_int64_t offset, int whenc
 }
 
 // static
-int SourceFileOggVorbis::closeFn( void *datasource )
+int SourceFileOggVorbis::closeFn( void * /*datasource*/ )
 {
 	return 0;
 }

--- a/src/cinder/audio/InputNode.cpp
+++ b/src/cinder/audio/InputNode.cpp
@@ -46,7 +46,7 @@ InputNode::~InputNode()
 {
 }
 
-void InputNode::connectInput( const NodeRef &input )
+void InputNode::connectInput( const NodeRef & /*input*/ )
 {
 	CI_ASSERT_MSG( 0, "InputNode does not support inputs" );
 }

--- a/src/cinder/audio/Node.cpp
+++ b/src/cinder/audio/Node.cpp
@@ -435,6 +435,10 @@ void Node::pullInputs( Buffer *inPlaceBuffer )
 	}
 }
 
+void Node::process( Buffer * /*buffer*/ )
+{
+}
+
 void Node::sumInputs()
 {
 	// Pull all inputs, summing the results from the buffer that input used for processing.

--- a/src/cinder/audio/OutputNode.cpp
+++ b/src/cinder/audio/OutputNode.cpp
@@ -43,7 +43,7 @@ OutputNode::OutputNode( const Format &format )
 		setAutoEnabled( false );
 }
 
-void OutputNode::connect( const NodeRef &output )
+void OutputNode::connect( const NodeRef & /*output*/ )
 {
 	CI_ASSERT_MSG( 0, "OutputNode does not support connecting to other outputs" );
 }


### PR DESCRIPTION
This is #1670, conflicts resolved and a couple minor tweaks to how unused args are handled in ci::audio headers.

Related discussion in #1629.