### PR TITLE
fix capture cube vs2013 project file

### DIFF
--- a/samples/CaptureCube/vc2013/CaptureCube.vcxproj
+++ b/samples/CaptureCube/vc2013/CaptureCube.vcxproj
@@ -153,7 +153,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\RotatingBox.cpp"/>
+    <ClCompile Include="..\src\CaptureCubeApp.cpp"/>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets">

--- a/samples/CaptureCube/vc2013/CaptureCube.vcxproj.filters
+++ b/samples/CaptureCube/vc2013/CaptureCube.vcxproj.filters
@@ -15,7 +15,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\RotatingBox.cpp">
+    <ClCompile Include="..\src\CaptureCubeApp.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
The project file for visual studio had the wrong name for the source file. 
