### PR TITLE
updated cmake to junction symlink in windows

### DIFF
--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -197,14 +197,34 @@ function( ci_make_app )
 
 			file( COPY "${ARG_ASSETS_PATH}" DESTINATION "${ASSETS_DEST_PATH}" )
 		else()
-			# make a symlink
-			execute_process(
-					COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "${ARG_ASSETS_PATH}" "${ASSETS_DEST_PATH}"
-					RESULT_VARIABLE resultCode
-			)
+			if( CINDER_MSW )
 
-			if( NOT resultCode EQUAL 0 )
-			    message( WARNING "Failed to symlink '${ARG_ASSETS_PATH}' to '${ASSETS_DEST_PATH}', result: ${resultCode}" )
+				# Get OS dependent path to use in `execute_process`
+				file( TO_NATIVE_PATH "${ASSETS_DEST_PATH}" link )
+				file( TO_NATIVE_PATH "${ARG_ASSETS_PATH}" target )
+				set( link_cmd cmd.exe /c mklink /J ${link} ${target} )
+				# make a windows symlink using mklink
+				execute_process(
+						COMMAND ${link_cmd}
+						RESULT_VARIABLE resultCode
+						ERROR_VARIABLE errorMessage
+				)
+
+				if( NOT resultCode EQUAL 0 )
+				    message( WARNING "\nFailed to symlink '${ARG_ASSETS_PATH}' to '${ASSETS_DEST_PATH}', result: ${resultCode} error: ${errorMessage}" )
+				endif()
+
+			else()
+				# make a symlink
+				execute_process(
+						COMMAND "${CMAKE_COMMAND}" "-E" "create_symlink" "${ARG_ASSETS_PATH}" "${ASSETS_DEST_PATH}"
+						RESULT_VARIABLE resultCode
+				)
+
+				if( NOT resultCode EQUAL 0 )
+				    message( WARNING "Failed to symlink '${ARG_ASSETS_PATH}' to '${ASSETS_DEST_PATH}', result: ${resultCode}" )
+				endif()
+
 			endif()
 		endif()
 	endif()


### PR DESCRIPTION
addresses #1776

To test this, generate a project with the cube sample before and after this addition.
```
$ mkdir build
$ cd build
$ $ cmake -DCINDER_BUILD_SAMPLE=_opengl/Cube -G"Visual Studio 14 2015 Win64" ..
```