### PR TITLE
Adding off-by-one fix for RADIANCE parser

### DIFF
--- a/src/cinder/ImageSourceFileRadiance.cpp
+++ b/src/cinder/ImageSourceFileRadiance.cpp
@@ -156,6 +156,10 @@ bool decrunchScanline( RgbePixel *scanline, int len, IStreamCinder *stream )
 {
 	char i;
 
+	// Early out if there's nothing more to read from the stream
+ 	if ( stream->isEof() )
+ 		 return false;
+
 	if( len < MINELEN || len > MAXELEN )
 		return oldStyleDecrunch(scanline, len, stream );
 
@@ -194,7 +198,9 @@ bool decrunchScanline( RgbePixel *scanline, int len, IStreamCinder *stream )
 		}
     }
 
-	return ! stream->isEof();
+	// NOTE: at this point on the **LAST** scanline, the stream
+	// should be EOF, but we still want to process that last scanline!
+	return true;
 }
 
 bool oldStyleDecrunch( RgbePixel *scanline, int len, IStreamCinder *stream )


### PR DESCRIPTION
**TL;DR;** The fix is to check for EOF at the start of the line scanning method instead of the end so we don't skip the last line.

**Details:**

The core of the RADIANCE/HDR/RBGE file decoder does this:

```c++
	for( int y = height - 1; y >= 0; y-- ) {
		if( ! decrunchScanline( scanline.get(), width, stream.get() ) )
			break;  /// <<< if we hit this, we miss a line!
		workOnRgbeScanline( scanline.get(), width, cols );
		cols += width * 3;
	}
```

... where ```decrunchScanline(...)``` deals with unpacking the RLE bytes that are compressed into a non-compressed format that ```workOnRgbeScanline``` then converts into a 3-float value scanline.

```c++
bool decrunchScanline( RgbePixel *scanline, int len, IStreamCinder *stream )
{
      ...
      // while we have bytes to read from the stream ...
      while( ... ) {
            ...
            // ... read bytes form the stream into the scanline
            stream->read(&scanline[j++][i]);
      }

      // and finally this: 
      return ! stream->isEof();
     // ... that is a problem on the last line !!!
}
```
The problem with the check at the end means that for the last line of a perfectly valid file, we read in the last line, parse all the data, but as we consume the input stream to the last byte, we reach EOF, report it at the end and so we skip the part where we call ```workOnRgbeScanline(...)``` in the top loop.
The texture now has one line worth of unprocessed memory.





