### PR TITLE
Fix some warnings

### DIFF
--- a/include/cinder/Stream.h
+++ b/include/cinder/Stream.h
@@ -96,7 +96,7 @@ class OStream : public virtual StreamBase {
 	void		writeData( const void *src, size_t size );
 
  protected:
-	OStream() : StreamBase() {}
+	OStream() = default;
  
 	virtual void		IOWrite( const void *t, size_t size ) = 0;
 };
@@ -131,7 +131,7 @@ class IStreamCinder : public virtual StreamBase {
 	virtual bool		isEof() const = 0;
 
  protected:
-	IStreamCinder() : StreamBase() {}
+	IStreamCinder() = default;
 
 	virtual void		IORead( void *t, size_t size ) = 0;
 		

--- a/include/cinder/UrlImplWinInet.h
+++ b/include/cinder/UrlImplWinInet.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "cinder/Url.h"
+#include <vector>
 
 namespace cinder {
 
@@ -47,8 +48,7 @@ class IStreamUrlImplWinInet : public IStreamUrlImpl {
 	std::shared_ptr<void>		mSession, mConnection, mRequest;
 	
 	mutable bool			mIsFinished;
-	mutable uint8_t			*mBuffer; // todo - consider an exception-safe version of this
-	mutable int				mBufferSize;
+	mutable std::vector<uint8_t> mBuffer;
 	mutable int				mBufferOffset, mBufferedBytes;
 	mutable off_t			mBufferFileOffset;	// where in the file the buffer starts
 	static const int		DEFAULT_BUFFER_SIZE = 4096;

--- a/src/cinder/CinderMath.cpp
+++ b/src/cinder/CinderMath.cpp
@@ -541,7 +541,7 @@ glm::tvec2<T, glm::defaultp> getClosestPointQuadratic( const glm::tvec2<T, glm::
 	int solutions = solveCubic<T>( a, b, c, d, t );
 
 	T distance2 = std::numeric_limits<T>::max();
-	for( int i = 0; i < 3; ++i ) {
+	for( int i = 0; i < solutions; ++i ) {
 		T u = glm::clamp( t[i], T{0}, T{1} );
 		T v = T{1} - u;
 		glm::tvec2<T, glm::defaultp> p = controlPoints[0] * ( v*v ) + controlPoints[1] * ( T{2} * u*v ) + controlPoints[2] * ( u*u );

--- a/src/cinder/app/msw/AppImplMsw.cpp
+++ b/src/cinder/app/msw/AppImplMsw.cpp
@@ -461,8 +461,6 @@ void WindowImplMsw::toggleFullScreen( const app::FullScreenOptions &options )
 {
 	ivec2 newWindowSize;
 	bool prevFullScreen = mFullScreen;
-	HDC oldDC = mDC;
-	HWND oldWnd = mWnd;
 	
 	mFullScreen = ! mFullScreen;
 	setWindowStyleValues();

--- a/src/tinyexr/tinyexr.cc
+++ b/src/tinyexr/tinyexr.cc
@@ -8992,10 +8992,7 @@ int ParseMultiChannelEXRHeaderFromMemory(EXRImage *exrImage,
     return -1;
   }
 
-  const char *buf = reinterpret_cast<const char *>(memory);
-
-  const char *head = &buf[0];
-  const char *marker = &buf[0];
+  const char *marker = reinterpret_cast<const char *>(memory);
 
   // Header check.
   {

--- a/src/videoInput/videoInput.cpp
+++ b/src/videoInput/videoInput.cpp
@@ -337,9 +337,7 @@ void videoDevice::NukeDownstream(IBaseFilter *pBF){
 // ---------------------------------------------------------------------- 
 
 void videoDevice::destroyGraph(){
-	HRESULT hr = NULL;
-	int FuncRetval=0;
-	int NumFilters=0;
+	HRESULT hr = NOERROR;
 
 	while (hr == NOERROR)	
 	{
@@ -1548,10 +1546,6 @@ void videoInput::processPixels(unsigned char * src, unsigned char * dst, int wid
 	int numBytes = widthInBytes * height;
 	
 	if(!bRGB){
-		
-		int x = 0;
-		int y = 0;
-	
 		if(bFlip){
 			for(int y = 0; y < height; y++){
 				memcpy(dst + (y * widthInBytes), src + ( (height -y -1) * widthInBytes), widthInBytes);	
@@ -1747,6 +1741,7 @@ static bool setSizeAndSubtype(videoDevice * VD, int attemptWidth, int attemptHei
 	VIDEOINFOHEADER *pVih =  reinterpret_cast<VIDEOINFOHEADER*>(VD->pAmMediaType->pbFormat);
 
 	//store current size
+	//XXX: Should be reset in case of failure?
 	int tmpWidth  = HEADER(pVih)->biWidth;
 	int tmpHeight = HEADER(pVih)->biHeight;	
 	AM_MEDIA_TYPE * tmpType = NULL;


### PR DESCRIPTION
Again working on some warnings that VS puts out under W4
- Some unused local variables
- Calling the constructor of a virtual base class from a abstract class doesn't have any effect
- use `std::vector` to implement internal buffer of IStreamUrlImplWinInet (makes functions exception safe)
- Fix a bug in `getClosestPointQuadratic`, where number of solutions wasn't considered.
