### PR TITLE
Fixing compile error for Ssbo.h

### DIFF
--- a/include/cinder/gl/Ssbo.h
+++ b/include/cinder/gl/Ssbo.h
@@ -26,7 +26,7 @@
 #include "cinder/Cinder.h"
 #include "cinder/gl/gl.h"
 
-#if ( defined( CINDER_MSW ) && ! defined( CINDER_GL_ANGLE ) ) || defined( CINDER_LINUX )
+#if ( defined( CINDER_MSW ) && ! defined( CINDER_GL_ANGLE ) ) || ( defined( CINDER_LINUX ) && ! defined( CINDER_GL_ES ) )
 
 #include "cinder/gl/BufferObj.h"
 


### PR DESCRIPTION
Preprocessor definition to prevent Ssbo.h compilation on ES (specifically rpi2)