### PR TITLE
Conversion error

### DIFF
--- a/include/cinder/GeomIo.h
+++ b/include/cinder/GeomIo.h
@@ -844,7 +844,7 @@ class BSpline : public Source {
 	template<typename T>
 	void init( const ci::BSpline<4,T> &spline, int subdivisions );
 
-	int						mPositionDims;
+	uint8_t					mPositionDims;
 	size_t					mNumVertices;
 	std::vector<float>		mPositions;
 	std::vector<vec3>		mNormals;
@@ -1306,7 +1306,7 @@ class Constant : public Modifier {
   protected:
 	geom::Attrib	mAttrib;
 	vec4			mValue;
-	int				mDims;
+	uint8_t				mDims;
 };
 
 //! Maps an attribute as a function of another attribute. Valid types are: float, vec2, vec3, vec4

--- a/src/cinder/CaptureImplDirectShow.cpp
+++ b/src/cinder/CaptureImplDirectShow.cpp
@@ -21,9 +21,7 @@
 */
 
 #include "cinder/CaptureImplDirectShow.h"
-#include <boost/noncopyable.hpp>
 
-#include <set>
 using namespace std;
 
 namespace cinder {
@@ -98,8 +96,8 @@ const vector<Capture::DeviceRef>& CaptureImplDirectShow::getDevices( bool forceR
 	static std::vector<Capture::DeviceRef>	devices;
 
 	if( firstCall || forceRefresh ) {
-		const int devCnt = getVideoInput().listDevices(true);
-		devices.resize(devCnt);
+		const int devCnt = getVideoInput().listDevices( true );
+		devices.resize( devCnt );
 		for ( int i = 0; i < devCnt; ++i ) {
 			devices[i] = std::make_shared<CaptureImplDirectShow::Device>( videoInput::getDeviceName( i ), i );
 		}

--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -323,8 +323,12 @@ void copyData( uint8_t srcDimensions, const float *srcData, size_t numElements, 
 namespace { 
 
 template<class T, class U>
-typename std::remove_reference<T>::type narrow( U other ) {
-	return static_cast<typename std::remove_reference<T>::type>( other );
+auto narrow( U other ) -> typename std::remove_reference<T>::type 
+{
+	using Ret = typename std::remove_reference<T>::type;
+	assert( other < std::numeric_limits<Ret>::max() );
+	assert( other > std::numeric_limits<Ret>::min() );
+	return static_cast<Ret>( other );
 }
 
 template<typename T>

--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -338,13 +338,8 @@ void copyIndexDataForceTrianglesImpl( Primitive primitive, const uint32_t *sourc
 		case Primitive::LINES:
 		case Primitive::LINE_STRIP:
 		case Primitive::TRIANGLES:
-			if( indexOffset == 0 ) {
-				memcpy( target, source, sizeof(uint32_t) * numIndices );
-			}
-			else {
-				for( size_t i = 0; i < numIndices; ++i )
-					target[i] = narrow<T>( source[i] + indexOffset );
-			}
+			//XXX: potentially narrowing
+			std::copy_n( source + indexOffset, numIndices, target );
 		break;
 		case Primitive::TRIANGLE_STRIP: { // ABC, CBD, CDE, EDF, etc
 			if( numIndices < 3 )

--- a/src/cinder/Path2d.cpp
+++ b/src/cinder/Path2d.cpp
@@ -69,7 +69,7 @@ Path2d::Path2d( const BSpline2f &spline, float subdivisionStep )
 				spl2 = spline.getControlPoint( lastPt % numPoints );
 			else
 				spl2 = ( spline.getControlPoint( i % numPoints ) + spline.getControlPoint( ( i + 1 ) % numPoints ) ) * 0.5f;
-			
+
 			quadTo( spl1, spl2 );
 		}
 	}
@@ -80,7 +80,7 @@ Path2d::Path2d( const BSpline2f &spline, float subdivisionStep )
 		int lastPt = ( spline.isLoop() ) ? numPoints : numPoints - 3;
 		for( int i = 0; i < lastPt; ++i ) {
 			vec2 p1 = spline.getControlPoint( ( i + 1 ) % numPoints ), p2 = spline.getControlPoint( ( i + 2 ) % numPoints ), p3 = spline.getControlPoint( ( i + 3 ) % numPoints );
-			
+
 			q1 = p1 * ( 4.0f / 6.0f ) + p2 * ( 2.0f / 6.0f );
 			q2 = p1 * ( 2.0f / 6.0f ) + p2 * ( 4.0f / 6.0f );
 			q3 = p1 * ( 1.0f / 6.0f ) + p2 * ( 4.0f / 6.0f ) + p3 * ( 1.0f / 6.0f );
@@ -140,14 +140,14 @@ Path2d::Path2d( const BSpline2f &spline, float subdivisionStep )
 		moveTo( spline.getPosition( 0 ) );
 		for( float t = subdivisionStep; t <= 1.0f; t += subdivisionStep )
 			lineTo( spline.getPosition( t ) );
-	}	
+	}
 }
 
 void Path2d::moveTo( const vec2 &p )
 {
 	if( ! mPoints.empty() )
 		throw Path2dExc(); // can only moveTo as the first point
-		
+
 	mPoints.push_back( p );
 }
 
@@ -155,7 +155,7 @@ void Path2d::lineTo( const vec2 &p )
 {
 	if( mPoints.empty() )
 		throw Path2dExc(); // can only lineTo as non-first point
-		
+
 	mPoints.push_back( p );
 	mSegments.push_back( LINETO );
 }
@@ -177,7 +177,7 @@ void Path2d::curveTo( const vec2 &p1, const vec2 &p2, const vec2 &p3 )
 
 	mPoints.push_back( p1 );
 	mPoints.push_back( p2 );
-	mPoints.push_back( p3 );	
+	mPoints.push_back( p3 );
 	mSegments.push_back( CUBICTO );
 }
 
@@ -221,7 +221,7 @@ void Path2d::arcHelper( const vec2 &center, float radius, float startRadians, fl
 			arcHelper( center, radius, midRadians, endRadians, forward );
 			arcHelper( center, radius, startRadians, midRadians, forward );
 		}
-    } 
+    }
 	else if( math<float>::abs( endRadians - startRadians ) > 0.000001f ) {
 		int segments = static_cast<int>( math<float>::ceil( math<float>::abs( endRadians - startRadians ) / ( M_PI / 2.0f ) ) );
 		float angle;
@@ -236,7 +236,7 @@ void Path2d::arcHelper( const vec2 &center, float radius, float startRadians, fl
 		for( int seg = 0; seg < segments; seg++, angle += angleDelta ) {
 			arcSegmentAsCubicBezier( center, radius, angle, angle + angleDelta );
 		}
-    }	
+    }
 }
 
 void Path2d::arcSegmentAsCubicBezier( const vec2 &center, float radius, float startRadians, float endRadians )
@@ -266,11 +266,11 @@ void Path2d::arcTo( const vec2 &p1, const vec2 &t, float radius )
 	
 	// Get current point.
 	const vec2& p0 = getCurrentPoint();
-	
+
 	// Calculate the tangent vectors tangent1 and tangent2.
 	const vec2 p0t = p0 - t;
 	const vec2 p1t = p1 - t;
-	
+
 	// Calculate tangent distance squares.
 	const float p0tSquare = length2( p0t );
 	const float p1tSquare = length2( p1t );
@@ -285,10 +285,10 @@ void Path2d::arcTo( const vec2 &p1, const vec2 &t, float radius )
 	// and
 	//
 	// tan(a/2) = sin(a) / ( 1 - cos(a) )
-	
+
 	const float numerator = p0t.y * p1t.x - p1t.y * p0t.x;
 	const float denominator = math<float>::sqrt( p0tSquare * p1tSquare ) - ( p0t.x * p1t.x + p0t.y * p1t.y );
-	
+
 	// The denominator is zero <=> p0 and p1 are colinear.
 	if( math<float>::abs( denominator ) < epsilon ) {
 		lineTo( t );
@@ -296,27 +296,27 @@ void Path2d::arcTo( const vec2 &p1, const vec2 &t, float radius )
 	else {
 		// |b0 - t| = |b3 - t| = radius * tan(a/2).
 		const float distanceFromT = math<float>::abs( radius * numerator / denominator );
-		
+
 		// b0 = t + |b0 - t| * (p0 - t)/|p0 - t|.
 		const vec2 b0 = t + distanceFromT * normalize( p0t );
-		
+
 		// If b0 deviates from p0, add a line to it.
 		if( math<float>::abs(b0.x - p0.x) > epsilon || math<float>::abs(b0.y - p0.y) > epsilon ) {
 			lineTo( b0 );
 		}
-		
+
 		// b3 = t + |b3 - t| * (p1 - t)/|p1 - t|.
 		const vec2 b3 = t + distanceFromT * normalize( p1t );
-		
+
 		// The two bezier-control points are located on the tangents at a fraction
 		// of the distance[ tangent points <-> tangent intersection ].
-		// See "Approxmiation of a Cubic Bezier Curve by Circular Arcs and Vice Versa" by Aleksas Riskus 
+		// See "Approxmiation of a Cubic Bezier Curve by Circular Arcs and Vice Versa" by Aleksas Riskus
 		// http://itc.ktu.lt/itc354/Riskus354.pdf
-		
+
 		float b0tSquare = (t.x - b0.x) *  (t.x - b0.x) + (t.y - b0.y) *  (t.y - b0.y);
 		float radiusSquare = radius * radius;
 		float fraction;
-		
+
 		// Assume dist = radius = 0 if the radius is very small.
 		if( math<float>::abs( radiusSquare / b0tSquare ) < epsilon )
 			fraction = 0.0;
@@ -325,20 +325,20 @@ void Path2d::arcTo( const vec2 &p1, const vec2 &t, float radius )
 		
 		const vec2 b1 = b0 + fraction * (t - b0);
 		const vec2 b2 = b3 + fraction * (t - b3);
-		
+
 		curveTo( b1, b2, b3 );
 	}
 }
-    
+
 void Path2d::reverse()
 {
     // The path is empty: nothing to do.
     if( empty() )
         return;
-    
+
     // Reverse all points.
     std::reverse( mPoints.begin(), mPoints.end() );
-    
+
     // Reverse the segments, but skip the "moveto" and "close":
 	if( isClosed() ) {
         // There should be at least 4 segments: "moveto", "close" and two other segments.
@@ -361,7 +361,7 @@ void Path2d::removeSegment( size_t segment )
 
 	int pointCount = sSegmentTypePointCounts[mSegments[segment]];
 	mPoints.erase( mPoints.begin() + firstPoint, mPoints.begin() + firstPoint + pointCount );
-	
+
 	mSegments.erase( mSegments.begin() + segment );
 }
 
@@ -385,7 +385,7 @@ void Path2d::getSegmentRelativeT( float t, size_t *segment, float *relativeT ) c
 			*relativeT = 1;
 		return;
 	}
-	
+
 	size_t totalSegments = mSegments.size();
 	float segParamLength = 1.0f / totalSegments; 
 	*segment = t * totalSegments;
@@ -477,8 +477,8 @@ void subdivideQuadratic( float distanceToleranceSqr, const vec2 &p1, const vec2 
 {
 	const int recursionLimit = 17;
 	const float collinearEpsilon = 0.0000001f;
-	
-	if( level > recursionLimit ) 
+
+	if( level > recursionLimit )
 		return;
 
 	vec2 p12 = ( p1 + p2 ) * 0.5f;
@@ -489,7 +489,7 @@ void subdivideQuadratic( float distanceToleranceSqr, const vec2 &p1, const vec2 
 	float dy = p3.y - p1.y;
 	float d = math<float>::abs(((p2.x - p3.x) * dy - (p2.y - p3.y) * dx));
 
-	if( d > collinearEpsilon ) { 
+	if( d > collinearEpsilon ) {
 		if( d * d <= distanceToleranceSqr * (dx*dx + dy*dy) ) {
 			resultPositions->emplace_back( p123 );
 			if( resultTangents )
@@ -508,7 +508,7 @@ void subdivideQuadratic( float distanceToleranceSqr, const vec2 &p1, const vec2 
 				// Simple collinear case, 1---2---3 - We can leave just two endpoints
 				return;
 			}
-			
+
 			if(d <= 0)
 				d = distance2( p2, p1 );
 			else if(d >= 1)
@@ -534,10 +534,10 @@ void subdivideCubic( float distanceToleranceSqr, const vec2 &p1, const vec2 &p2,
 {
 	const int recursionLimit = 17;
 	const float collinearEpsilon = 0.0000001f;
-	
-	if( level > recursionLimit ) 
+
+	if( level > recursionLimit )
 		return;
-	
+
 	// Calculate all the mid-points of the line segments
 	//----------------------
 
@@ -622,7 +622,7 @@ void subdivideCubic( float distanceToleranceSqr, const vec2 &p1, const vec2 &p2,
 				return;
 			}
 		break;
-		case 3: 
+		case 3:
 			// Regular case
 			if( (d2 + d3)*(d2 + d3) <= distanceToleranceSqr * ( dx*dx + dy*dy ) ) {
 				resultPositions->emplace_back( p23 );
@@ -643,7 +643,7 @@ std::vector<vec2> Path2d::subdivide( float approximationScale ) const
 {
 	std::vector<vec2> result;
 	subdivide( &result, nullptr, approximationScale );
-	
+
 	return result;
 }
 
@@ -654,7 +654,7 @@ void Path2d::subdivide( std::vector<vec2> *resultPositions, std::vector<vec2> *r
 
 	float distanceToleranceSqr = 0.5f / approximationScale;
 	distanceToleranceSqr *= distanceToleranceSqr;
-	
+
 	size_t firstPoint = 0;
 	resultPositions->emplace_back( mPoints[0] );
 	if( resultTangents )
@@ -698,7 +698,7 @@ void Path2d::subdivide( std::vector<vec2> *resultPositions, std::vector<vec2> *r
 			default:
 				throw Path2dExc();
 		}
-		
+
 		firstPoint += sSegmentTypePointCounts[mSegments[s]];
 	}
 }
@@ -730,8 +730,8 @@ Rectf Path2d::calcBoundingBox() const
 		result = Rectf( mPoints[0], mPoints[0] );
 		result.include( mPoints );
 	}
-	
-	return result;	
+
+	return result;
 }
 
 // calcPreciseBoundingBox helper routines
@@ -750,7 +750,7 @@ int	Path2d::calcQuadraticBezierMonotoneRegions( const vec2 p[3], float resultT[2
 		if( t > 0 && t < 1 )
 			resultT[resultIdx++] = t;
 	}
-	
+
 	return resultIdx;
 }
 
@@ -814,7 +814,7 @@ vec2 Path2d::calcCubicBezierDerivative( const vec2 p[4], float t )
 	float w1 = 3 * nt * nt - 6 * t * nt;
 	float w2 = -3 * t * t + 6 * t * nt;
 	float w3 = 3 * t * t;
-	
+
 	return vec2( w0 * p[0].x + w1 * p[1].x + w2 * p[2].x + w3 * p[3].x, w0 * p[0].y + w1 * p[1].y + w2 * p[2].y + w3 * p[3].y );
 }
 
@@ -826,7 +826,7 @@ Rectf Path2d::calcPreciseBoundingBox() const
 		return Rectf( mPoints[0], mPoints[0] );
 	else if( mPoints.size() == 2 )
 		return Rectf( mPoints[0], mPoints[1] );
-	
+
 	Rectf result( mPoints[0], mPoints[0] );
 	size_t firstPoint = 0;
 	for( size_t s = 0; s < mSegments.size(); ++s ) {
@@ -858,10 +858,10 @@ Rectf Path2d::calcPreciseBoundingBox() const
 			default:
 				throw Path2dExc();
 		}
-		
+
 		firstPoint += sSegmentTypePointCounts[mSegments[s]];
 	}
-	
+
 	return result;
 }
 
@@ -1155,7 +1155,7 @@ int chopQuadAtYExtrema( const vec2 src[3], vec2 dst[5] )
 		// we couldn't compute a unit_divide value (probably underflow).
 		b = fabsf(a - b) < fabsf(b - c) ? a : c;
 	}
-	
+
 	dst[0] = { src[0].x, a };
 	dst[1] = { src[1].x, b };
 	dst[2] = { src[2].x, c };
@@ -1247,7 +1247,7 @@ int windingMonoQuad( const vec2 pts[], const vec2 &test, int* onCurveCount )
 				2 * (pts[1].y - pts[0].y),
 				pts[0].y - test.y,
 				roots);
-	
+
 	float xt;
 	if( 0 == n ) {
 		// zero roots are returned only when y0 == y
@@ -1344,7 +1344,7 @@ int windingCubic( const vec2 pts[], const vec2 &test, int *onCurveCount )
 
 	return w;
 }
-} // anonymous namespace Path2d::contains() helpers 
+} // anonymous namespace Path2d::contains() helpers
 
 int Path2d::calcWinding( const ci::vec2 &pt, int *onCurveCount ) const
 {
@@ -1468,7 +1468,7 @@ vec2 Path2d::calcClosestPoint( const vec2 &pt, size_t segment, size_t firstPoint
 float Path2d::calcLength() const
 {
 	float result = 0;
-	
+
 	size_t firstPoint = 0;
 	for( size_t s = 0; s < mSegments.size(); ++s ) {
 		switch( mSegments[s] ) {
@@ -1490,7 +1490,7 @@ float Path2d::calcLength() const
 
 		firstPoint += Path2d::sSegmentTypePointCounts[mSegments[s]];
 	}
-	
+
 	return result;
 }
 
@@ -1498,11 +1498,11 @@ float Path2d::calcSegmentLength( size_t segment, float minT, float maxT ) const
 {
 	if( segment >= mSegments.size() )
 		return 0;
-	
+
 	size_t firstPoint = 0;
 	for( size_t s = 0; s < segment; ++s )
 		firstPoint += sSegmentTypePointCounts[mSegments[s]];
-	
+
 	switch( mSegments[segment] ) {
 		case CUBICTO:
 			return rombergIntegral<float,7>( minT, maxT, std::bind( calcCubicBezierSpeed, &mPoints[firstPoint], std::placeholders::_1 ) );
@@ -1518,7 +1518,7 @@ float Path2d::calcSegmentLength( size_t segment, float minT, float maxT ) const
 		break;
 		default:
 			return 0;
-	}	
+	}
 }
 
 float Path2d::calcNormalizedTime( float relativeTime, bool wrap, float tolerance, int maxIterations ) const
@@ -1541,7 +1541,7 @@ float Path2d::calcNormalizedTime( float relativeTime, bool wrap, float tolerance
 	}
 
 	float targetLength = calcLength() * math<float>::clamp( relativeTime, 0.0f, 1.0f );
-	
+
 	int currentSegment = 0;
 	float currentSegmentLength = calcSegmentLength( 0 );
 	while( targetLength > currentSegmentLength ) {
@@ -1604,14 +1604,14 @@ float Path2d::segmentSolveTimeForDistance( size_t segment, float segmentLength, 
 		// get speed along curve
 		const float speed = length( getSegmentTangent( segment, currentT + p ) );
 
-		// if result will lie outside [a,b] 
+		// if result will lie outside [a,b]
 		if( ((p-a)*speed - delta)*((p-b)*speed - delta) > -tolerance )
 			p = 0.5f*(a+b);	// do bisection
 		else
 			p -= delta/speed; // otherwise Newton-Raphson
 	}
 	// If we failed to converge, hopefully 'p' is close enough
-	
+
 	return ( p + segment ) / (float)mSegments.size();
 }
 
@@ -1645,7 +1645,7 @@ float Path2dCalcCache::calcNormalizedTime( float relativeTime, bool wrap, float 
 
 	// We're looking for a length that is relativeTime * totalPathLength
 	float targetLength = mLength * math<float>::clamp( relativeTime, 0.0f, 1.0f );
-	
+
 	// Iterate the segments to find the segment defining the range containing our targetLength
 	int currentSegment = 0;
 	float currentSegmentLength = mSegmentLengths[0];

--- a/src/cinder/Path2d.cpp
+++ b/src/cinder/Path2d.cpp
@@ -185,11 +185,11 @@ void Path2d::arc( const vec2 &center, float radius, float startRadians, float en
 {
 	if( forward ) {
 		while( endRadians < startRadians )
-			endRadians += 2 * M_PI;
+			endRadians += 2 * static_cast<float>( M_PI );
 	}
 	else {
 		while( endRadians > startRadians )
-			endRadians -= 2 * M_PI;
+			endRadians -= 2 * static_cast<float>( M_PI );
 	}
 
 	if( mPoints.empty() )
@@ -208,7 +208,7 @@ void Path2d::arcHelper( const vec2 &center, float radius, float startRadians, fl
 {
 	// wrap the angle difference around to be in the range [0, 4*pi]
     while( endRadians - startRadians > 4 * M_PI )
-		endRadians -= 2 * M_PI;
+		endRadians -= 2 * static_cast<float>( M_PI );
 
     // Recurse if angle delta is larger than PI
     if( endRadians - startRadians > M_PI ) {
@@ -223,7 +223,7 @@ void Path2d::arcHelper( const vec2 &center, float radius, float startRadians, fl
 		}
     }
 	else if( math<float>::abs( endRadians - startRadians ) > 0.000001f ) {
-		int segments = static_cast<int>( math<float>::ceil( math<float>::abs( endRadians - startRadians ) / ( M_PI / 2.0f ) ) );
+		int segments = static_cast<int>( math<float>::ceil( math<float>::abs( endRadians - startRadians ) / (static_cast<float>( M_PI ) / 2.0f ) ) );
 		float angle;
 		float angleDelta = ( endRadians - startRadians ) / (float)segments;
 		if( forward )
@@ -262,8 +262,8 @@ void Path2d::arcTo( const vec2 &p1, const vec2 &t, float radius )
 	if( isClosed() || empty() )
 		throw Path2dExc(); // can only arcTo as non-first point
 
-	const float epsilon = 1e-8;
-	
+	const float epsilon = 1e-8f;
+
 	// Get current point.
 	const vec2& p0 = getCurrentPoint();
 
@@ -321,8 +321,8 @@ void Path2d::arcTo( const vec2 &p1, const vec2 &t, float radius )
 		if( math<float>::abs( radiusSquare / b0tSquare ) < epsilon )
 			fraction = 0.0;
 		else
-			fraction = ( 4.0 / 3.0 ) / ( 1.0 + math<float>::sqrt( 1.0 + b0tSquare / radiusSquare ) );
-		
+			fraction = ( 4.0f / 3.0f ) / ( 1.0f + math<float>::sqrt( 1.0f + b0tSquare / radiusSquare ) );
+
 		const vec2 b1 = b0 + fraction * (t - b0);
 		const vec2 b2 = b3 + fraction * (t - b3);
 
@@ -387,7 +387,7 @@ void Path2d::getSegmentRelativeT( float t, size_t *segment, float *relativeT ) c
 	}
 
 	size_t totalSegments = mSegments.size();
-	float segParamLength = 1.0f / totalSegments; 
+	float segParamLength = 1.0f / totalSegments;
 	*segment = t * totalSegments;
 	if( relativeT )
 		*relativeT = ( t - *segment * segParamLength ) / segParamLength;
@@ -1587,7 +1587,7 @@ float Path2d::segmentSolveTimeForDistance( size_t segment, float segmentLength, 
 	// iterate and look for zeros
 	float lastArcLength = 0;
 	float currentT = 0;
-	for( size_t i = 0; i < maxIterations; ++i ) {
+	for( int i = 0; i < maxIterations; ++i ) {
 		// compute function value and test against zero
 		lastArcLength = calcSegmentLength( segment, currentT, currentT + p );
 		float delta = lastArcLength - segmentRelativeDistance;

--- a/src/cinder/audio/Param.cpp
+++ b/src/cinder/audio/Param.cpp
@@ -34,7 +34,7 @@ namespace cinder { namespace audio {
 void rampLinear( float *array, size_t count, double t, double tIncr, float valueBegin, float valueEnd )
 {
 	for( size_t i = 0; i < count; i++ ) {
-		float factor( t );
+		auto factor = float( t );
 		array[i] = lerp( valueBegin, valueEnd, factor );
 		t += tIncr;
 	}
@@ -52,7 +52,7 @@ void rampInQuad( float *array, size_t count, double t, double tIncr, float value
 void rampOutQuad( float *array, size_t count, double t, double tIncr, float valueBegin, float valueEnd )
 {
 	for( size_t i = 0; i < count; i++ ) {
-		float factor( -t * ( t - 2 ) );
+		auto factor = float( -t * ( t - 2 ) );
 		array[i] = lerp( valueBegin, valueEnd, factor );
 		t += tIncr;
 	}

--- a/src/cinder/audio/Param.cpp
+++ b/src/cinder/audio/Param.cpp
@@ -201,7 +201,7 @@ float Param::findDuration() const
 		return 0;
 	else {
 		const EventRef &event = mEvents.back();
-		return event->mTimeEnd - (float)ctx->getNumProcessedSeconds();
+		return static_cast<float>(event->mTimeEnd - ctx->getNumProcessedSeconds());
 	}
 }
 
@@ -257,7 +257,7 @@ bool Param::eval( double timeBegin, float *array, size_t arrayLength, size_t sam
 			// if we skipped over the last event, record its end value before erasing.
 			if( mEvents.size() == 1 && ! cancelled )
 				mValue = event.mValueEnd;
-			
+
 			eventIt = mEvents.erase( eventIt );
 			continue;
 		}

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -691,14 +691,14 @@ ivec2 TextureBase::calcMipLevelSize( int mipLevel, GLint width, GLint height )
 {
 	width = std::max<int>( 1, width >> mipLevel );
 	height = std::max<int>( 1, height >> mipLevel );
-	
+
 	return ivec2( width, height );
 }
-	
+
 int TextureBase::requiredMipLevels( GLint width, GLint height, GLint depth )
 {
 	int maxDim = std::max( width, std::max( height, depth ) );
-	return floor( std::log2( maxDim ) ) + 1;
+	return static_cast<int>( floor( std::log2( maxDim ) ) )+ 1;
 }
 
 GLfloat TextureBase::getMaxAnisotropyMax()

--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -38,7 +38,7 @@
 
 // Figure out if we need std::Log2
 #if defined(CINDER_ANDROID ) && ((__GNUC__ == 4) && (__GNUC_MINOR__ <= 9))
-    #if defined(__arm__) 
+    #if defined(__arm__)
         #define _IS_ARM32
     #endif
 
@@ -59,9 +59,9 @@
  	#endif
 
  	#if defined(__mips64)
- 		#define _IS_MIPS64 
+ 		#define _IS_MIPS64
  	#endif
-    
+
     #if defined(_IS_ARM32) || defined(_IS_X86_32) || defined(_IS_MIPS32)
         #define NEEDS_STD_LOG2
     #endif
@@ -79,7 +79,7 @@ namespace std {
 
 double log2( double x ) {
 #if __ANDROID_API__ < 18
-    return ::log( x ) / ::log( 2.0 ); 
+    return ::log( x ) / ::log( 2.0 );
 #else
     return ::log2( x );
 #endif
@@ -111,15 +111,15 @@ class ImageTargetGlTexture : public ImageTarget {
 	// receives a pointer to an intermediate data store, presumably a mapped PBO
 	static shared_ptr<ImageTargetGlTexture> create( const Texture *texture, ImageIo::ChannelOrder &channelOrder, bool isGray, bool hasAlpha, void *data );
 #endif
-	
+
 	virtual bool	hasAlpha() const { return mHasAlpha; }
 	virtual void*	getRowPointer( int32_t row );
-	
+
 	void*			getData() const { return mDataBaseAddress; }
-	
+
   private:
 	ImageTargetGlTexture( const Texture *texture, ImageIo::ChannelOrder &channelOrder, bool isGray, bool hasAlpha, void *intermediateData );
-	
+
 	const Texture		*mTexture;
 	bool				mHasAlpha;
 	uint8_t				mPixelInc;
@@ -178,7 +178,7 @@ void TextureBase::initParams( Format &format, GLint defaultInternalFormat, GLint
 	// default is GL_LINEAR
 	if( format.mMagFilter != GL_LINEAR )
 		glTexParameteri( mTarget, GL_TEXTURE_MAG_FILTER, format.mMagFilter );
-	
+
 	if( format.mMaxAnisotropy > 1.0f )
 		glTexParameterf( mTarget, GL_TEXTURE_MAX_ANISOTROPY_EXT, format.mMaxAnisotropy );
 
@@ -192,7 +192,7 @@ void TextureBase::initParams( Format &format, GLint defaultInternalFormat, GLint
 	//if( ( format.mDataType == -1 ) && ( defaultDataType > 0 ) )
 	//	format.mDataType = defaultDataType;
 
-	// Try to find a matching data type based on the internal format, use the 
+	// Try to find a matching data type based on the internal format, use the
 	// defaultDataType if a match isn't found.
 	GLenum dataFormatFromInternal = GL_INVALID_ENUM;
 	GLenum dataTypeFromInternal = GL_INVALID_ENUM;
@@ -220,7 +220,7 @@ void TextureBase::initParams( Format &format, GLint defaultInternalFormat, GLint
 	if( format.mSwizzleMask[3] != GL_ALPHA )
 		glTexParameteri( mTarget, GL_TEXTURE_SWIZZLE_A, format.mSwizzleMask[3] );
 #endif
-	mSwizzleMask = format.mSwizzleMask;	
+	mSwizzleMask = format.mSwizzleMask;
 
 	// Compare Mode and Func for Depth Texture
 #if defined( CINDER_GL_ES_2 )
@@ -242,15 +242,15 @@ void TextureBase::initParams( Format &format, GLint defaultInternalFormat, GLint
 		}
 	}
   #endif
-#else 
+#else
 	if( format.mCompareMode > -1 ) {
 		glTexParameteri( mTarget, GL_TEXTURE_COMPARE_MODE, format.mCompareMode );
 	}
 	if( format.mCompareFunc > -1 ) {
 		glTexParameteri( mTarget, GL_TEXTURE_COMPARE_FUNC, format.mCompareFunc );
-	}	
+	}
 #endif
-	
+
 	mMipmapping = format.mMipmapping;
 	if( mMipmapping ) {
 		mBaseMipmapLevel = format.mBaseMipmapLevel;
@@ -317,7 +317,7 @@ void TextureBase::getInternalFormatInfo( GLint internalFormat, GLenum *outDataFo
 		case GL_RGB16F_EXT:				dataFormat = GL_RGB;				dataType = GL_HALF_FLOAT_OES;			break;
 		case GL_RG16F_EXT:				dataFormat = GL_RG;					dataType = GL_HALF_FLOAT_OES;			break;
 		case GL_R16F_EXT:				dataFormat = GL_RED;				dataType = GL_HALF_FLOAT_OES;			break;
-	#endif	
+	#endif
 #else
 		case GL_R8:				dataFormat = GL_RED;			dataType = GL_UNSIGNED_BYTE;					break;
 		case GL_R8_SNORM:		dataFormat = GL_RED;			dataType = GL_BYTE;								break;
@@ -431,16 +431,16 @@ void TextureBase::getInternalFormatInfo( GLint internalFormat, GLenum *outDataFo
 		case GL_COMPRESSED_SIGNED_RG11_EAC:					dataFormat = GL_RG;		dataType = 0;					break;
 #endif
 
-		default: 		
+		default:
 			CI_LOG_W( "Unknown internalFormat:" << gl::constantToString( internalFormat ) );
 			// Defaulting to GL_RGBA and GL_UNSIGNED_BYTE can cause the wrong texture storage
-			// allocation to happen for the wrong data type. This leads to FBOs having 
+			// allocation to happen for the wrong data type. This leads to FBOs having
 			// incomplete attachments on Android and Linux.
 			dataFormat = GL_INVALID_ENUM; //GL_RGBA;
 			dataType = GL_INVALID_ENUM; //GL_UNSIGNED_BYTE;
 			break;
 	}
-	
+
 	if( outAlpha )
 #if defined( CINDER_GL_ES )
 		*outAlpha = ( dataFormat == GL_RGBA ) || ( dataFormat == GL_ALPHA ) || ( dataFormat == GL_LUMINANCE_ALPHA );
@@ -506,10 +506,10 @@ GLenum TextureBase::getBindingConstantForTarget( GLenum target )
 		break;
 		case GL_TEXTURE_CUBE_MAP_ARRAY:
 			return GL_TEXTURE_BINDING_CUBE_MAP_ARRAY;
-		break;			
+		break;
 		case GL_TEXTURE_BUFFER:
 			return GL_TEXTURE_BINDING_BUFFER;
-		break;			
+		break;
 		case GL_TEXTURE_2D_MULTISAMPLE:
 			return GL_TEXTURE_BINDING_2D_MULTISAMPLE;
 		break;
@@ -553,7 +553,7 @@ void TextureBase::setMagFilter( GLenum magFilter )
 	ScopedTextureBind tbs( mTarget, mTextureId );
 	glTexParameteri( mTarget, GL_TEXTURE_MAG_FILTER, magFilter );
 }
-	
+
 void TextureBase::setMaxAnisotropy( GLfloat maxAnisotropy )
 {
 	ScopedTextureBind tbs( mTarget, mTextureId );
@@ -574,10 +574,10 @@ void TextureBase::setCompareMode( GLenum compareMode )
   #endif
 #else
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	glTexParameteri( mTarget, GL_TEXTURE_COMPARE_MODE, compareMode );	
+	glTexParameteri( mTarget, GL_TEXTURE_COMPARE_MODE, compareMode );
 #endif
 }
-	
+
 void TextureBase::setCompareFunc( GLenum compareFunc )
 {
 #if defined( CINDER_GL_ES_2 )
@@ -589,10 +589,10 @@ void TextureBase::setCompareFunc( GLenum compareFunc )
 	else {
 		CI_LOG_E("This device doesn't support GL_TEXTURE_COMPARE_FUNC from EXT_shadow_samplers");
 	}
-  #endif	
+  #endif
 #else
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	glTexParameteri( mTarget, GL_TEXTURE_COMPARE_FUNC, compareFunc );	
+	glTexParameteri( mTarget, GL_TEXTURE_COMPARE_FUNC, compareFunc );
 #endif
 }
 
@@ -601,7 +601,7 @@ bool TextureBase::surfaceRequiresIntermediate( int32_t width, uint8_t pixelBytes
 {
 	if( width * pixelBytes != rowBytes )
 		return true;
-	
+
 	if( std::is_same<T,uint8_t>::value ) { // 8-bit
 		switch( surfaceChannelOrder.getCode() ) {
 			case SurfaceChannelOrder::RGB:
@@ -733,7 +733,7 @@ bool TextureBase::supportsShadowSampler()
 void TextureBase::setLabel( const std::string &label )
 {
 	mLabel = label;
-	env()->objectLabel( GL_TEXTURE, mTextureId, (GLsizei)label.size(), label.c_str() );	
+	env()->objectLabel( GL_TEXTURE, mTextureId, (GLsizei)label.size(), label.c_str() );
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -759,7 +759,7 @@ TextureBase::Format::Format()
 	mSwizzleSpecified = false;
 	mSwizzleMask[0] = GL_RED; mSwizzleMask[1] = GL_GREEN; mSwizzleMask[2] = GL_BLUE; mSwizzleMask[3] = GL_ALPHA;
 	mCompareMode = -1;
-	mCompareFunc = -1;	
+	mCompareFunc = -1;
 }
 
 void TextureBase::Format::setSwizzleMask( GLint r, GLint g, GLint b, GLint a )
@@ -851,7 +851,7 @@ void Texture1d::update( const Surface8u &surface, int mipLevel )
 	GLint dataFormat;
 	GLenum type;
 	SurfaceChannelOrderToDataFormatAndType<uint8_t>( surface.getChannelOrder(), &dataFormat, &type );
-		
+
 	ivec2 mipMapSize = calcMipLevelSize( mipLevel, getWidth(), getHeight() );
 	if( surface.getSize() != mipMapSize )
 		throw TextureResizeExc( "Invalid Texture1d::update() surface dimensions", surface.getSize(), mipMapSize );
@@ -864,7 +864,7 @@ void Texture1d::update( const Surface8u &surface, int mipLevel )
 void Texture1d::update( const void *data, GLenum dataFormat, GLenum dataType, int mipLevel, int width, int offset )
 {
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	glTexSubImage1D( mTarget, mipLevel, offset, width, dataFormat, dataType, data );	
+	glTexSubImage1D( mTarget, mipLevel, offset, width, dataFormat, dataType, data );
 }
 
 void Texture1d::printDims( std::ostream &os ) const
@@ -931,7 +931,7 @@ Texture2dRef Texture2d::create( const Channel16u &channel, const Format &format 
 	else
 		return TextureRef( new Texture( channel, format ) );
 }
-	
+
 Texture2dRef Texture2d::create( const Channel32f &channel, const Format &format )
 {
 	if( format.mDeleter )
@@ -939,7 +939,7 @@ Texture2dRef Texture2d::create( const Channel32f &channel, const Format &format 
 	else
 		return TextureRef( new Texture( channel, format ) );
 }
-	
+
 Texture2dRef Texture2d::create( ImageSourceRef imageSource, const Format &format )
 {
 	if( format.mDeleter )
@@ -947,7 +947,7 @@ Texture2dRef Texture2d::create( ImageSourceRef imageSource, const Format &format
 	else
 		return TextureRef( new Texture( imageSource, format ) );
 }
-	
+
 Texture2dRef Texture2d::create( GLenum target, GLuint textureID, int width, int height, bool doNotDispose, const std::function<void(Texture2d*)> &deleter )
 {
 	if( deleter )
@@ -1198,7 +1198,7 @@ Texture2d::Texture2d( const TextureData &data, Format format )
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
 	initParams( format, 0 /* unused */, 0 /* unused */ );
-	
+
 	replace( data );
 
 	if( mMipmapping && data.getNumLevels() <= 1 ) {
@@ -1211,7 +1211,7 @@ void Texture2d::setData( const SurfaceT<T> &original, bool createStorage, int mi
 {
 	SurfaceT<T> intermediate;
 	bool useIntermediate = false;
-	
+
 	// we need an intermediate format for not top-down, certain channel orders, and rowBytes != numChannels * width
 	if( ( ! mTopDown ) || surfaceRequiresIntermediate<T>( original.getWidth(), original.getPixelBytes(), original.getRowBytes(), original.getChannelOrder() ) ) {
 		intermediate = SurfaceT<T>( original.getWidth(), original.getHeight(), original.hasAlpha(), original.hasAlpha() ? SurfaceChannelOrder::RGBA : SurfaceChannelOrder::RGB );
@@ -1221,21 +1221,21 @@ void Texture2d::setData( const SurfaceT<T> &original, bool createStorage, int mi
 			ip::flipVertical( original, &intermediate );
 		useIntermediate = true;
 	}
-	
+
 	const SurfaceT<T> &source = ( useIntermediate ) ? intermediate : original;
-		
+
 	GLint dataFormat;
 	GLenum type;
 	SurfaceChannelOrderToDataFormatAndType<T>( source.getChannelOrder(), &dataFormat, &type );
 
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	
+
 	glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
 	if( createStorage )
 		glTexImage2D( mTarget, 0, mInternalFormat, source.getWidth(), source.getHeight(), 0, dataFormat, type, source.getData() );
     else
 		glTexSubImage2D( mTarget, mipLevel, destOffset.x, destOffset.y, source.getWidth(), source.getHeight(), dataFormat, type, source.getData() );
-	
+
 	if( mMipmapping && mipLevel == 0 )
 		glGenerateMipmap( mTarget );
 }
@@ -1245,7 +1245,7 @@ void Texture2d::setData( const ChannelT<T> &original, bool createStorage, int mi
 {
 	ChannelT<T> intermediate;
 	bool useIntermediate = false;
-	
+
 	// we need an intermediate format for not top-down or non-planar
 	if( ( ! mTopDown ) || ( ! original.isPlanar() ) ) {
 		intermediate = ChannelT<T>( original.getWidth(), original.getHeight() );
@@ -1260,7 +1260,7 @@ void Texture2d::setData( const ChannelT<T> &original, bool createStorage, int mi
 
 	GLenum dataFormat;
 	getInternalFormatInfo( mInternalFormat, &dataFormat, nullptr, nullptr, nullptr, nullptr );
-	
+
 	GLenum type = GL_UNSIGNED_BYTE;
 	if( std::is_same<uint16_t,T>::value )
 		type = GL_UNSIGNED_SHORT;
@@ -1268,13 +1268,13 @@ void Texture2d::setData( const ChannelT<T> &original, bool createStorage, int mi
 		type = GL_FLOAT;
 
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	
+
 	glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
 	if( createStorage )
 		glTexImage2D( mTarget, 0, mInternalFormat, source.getWidth(), source.getHeight(), 0, dataFormat, type, source.getData() );
     else
 		glTexSubImage2D( mTarget, mipLevel, destOffset.x, destOffset.y, source.getWidth(), source.getHeight(), dataFormat, type, source.getData() );
-	
+
 	if( mMipmapping && mipLevel == 0 )
 		glGenerateMipmap( mTarget );
 }
@@ -1282,10 +1282,10 @@ void Texture2d::setData( const ChannelT<T> &original, bool createStorage, int mi
 void Texture2d::initData( const void *data, GLenum dataFormat, const Format &format )
 {
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	
+
 	glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
 	glTexImage2D( mTarget, 0, mInternalFormat, mActualSize.x, mActualSize.y, 0, dataFormat, format.getDataType(), data );
-    
+
 	if( mMipmapping ) {
 		initMaxMipmapLevel();
 		glGenerateMipmap( mTarget );
@@ -1304,7 +1304,7 @@ void Texture2d::initDataImageSourceWithPboImpl( const ImageSourceRef &imageSourc
 	if( pbo->getSize() < imageSource->getRowBytes() * imageSource->getHeight() )
 		pbo->bufferData( imageSource->getRowBytes() * imageSource->getHeight(), nullptr, GL_STREAM_DRAW );
 	void *pboData = pbo->map( GL_WRITE_ONLY );
-	
+
 	if( imageSource->getDataType() == ImageIo::UINT8 ) {
 		auto target = ImageTargetGlTexture<uint8_t>::create( this, channelOrder, isGray, imageSource->hasAlpha(), pboData );
 		imageSource->load( target );
@@ -1326,10 +1326,10 @@ void Texture2d::initDataImageSourceWithPboImpl( const ImageSourceRef &imageSourc
 	else {
 		auto target = ImageTargetGlTexture<float>::create( this, channelOrder, isGray, imageSource->hasAlpha(), pboData );
 		imageSource->load( target );
-		pbo->unmap();		
+		pbo->unmap();
 		glTexImage2D( mTarget, 0, mInternalFormat, mActualSize.x, mActualSize.y, 0, dataFormat, dataType, nullptr );
 	}
-	
+
 	ctx->popBufferBinding( GL_PIXEL_UNPACK_BUFFER );
 }
 #endif
@@ -1346,7 +1346,7 @@ void Texture2d::initDataImageSourceImpl( const ImageSourceRef &imageSource, cons
 		auto target = ImageTargetGlTexture<uint16_t>::create( this, channelOrder, isGray, imageSource->hasAlpha() );
 		imageSource->load( target );
 		glTexImage2D( mTarget, 0, mInternalFormat, mActualSize.x, mActualSize.y, 0, dataFormat, dataType, target->getData() );
-		
+
 	}
 	else if( imageSource->getDataType() == ImageIo::FLOAT16 ) {
 		auto target = ImageTargetGlTexture<half_float>::create( this, channelOrder, isGray, imageSource->hasAlpha() );
@@ -1356,7 +1356,7 @@ void Texture2d::initDataImageSourceImpl( const ImageSourceRef &imageSource, cons
 #else
 		glTexImage2D( mTarget, 0, mInternalFormat, mActualSize.x, mActualSize.y, 0, dataFormat, dataType, target->getData() );
 #endif
-		
+
 	}
 	else {
 		auto target = ImageTargetGlTexture<float>::create( this, channelOrder, isGray, imageSource->hasAlpha() );
@@ -1369,7 +1369,7 @@ void Texture2d::initData( const ImageSourceRef &imageSource, const Format &forma
 {
 	mActualSize = ivec2( imageSource->getWidth(), imageSource->getHeight() );
 	mCleanBounds = Area( 0, 0, mActualSize.x, mActualSize.y );
-	
+
 	// setup an appropriate dataFormat/ImageTargetTexture based on the image's color space
 	ImageIo::ChannelOrder channelOrder;
 	bool isGray = false;
@@ -1390,9 +1390,9 @@ void Texture2d::initData( const ImageSourceRef &imageSource, const Format &forma
 	getInternalFormatInfo( mInternalFormat, &dataFormat, &dataType, nullptr, nullptr, nullptr );
 	if( ! format.isAutoDataType() )
 		dataType = format.getDataType();
-	
-	ScopedTextureBind tbs( mTarget, mTextureId );	
-	
+
+	ScopedTextureBind tbs( mTarget, mTextureId );
+
 	glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
 #if ! defined( CINDER_GL_ES )
 	auto pbo = format.getIntermediatePbo();
@@ -1400,10 +1400,10 @@ void Texture2d::initData( const ImageSourceRef &imageSource, const Format &forma
 		initDataImageSourceWithPboImpl( imageSource, format, dataFormat, dataType, channelOrder, isGray, pbo );
 	else {
 		initDataImageSourceImpl( imageSource, format, dataFormat, dataType, channelOrder, isGray );
-	}	
+	}
 #else
 	initDataImageSourceImpl( imageSource, format, dataFormat, dataType, channelOrder, isGray );
-#endif	
+#endif
 
 	if( mMipmapping ) {
 		initMaxMipmapLevel();
@@ -1459,7 +1459,7 @@ void Texture2d::update( const PboRef &pbo, GLenum format, GLenum type, const Are
 	/*
 	CI_ASSERT_ERROR( pbo->getTarget() == GL_PIXEL_UNPACK_BUFFER )
 	*/
-	
+
 	ScopedBuffer bufScp( (BufferObjRef)( pbo ) );
 	ScopedTextureBind tbs( mTarget, mTextureId );
 	glTexSubImage2D( mTarget, mipLevel, destArea.getX1(), mActualSize.y - destArea.getY2(), destArea.getWidth(), destArea.getHeight(), format, type, reinterpret_cast<const GLvoid*>( pboByteOffset ) );
@@ -1476,19 +1476,19 @@ void Texture2d::setCleanBounds( const Area &cleanBounds )
 Rectf Texture2d::getAreaTexCoords( const Area &area ) const
 {
 	Rectf result;
-	
+
 	if( mTarget == GL_TEXTURE_2D
 #if ! defined( CINDER_GL_ES )
-		|| mTarget == GL_TEXTURE_2D_MULTISAMPLE 
+		|| mTarget == GL_TEXTURE_2D_MULTISAMPLE
 #elif defined( CINDER_ANDROID )
-		|| mTarget == GL_TEXTURE_EXTERNAL_OES		
+		|| mTarget == GL_TEXTURE_EXTERNAL_OES
 #endif
 	   ) { // normalized 0-1.0 coordinates
 		result.x1 = (mCleanBounds.x1 + area.x1) / (float)mActualSize.x;
 		result.y1 = (mCleanBounds.y1 + area.y1) / (float)mActualSize.y;
 		result.x2 = (mCleanBounds.x1 + area.x2) / (float)mActualSize.x;
 		result.y2 = (mCleanBounds.y1 + area.y2) / (float)mActualSize.y;
-		
+
 		if( ! mTopDown ) {
 			result.y1 = 1 - result.y1;
 			result.y2 = 1 - result.y2;
@@ -1502,14 +1502,14 @@ Rectf Texture2d::getAreaTexCoords( const Area &area ) const
 			result.y2 = mActualSize.y - result.y2;
 		}
 	}
-	
+
 	return result;
 }
 
 std::ostream& operator<<( std::ostream &os, const TextureBase &rhs )
 {
 	ScopedTextureBind bind( rhs.getTarget(), rhs.getId() );
-	
+
 	os << "Target: " << constantToString( rhs.getTarget() ) << "  ID: " << rhs.mTextureId << std::endl;
 	if( ! rhs.mLabel.empty() )
 	os << "       Label: " << rhs.mLabel << std::endl;
@@ -1526,7 +1526,7 @@ std::ostream& operator<<( std::ostream &os, const TextureBase &rhs )
 		os << "  Level 0 Size: " << compressedSize << " bytes (Compressed)";
 	}
 #endif
-	
+
 	return os;
 }
 
@@ -1548,23 +1548,23 @@ Texture2dCacheRef Texture2dCache::create()
 {
 	return Texture2dCacheRef( new Texture2dCache() );
 }
-	
+
 Texture2dCacheRef Texture2dCache::create( const Surface8u &prototypeSurface, const Texture2d::Format &format )
 {
 	return Texture2dCacheRef( new Texture2dCache( prototypeSurface, format ) );
 }
-	
+
 Texture2dCache::Texture2dCache()
 {
 }
-	
+
 Texture2dCache::Texture2dCache( const Surface8u &prototypeSurface, const Texture2d::Format &format )
 	: mWidth( prototypeSurface.getWidth() ), mHeight( prototypeSurface.getHeight() ),
 	mFormat( format ), mNextId( 0 )
 {
 	if( mWidth * prototypeSurface.getChannelOrder().getPixelInc() != prototypeSurface.getRowBytes() ) {
 		CI_LOG_V( "Surface rowBytes will prevent full efficiency in gl::Texture upload." );
-		mIntermediateSurface = Surface8u::create( prototypeSurface.getWidth(), prototypeSurface.getHeight(), 
+		mIntermediateSurface = Surface8u::create( prototypeSurface.getWidth(), prototypeSurface.getHeight(),
 				prototypeSurface.hasAlpha(), prototypeSurface.getChannelOrder() );
 	}
 }
@@ -1586,7 +1586,7 @@ gl::TextureRef Texture2dCache::cache( const Surface8u &originalData )
 			return TextureRef( texIt->second.get(), std::bind( &Texture2dCache::markTextureAsFree, shared_from_this(), texIt->first ) );
 		}
 	}
-	
+
 	// we didn't find an available slot, so let's make a new texture
 	TextureRef masterTex( new Texture( surfaceData, mFormat ) );
 	mTextures.push_back( make_pair( mNextId++, masterTex ) );
@@ -1613,21 +1613,21 @@ class ImageSourceTexture : public ImageSource {
 	{
 		mWidth = texture.getWidth();
 		mHeight = texture.getHeight();
-		
+
 
 		GLenum format;
-#if ! defined( CINDER_GL_ES )		
+#if ! defined( CINDER_GL_ES )
 		GLint internalFormat = texture.getInternalFormat();
 		switch( internalFormat ) {
 			case GL_RGB: setChannelOrder( ImageIo::RGB ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::UINT8 ); format = GL_RGB; break;
 			case GL_RGBA: setChannelOrder( ImageIo::RGBA ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::UINT8 ); format = GL_RGBA; break;
-			case GL_RGBA8: setChannelOrder( ImageIo::RGBA ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::UINT8 ); format = GL_RGBA; break; 
+			case GL_RGBA8: setChannelOrder( ImageIo::RGBA ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::UINT8 ); format = GL_RGBA; break;
 			case GL_RGB8: setChannelOrder( ImageIo::RGB ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::UINT8 ); format = GL_RGB; break;
 			case GL_BGR: setChannelOrder( ImageIo::RGB ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::FLOAT32 ); format = GL_RGB; break;
 			case GL_DEPTH_COMPONENT16: setChannelOrder( ImageIo::Y ); setColorModel( ImageIo::CM_GRAY ); setDataType( ImageIo::UINT16 ); format = GL_DEPTH_COMPONENT; break;
 			case GL_DEPTH_COMPONENT24: setChannelOrder( ImageIo::Y ); setColorModel( ImageIo::CM_GRAY ); setDataType( ImageIo::FLOAT32 ); format = GL_DEPTH_COMPONENT; break;
 			case GL_DEPTH_COMPONENT32: setChannelOrder( ImageIo::Y ); setColorModel( ImageIo::CM_GRAY ); setDataType( ImageIo::FLOAT32 ); format = GL_DEPTH_COMPONENT; break;
-			case GL_RGBA32F_ARB: setChannelOrder( ImageIo::RGBA ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::FLOAT32 ); format = GL_RGBA; break; 
+			case GL_RGBA32F_ARB: setChannelOrder( ImageIo::RGBA ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::FLOAT32 ); format = GL_RGBA; break;
 			case GL_RGB32F_ARB: setChannelOrder( ImageIo::RGB ); setColorModel( ImageIo::CM_RGB ); setDataType( ImageIo::FLOAT32 ); format = GL_RGB; break;
 			case GL_R32F: setChannelOrder( ImageIo::Y ); setColorModel( ImageIo::CM_GRAY ); setDataType( ImageIo::FLOAT32 ); format = GL_RED; break;
 			case GL_RG32F: setChannelOrder( ImageIo::YA ); setColorModel( ImageIo::CM_GRAY ); setDataType( ImageIo::FLOAT32 ); format = GL_RG; break;
@@ -1664,7 +1664,7 @@ class ImageSourceTexture : public ImageSource {
 			dataType = GL_FLOAT;
 			dataSize = 4;
 		}
-			
+
 		mRowBytes = mWidth * ImageIo::channelOrderNumChannels( mChannelOrder ) * dataSize;
 		mData = unique_ptr<uint8_t[]>( new uint8_t[mRowBytes * mHeight] );
 
@@ -1672,7 +1672,7 @@ class ImageSourceTexture : public ImageSource {
 		// This line is not too awesome, however we need a TextureRef, not a Texture, for an FBO attachment. So this creates a shared_ptr with a no-op deleter
 		// that won't destroy our original texture.
 		TextureRef tempSharedPtr( &texture, []( const Texture* ){} );
-		// The theory here is we need to build an FBO, attach the Texture to it, issue a glReadPixels against it, and the put it away		
+		// The theory here is we need to build an FBO, attach the Texture to it, issue a glReadPixels against it, and the put it away
 		FboRef fbo = Fbo::create( mWidth, mHeight, gl::Fbo::Format().attachment( GL_COLOR_ATTACHMENT0, tempSharedPtr ).disableDepth() );
 		ScopedFramebuffer fbScp( fbo );
 		glReadPixels( 0, 0, mWidth, mHeight, format, dataType, mData.get() );
@@ -1690,7 +1690,7 @@ class ImageSourceTexture : public ImageSource {
 	void load( ImageTargetRef target ) {
 		// get a pointer to the ImageSource function appropriate for handling our data configuration
 		ImageSource::RowFunc func = setupRowFunc( target );
-		
+
 		const uint8_t *data = mData.get();
 		if( mRowBytes < 0 )
 			data = data + ( mHeight - 1 ) * (-mRowBytes);
@@ -1699,7 +1699,7 @@ class ImageSourceTexture : public ImageSource {
 			data += mRowBytes;
 		}
 	}
-	
+
 	std::unique_ptr<uint8_t[]>	mData;
 	int32_t						mRowBytes;
 };
@@ -1756,11 +1756,11 @@ void Texture3d::update( const Surface8u &surface, int depth, int mipLevel )
 	GLint dataFormat;
 	GLenum dataType;
 	SurfaceChannelOrderToDataFormatAndType<uint8_t>( surface.getChannelOrder(), &dataFormat, &dataType );
-		
+
 	ivec2 mipMapSize = calcMipLevelSize( mipLevel, getWidth(), getHeight() );
 	if( surface.getSize() != mipMapSize )
 		throw TextureResizeExc( "Invalid Texture3d::update() surface dimensions", surface.getSize(), mipMapSize );
-	
+
 	update( (void*)surface.getData(), dataFormat, dataType, mipLevel, mipMapSize.x, mipMapSize.y, 1, 0, 0, depth );
 }
 
@@ -1792,7 +1792,7 @@ std::vector<CubeMapFaceRegion> calcCubeMapHorizontalCrossRegions( const ImageSou
 
 	ivec2 faceSize( imageSource->getWidth() / 4, imageSource->getHeight() / 3 );
 	Area faceArea( 0, 0, faceSize.x, faceSize.y );
-	
+
 	Area area;
 	ivec2 offset;
 
@@ -1820,17 +1820,17 @@ std::vector<CubeMapFaceRegion> calcCubeMapHorizontalCrossRegions( const ImageSou
 	area = faceArea + ivec2( faceSize.x * 3, faceSize.y * 1 );
 	offset = -ivec2( faceSize.x * 3, faceSize.y * 1 );
 	result.push_back( { area, offset, false } );
-		
+
 	return result;
 };
-	
+
 std::vector<CubeMapFaceRegion> calcCubeMapVerticalCrossRegions( const ImageSourceRef &imageSource )
 {
 	std::vector<CubeMapFaceRegion> result;
-	
+
 	ivec2 faceSize( imageSource->getWidth() / 3, imageSource->getHeight() / 4 );
 	Area faceArea( 0, 0, faceSize.x, faceSize.y );
-	
+
 	Area area;
 	ivec2 offset;
 
@@ -1858,10 +1858,10 @@ std::vector<CubeMapFaceRegion> calcCubeMapVerticalCrossRegions( const ImageSourc
 	area = faceArea + ivec2( faceSize.x * 1, faceSize.y * 3 );
 	offset = -ivec2( faceSize.x * 1, faceSize.y * 3 );
 	result.push_back( { area, offset, true } );
-	
+
 	return result;
 };
-	
+
 std::vector<CubeMapFaceRegion> calcCubeMapHorizontalRegions( const ImageSourceRef &imageSource )
 {
 	std::vector<CubeMapFaceRegion> result;
@@ -1875,12 +1875,12 @@ std::vector<CubeMapFaceRegion> calcCubeMapHorizontalRegions( const ImageSourceRe
 
 	return result;
 };
-	
+
 std::vector<CubeMapFaceRegion> calcCubeMapVerticalRegions( const ImageSourceRef &imageSource )
 {
 	std::vector<CubeMapFaceRegion> result;
 	ivec2 faceSize( imageSource->getWidth(), imageSource->getWidth() );
-	
+
 	for( uint8_t index = 0; index < 6; ++index ) {
 		Area area( 0.0f, index * faceSize.x, faceSize.x, (index + 1) * faceSize.y );
 		ivec2 offset( 0.0f, -index * faceSize.y );
@@ -1896,7 +1896,7 @@ TextureCubeMap::Format::Format()
 {
 	mTarget = GL_TEXTURE_CUBE_MAP;
 	mMinFilter = GL_NEAREST;
-	mMagFilter = GL_NEAREST;	
+	mMagFilter = GL_NEAREST;
 }
 
 TextureCubeMapRef TextureCubeMap::create( int32_t width, int32_t height, const Format &format )
@@ -1922,7 +1922,7 @@ TextureCubeMapRef TextureCubeMap::create( const TextureData &data, const Format 
 	else
 		return TextureCubeMapRef( new TextureCubeMap( data, format ) );
 }
-	
+
 template<typename T>
 TextureCubeMapRef TextureCubeMap::createTextureCubeMapImpl( const ImageSourceRef &imageSource, const Format &format )
 {
@@ -1942,10 +1942,10 @@ TextureCubeMapRef TextureCubeMap::createTextureCubeMapImpl( const ImageSourceRef
 
 	Area faceArea = faceRegions.front().mArea;
 	ivec2 faceSize = faceArea.getSize();
-	
+
 	SurfaceT<T> masterSurface( imageSource, SurfaceConstraintsDefault() );
 	SurfaceT<T> images[6];
-	
+
 	for( uint8_t f = 0; f < 6; ++f ) {
 		images[f] = SurfaceT<T>( faceSize.x, faceSize.y, masterSurface.hasAlpha(), SurfaceConstraints() );
 		images[f].copyFrom( masterSurface, faceRegions[f].mArea, faceRegions[f].mOffset );
@@ -1954,7 +1954,7 @@ TextureCubeMapRef TextureCubeMap::createTextureCubeMapImpl( const ImageSourceRef
 			ip::flipHorizontal( &images[f] );
 		}
 	}
-	
+
 	if( format.mDeleter )
 		return TextureCubeMapRef( new TextureCubeMap( images, format ), format.mDeleter );
 	else
@@ -1967,7 +1967,7 @@ TextureCubeMapRef TextureCubeMap::create( const ImageSourceRef images[6], const 
 		Surface8u surfaces[6];
 		for( size_t i = 0; i < 6; ++i )
 			surfaces[i] = Surface8u( images[i] );
-		
+
 		if( format.mDeleter )
 			return TextureCubeMapRef( new TextureCubeMap( surfaces, format ), format.mDeleter );
 		else
@@ -1977,7 +1977,7 @@ TextureCubeMapRef TextureCubeMap::create( const ImageSourceRef images[6], const 
 		Surface32f surfaces[6];
 		for( size_t i = 0; i < 6; ++i )
 			surfaces[i] = Surface32f( images[i] );
-		
+
 		if( format.mDeleter )
 			return TextureCubeMapRef( new TextureCubeMap( surfaces, format ), format.mDeleter );
 		else
@@ -2016,10 +2016,10 @@ TextureCubeMap::TextureCubeMap( int32_t width, int32_t height, Format format )
 {
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
-	ScopedTextureBind texBindScope( mTarget, mTextureId );	
+	ScopedTextureBind texBindScope( mTarget, mTextureId );
 	TextureBase::initParams( format, GL_RGB, GL_UNSIGNED_BYTE );
 
-	env()->allocateTexStorageCubeMap( mMaxMipmapLevel + 1, mInternalFormat, width, height, format.isImmutableStorage() );	
+	env()->allocateTexStorageCubeMap( mMaxMipmapLevel + 1, mInternalFormat, width, height, format.isImmutableStorage() );
 }
 
 template<typename T>
@@ -2027,7 +2027,7 @@ TextureCubeMap::TextureCubeMap( const SurfaceT<T> images[6], Format format )
 {
 	glGenTextures( 1, &mTextureId );
 	mTarget = format.getTarget();
-	ScopedTextureBind texBindScope( mTarget, mTextureId );	
+	ScopedTextureBind texBindScope( mTarget, mTextureId );
 
 	GLenum dataType = GL_UNSIGNED_BYTE;
 	if( std::is_same<T,float>::value )
@@ -2041,7 +2041,7 @@ TextureCubeMap::TextureCubeMap( const SurfaceT<T> images[6], Format format )
 	for( GLenum target = 0; target < 6; ++target )
 		glTexImage2D( GL_TEXTURE_CUBE_MAP_POSITIVE_X + target, 0, mInternalFormat, images[target].getWidth(), images[target].getHeight(), 0,
 			( images[target].hasAlpha() ) ? GL_RGBA : GL_RGB, format.getDataType(), images[target].getData() );
-			
+
 	if( format.mMipmapping ) {
 #if ! defined( CINDER_GL_ES_2 )
 		if( mMaxMipmapLevel == -1 )
@@ -2058,7 +2058,7 @@ TextureCubeMap::TextureCubeMap( const TextureData &data, Format format )
 	mTarget = format.getTarget();
 	ScopedTextureBind texBindScope( mTarget, mTextureId );
 	initParams( format, 0 /* unused */, 0 /* unused */ );
-	
+
 	replace( data );
 
 	if( mMipmapping && data.getNumLevels() <= 1 ) {
@@ -2099,7 +2099,7 @@ void TextureCubeMap::replace( const TextureData &textureData )
 
 #if ! defined( CINDER_GL_ES_2 )
 	mMaxMipmapLevel = (int32_t)textureData.getNumLevels() - 1;
-	glTexParameteri( mTarget, GL_TEXTURE_MAX_LEVEL, mMaxMipmapLevel );		
+	glTexParameteri( mTarget, GL_TEXTURE_MAX_LEVEL, mMaxMipmapLevel );
 #endif
 }
 
@@ -2136,7 +2136,7 @@ ImageTargetGlTexture<T>::ImageTargetGlTexture( const Texture *texture, ImageIo::
 		mPixelInc = mHasAlpha ? 4 : 3;
 	}
 	mRowInc = mTexture->getWidth() * mPixelInc;
-	
+
 	// allocate enough room to hold all these pixels if we haven't been passed a data*
 	if( ! intermediateDataStore ) {
 		mDataStore = std::unique_ptr<T[]>( new T[mTexture->getHeight() * mRowInc] );
@@ -2144,7 +2144,7 @@ ImageTargetGlTexture<T>::ImageTargetGlTexture( const Texture *texture, ImageIo::
 	}
 	else
 		mDataBaseAddress = reinterpret_cast<T*>( intermediateDataStore );
-	
+
 	if( std::is_same<T,uint8_t>::value ) {
 		setDataType( ImageIo::UINT8 );
 	}
@@ -2157,7 +2157,7 @@ ImageTargetGlTexture<T>::ImageTargetGlTexture( const Texture *texture, ImageIo::
 	else if( std::is_same<T,float>::value ) {
 		setDataType( ImageIo::FLOAT32 );
 	}
-	
+
 	setChannelOrder( channelOrder );
 	setColorModel( isGray ? ImageIo::CM_GRAY : ImageIo::CM_RGB );
 }


### PR DESCRIPTION
I was going over a few conversion warnings in VS and afaik came about an actual error:
If 

    Target::copyIndexDataForceTriangles

is called with a `uint16_t` array as a target and an non-zero offset, bytes are memcopied from a `uint32_t` array to a uint16_t array. I'm PR ing the whole branch, which silences a few more warnings, but the fix for that error is contained in the last commit. So if you don't want to merge the whole PR just cherry pick that one.