### PR TITLE
Fix for ComputeBasic sample freezing on window resize

### DIFF
--- a/include/cinder/app/RendererVk.h
+++ b/include/cinder/app/RendererVk.h
@@ -117,7 +117,7 @@ class RendererVk : public Renderer {
 		uint32_t							mSwapchainImageCount = 2;
 		VkSampleCountFlagBits				mSamples = VK_SAMPLE_COUNT_1_BIT;
 		VkFormat							mDepthStencilFormat = VK_FORMAT_D16_UNORM;
-		VkPresentModeKHR					mPresentMode = VK_PRESENT_MODE_MAX_ENUM;
+		VkPresentModeKHR					mPresentMode = VK_PRESENT_MODE_MAX_ENUM_KHR;
 		std::vector<std::string>			mInstanceLayers;
 		std::vector<std::string>			mDeviceLayers;
 		vk::DebugReportCallbackFn			mDebugReportCallbackFn = nullptr;

--- a/samples/_vulkan_explicit/ComputeBasic/src/ComputeBasicApp.cpp
+++ b/samples/_vulkan_explicit/ComputeBasic/src/ComputeBasicApp.cpp
@@ -49,6 +49,7 @@ class ComputeBasicApp : public App {
 public:	
 	void	setup() override;
 	void	update() override;
+	void	resize() override;
 	void	draw() override;
 	
 private:
@@ -184,6 +185,11 @@ void ComputeBasicApp::update()
 	}
 }
 
+void ComputeBasicApp::resize()
+{
+	update();
+}
+
 void ComputeBasicApp::draw()
 {
 	// Get next image
@@ -198,7 +204,7 @@ void ComputeBasicApp::draw()
 		// Initial params
 		std::vector<vk::CommandBufferRef> commandBuffers = { cmdBuf };
 		std::vector<VkSemaphore> waitSemaphores = { mImageAcquiredSemaphore, mComputeDoneSemaphore };
-		std::vector<VkPipelineStageFlags> waitDstStageMasks = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT };
+		std::vector<VkPipelineStageFlags> waitDstStageMasks = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT };
 		VkFence nullFence = VK_NULL_HANDLE;
 		std::vector<VkSemaphore> signalSemaphores = { mRenderingCompleteSemaphore };
 

--- a/src/cinder/vk/Swapchain.cpp
+++ b/src/cinder/vk/Swapchain.cpp
@@ -88,7 +88,7 @@ void Swapchain::initializeColorBuffers()
 	}
 
 	// If a specific present mode isn't requested, find one.
-	if( VK_PRESENT_MODE_MAX_ENUM == mOptions.mPresentMode ) {
+	if( VK_PRESENT_MODE_MAX_ENUM_KHR == mOptions.mPresentMode ) {
 		CI_LOG_I( "Finding best present mode..." );
 		// If mailbox mode is available, use it, as is the lowest-latency non-
 		// tearing mode.  If not, try IMMEDIATE which will usually be available,


### PR DESCRIPTION
ComputeBasic sample in Vulkan Explicit group is freezing on window resize. This commit fixes the issues. 

The issue is caused by draw() method being called before update() when a window resize happens. draw() method submits a command buffer to a graphics queue, but the rendering operation is configured to wait on mComputeDoneSemaphore being signaled. The signal operation for this semaphore is not scheduled at all if update() method is not called before draw(). The fix enforces to call update() before draw() during a window resize situation.

It fixes also another issue with waiting on mComputeDoneSemaphore semaphore in the wrong pipeline stage. Currently the code is waiting on mComputeDoneSemaphore in stage specified by bit VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT. This stage is not present at all in the set of graphics operations submitted to the graphics queue. The correct bit should be VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT as we are trying to sample a texture in fragment shader that ought to be filled in with data in a previous compute pass.