### PR TITLE
 setting mMaxMipmapLevel in Texture2d

### DIFF
--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -987,7 +987,9 @@ Texture2d::Texture2d( int width, int height, Format format )
 	initParams( format, GL_RGBA, GL_UNSIGNED_BYTE );
 #endif
 
-	//initMaxMipmapLevel();
+	if( mMipmapping )
+		initMaxMipmapLevel();
+
 	env()->allocateTexStorage2d( mTarget, mMaxMipmapLevel + 1, mInternalFormat, width, height, format.isImmutableStorage(), format.getDataType() );
 }
 


### PR DESCRIPTION
Fixes #1763. Before this (since android_linux branch merge), loading custom mipmaps was broken. 