### PR TITLE
copyIndexDataForceTriangles bugs

### DIFF
--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -322,8 +322,27 @@ void copyData( uint8_t srcDimensions, const float *srcData, size_t numElements, 
 
 namespace { 
 template<typename T>
+bool indicesInRange( const uint32_t *indices, size_t numIndices )
+{
+    for( size_t i = 0; i < numIndices; ++i )
+        if( indices[i] > std::numeric_limits<T>::max() )
+            return false;
+
+    return true;
+}
+
+template<>
+bool indicesInRange<uint32_t>( const uint32_t *indices, size_t numIndices )
+{
+	return true;
+}
+
+template<typename T>
 void copyIndexDataForceTrianglesImpl( Primitive primitive, const uint32_t *source, size_t numIndices, T indexOffset, T *target )
 {
+	// verify that all indices are within the range expressible by 'T'
+	CI_ASSERT( indicesInRange<T>( source, numIndices ) );
+
 	switch( primitive ) {
 		case Primitive::LINES:
 		case Primitive::LINE_STRIP:

--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -347,10 +347,8 @@ void copyIndexDataForceTrianglesImpl( Primitive primitive, const uint32_t *sourc
 		case Primitive::LINES:
 		case Primitive::LINE_STRIP:
 		case Primitive::TRIANGLES:
-			if( indexOffset == 0 ) {
-				for( size_t i = 0; i < numIndices; ++i )
-					target[i] = static_cast<T>( source[i] );
-			}
+			if( indexOffset == 0 )
+				std::copy_n( source, numIndices, target );
 			else {
 				for( size_t i = 0; i < numIndices; ++i )
 					target[i] = static_cast<T>( source[i] + indexOffset );

--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -322,17 +322,17 @@ void copyData( uint8_t srcDimensions, const float *srcData, size_t numElements, 
 
 namespace { 
 template<typename T>
-bool indicesInRange( const uint32_t *indices, size_t numIndices )
+bool indicesInRange( const uint32_t *indices, size_t numIndices, T indexOffset )
 {
     for( size_t i = 0; i < numIndices; ++i )
-        if( indices[i] > std::numeric_limits<T>::max() )
+        if( indices[i] + indexOffset > std::numeric_limits<T>::max() )
             return false;
 
     return true;
 }
 
 template<>
-bool indicesInRange<uint32_t>( const uint32_t *indices, size_t numIndices )
+bool indicesInRange<uint32_t>( const uint32_t *indices, size_t numIndices, uint32_t indexOffset )
 {
 	return true;
 }
@@ -341,46 +341,49 @@ template<typename T>
 void copyIndexDataForceTrianglesImpl( Primitive primitive, const uint32_t *source, size_t numIndices, T indexOffset, T *target )
 {
 	// verify that all indices are within the range expressible by 'T'
-	CI_ASSERT( indicesInRange<T>( source, numIndices ) );
+	CI_ASSERT( indicesInRange<T>( source, numIndices, indexOffset ) );
 
 	switch( primitive ) {
 		case Primitive::LINES:
 		case Primitive::LINE_STRIP:
 		case Primitive::TRIANGLES:
 			if( indexOffset == 0 ) {
-				memcpy( target, source, sizeof(uint32_t) * numIndices );
+				for( size_t i = 0; i < numIndices; ++i )
+					target[i] = static_cast<T>( source[i] );
 			}
 			else {
 				for( size_t i = 0; i < numIndices; ++i )
-					target[i] = source[i] + indexOffset;
+					target[i] = static_cast<T>( source[i] + indexOffset );
 			}
 		break;
 		case Primitive::TRIANGLE_STRIP: { // ABC, CBD, CDE, EDF, etc
+			CI_ASSERT( indexOffset == 0 ); // unsupported with TRIANGLE_STRIP
 			if( numIndices < 3 )
 				return;
 			size_t outIdx = 0; // (012, 213), (234, 435), etc : (odd,even), (odd,even), etc
 			for( size_t i = 0; i < numIndices - 2; ++i ) {
 				if( i & 1 ) { // odd
-					target[outIdx++] = source[i+1];
-					target[outIdx++] = source[i];
-					target[outIdx++] = source[i+2];
+					target[outIdx++] = static_cast<T>( source[i+1] );
+					target[outIdx++] = static_cast<T>( source[i] );
+					target[outIdx++] = static_cast<T>( source[i+2] );
 				}
 				else { // even
-					target[outIdx++] = source[i];
-					target[outIdx++] = source[i+1];
-					target[outIdx++] = source[i+2];
+					target[outIdx++] = static_cast<T>( source[i] );
+					target[outIdx++] = static_cast<T>( source[i+1] );
+					target[outIdx++] = static_cast<T>( source[i+2] );
 				}
 			}
 		}
 		break;
 		case Primitive::TRIANGLE_FAN: { // ABC, ACD, ADE, etc
+			CI_ASSERT( indexOffset == 0 ); // unsupported with TRIANGLE_FAN 
 			if( numIndices < 3 )
 				return;
 			size_t outIdx = 0;
 			for( size_t i = 0; i < numIndices - 2; ++i ) {
-				target[outIdx++] = source[0];
-				target[outIdx++] = source[i+1];
-				target[outIdx++] = source[i+2];
+				target[outIdx++] = static_cast<T>( source[0] );
+				target[outIdx++] = static_cast<T>( source[i+1] );
+				target[outIdx++] = static_cast<T>( source[i+2] );
 			}
 		}
 		break;


### PR DESCRIPTION
This addresses a bug found by @MikeGitb in #1764 in `Target::copyIndexDataForceTriangles()` which would manifest when using GL_TRIANGLES primitive with 16-bit indices. Additionally, this PR asserts that indices are within range in the 16-bit index case. Unfortunately I don't see an easy way to unit test that this assert fires using Catch. The code I used to exercise it is below.

```
	vector<uint16_t> idx16( 10 );
	vector<uint32_t> idx32;
	
	for( size_t i = 0; i < idx16.size() - 1; ++i )
		idx32.push_back( (uint32_t)i );
	idx32.push_back( 65536 ); // failure case
	
	geom::Target::copyIndexDataForceTriangles( geom::Primitive::TRIANGLES, idx32.data(), idx32.size(), 0, idx16.data() );
```