### PR TITLE
Use localPort variable

### DIFF
--- a/blocks/OSC/samples/SimpleReceiver/src/SimpleReceiverApp.cpp
+++ b/blocks/OSC/samples/SimpleReceiver/src/SimpleReceiverApp.cpp
@@ -37,7 +37,7 @@ class SimpleReceiverApp : public App {
 };
 
 SimpleReceiverApp::SimpleReceiverApp()
-: mReceiver( 3000 )
+: mReceiver( localPort )
 {
 }
 


### PR DESCRIPTION
Instead of hardcoding the port to listen on to 3000 the variable localPort is used.