### PR TITLE
cmake: rename CINDER_BUILD_SAMPLES -> CINDER_BUILD_ALL_SAMPLES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ endif()
 # Project start
 project( cinder )
 
-option( CINDER_BUILD_SAMPLES "Build all samples." OFF )
-option( CINDER_BUILD_TESTS "Build all unit tests." OFF )
+option( CINDER_BUILD_TESTS "Build unit tests." OFF )
+option( CINDER_BUILD_ALL_SAMPLES "Build all samples." OFF )
 set( CINDER_BUILD_SAMPLE "" CACHE STRING "Build a specific sample by specifying its path relative to the samples directory (ex. '_opengl/Cube')." )
 
 set( CINDER_PATH      "${CMAKE_CURRENT_SOURCE_DIR}" )
@@ -39,7 +39,7 @@ endif()
 
 include( ${CINDER_CMAKE_DIR}/libcinder_target.cmake )
 
-if( CINDER_BUILD_SAMPLES )
+if( CINDER_BUILD_ALL_SAMPLES )
 	include( ${CINDER_CMAKE_DIR}/modules/findCMakeDirs.cmake )
 
 	set( allSamples "" )

--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -145,7 +145,7 @@ if( NOT ( "Xcode" STREQUAL "${CMAKE_GENERATOR}" ) )
 	endif()
 endif()
 
-# These are samples that cannot be built on Mac OS X, indicating they should be skipped with CINDER_BUILD_SAMPLES is on.
+# These are samples that cannot be built on Mac OS X, indicating they should be skipped with CINDER_BUILD_ALL_SAMPLES is on.
 list( APPEND CINDER_SKIP_SAMPLES
 	_opengl/ParticleSphereCS
 	_opengl/NVidiaComputeParticles

--- a/tools/ci/cmake_test.sh
+++ b/tools/ci/cmake_test.sh
@@ -2,17 +2,18 @@
 set -e
 
 # meant to be run from the root directory of Cinder
+CMAKE_ARGS="-DCINDER_BUILD_TESTS=1 -DCINDER_BUILD_ALL_SAMPLES=0"
 
 # build debug
 mkdir build-debug
 cd build-debug
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DCINDER_BUILD_TESTS=1 -DCINDER_BUILD_ALL_SAMPLES=1
+cmake .. -DCMAKE_BUILD_TYPE=Debug ${CMAKE_ARGS}
 make -j4
 cd ..
 # build release
 mkdir build-release
 cd build-release
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCINDER_BUILD_TESTS=1 -DCINDER_BUILD_ALL_SAMPLES=1
+cmake .. -DCMAKE_BUILD_TYPE=Release ${CMAKE_ARGS}
 make -j4
 # test release
 make check


### PR DESCRIPTION
This makes it easier to distinguish the variable as different to `CINDER_BUILD_SAMPLES=${name}`.

Also disabled building all samples (for now) in the CI script, since they don't all build yet.