### PR TITLE
explicitly add signal::Connection copy constructor and assignment operator

### DIFF
--- a/include/cinder/Signals.h
+++ b/include/cinder/Signals.h
@@ -121,7 +121,9 @@ class Connection {
   public:
 	Connection();
 	Connection( const std::shared_ptr<detail::Disconnector> &disconnector, detail::SignalLinkBase *link, int priority );
+	Connection( const Connection &other );
 	Connection( Connection &&other );
+	Connection& operator=( const Connection &rhs );
 	Connection& operator=( Connection &&rhs );
 
 	//! Disconnects this Connection from the callback chain. \a return true if a disconnection was made, false otherwise.

--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -37,9 +37,23 @@ Connection::Connection( const std::shared_ptr<detail::Disconnector> &disconnecto
 {
 }
 
+Connection::Connection( const Connection &other )
+	: mDisconnector( other.mDisconnector ), mLink( other.mLink ), mPriority( other.mPriority )
+{
+}
+
 Connection::Connection( Connection &&other )
 	: mDisconnector( move( other.mDisconnector ) ), mLink( move( other.mLink ) ), mPriority( move( other.mPriority ) )
 {
+}
+
+Connection& Connection::operator=( const Connection &rhs )
+{
+	mDisconnector = rhs.mDisconnector;
+	mLink = rhs.mLink;
+	mPriority = rhs.mPriority;
+
+	return *this;
 }
 
 Connection& Connection::operator=( Connection &&rhs )

--- a/test/unit/src/signals/SignalsTest.cpp
+++ b/test/unit/src/signals/SignalsTest.cpp
@@ -305,6 +305,26 @@ TEST_CASE( "signals/Signals" )
 		}
 	}
 
+	SECTION( "Connection copy and assignment operators" )
+	{
+		// This one is mostly to test if the following builds successfully.
+		std::vector<signals::Connection>	connections;
+
+		for( auto connection : connections ) {
+			connection.disconnect();
+		}
+
+		Signal<void ()> sig;
+		int accum = 0;
+		auto slot = [&] { accum++; };
+
+		auto conn1 = sig.connect( slot );
+		auto conn2 = conn1;
+
+		sig.emit();
+		REQUIRE( accum == 1 );
+	}
+
 	SECTION( "ScopedConnection" )
 	{
 		Signal<void ()> sig;


### PR DESCRIPTION
Was no longer being generated on clang since the explicit && versions were added in #1676, causing some code to break (such as in https://github.com/simongeilfus/Cinder-ImGui/pull/31).

Added a simple unit test with this code that now passes.