### PR TITLE
Fix shader memory leak in GlslProg

### DIFF
--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -472,8 +472,7 @@ class GlslProg {
 	GlslProg( const Format &format );
 
 	void			bindImpl() const;
-	void			loadShader( const std::string &shaderSource, const fs::path &shaderPath, GLint shaderType, const ShaderPreprocessorRef &preprocessor );
-	void			attachShaders();
+	GLuint			loadShader( const std::string &shaderSource, const fs::path &shaderPath, GLint shaderType, const ShaderPreprocessorRef &preprocessor );
 	void			link();
 	
 	//! Caches all active Attributes after linking.

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -727,6 +727,8 @@ GLuint GlslProg::loadShader( const string &shaderSource, const fs::path &shaderP
 		}
 
 		glAttachShader( mHandle, handle );
+
+		// Scope the shader's lifetime to the program's. It will be cleaned up when later detached.
 		glDeleteShader( handle );
 	}
 

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -701,6 +701,7 @@ void GlslProg::loadShader( const string &shaderSource, const fs::path &shaderPat
 		throw GlslProgCompileExc( log, shaderType );
 	}
 	glAttachShader( mHandle, handle );
+	glDeleteShader( handle );
 }
 
 void GlslProg::link()

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -718,9 +718,16 @@ GLuint GlslProg::loadShader( const string &shaderSource, const fs::path &shaderP
 			}
 			log += "\n" + ss.str();
 		}
-#endif		
+#endif
+		// Since the GlslProg destructor will not be called after we throw, we must delete all
+		// owned GL objects here to avoid leaking. Any other attached shaders will be cleaned up
+		// when the program is deleted
+		glDeleteShader( handle );
+		glDeleteProgram( mHandle );
+
 		throw GlslProgCompileExc( log, shaderType );
 	}
+
 	glAttachShader( mHandle, handle );
 	glDeleteShader( handle );
 
@@ -745,6 +752,9 @@ void GlslProg::link()
 			glGetProgramInfoLog( mHandle, logLength, &charsWritten, debugLog.get() );
 			log.append( debugLog.get(), 0, logLength );
 		}
+
+		// Delete owned GL objects before throwing to avoid a leak
+		glDeleteProgram( mHandle );
 		
 		throw GlslProgLinkExc( log );
 	}


### PR DESCRIPTION
Calling `glDeleteShader` on a shader after it is attached to a program flags it for deletion once it is no longer attached (e.g. When the program is deleted).