### PR TITLE
ShaderPreprocessor gracefully handles duplicate #defines, add way to remove #defines

### DIFF
--- a/include/cinder/gl/ShaderPreprocessor.h
+++ b/include/cinder/gl/ShaderPreprocessor.h
@@ -64,7 +64,7 @@ class CI_API ShaderPreprocessor {
 
 	//! Adds a define directive
 	void	addDefine( const std::string &define );
-	//! Adds a define directive
+	//! Adds a define directive in the form of `define=value`
 	void	addDefine( const std::string &define, const std::string &value );
 	//! Specifies all define directives to add to the shader sources, overwriting any existing defines.
 	void	setDefines( const std::vector<std::string> &defines );
@@ -72,6 +72,10 @@ class CI_API ShaderPreprocessor {
 	const std::vector<std::string>&	getDefines() const	{ return mDefineDirectives; }
 	//! Returns all of the define directives to add to the shader sources, modifiable version.
 	std::vector<std::string>&		getDefines()		{ return mDefineDirectives; }
+	//! Removes a define directive
+	void	removeDefine( const std::string &define );
+	//! Removes a define directive in the form of `define=value`
+	void	removeDefine( const std::string &define, const std::string &value );
 	//! Clears all define directives
 	void	clearDefines();
 

--- a/include/cinder/gl/ShaderPreprocessor.h
+++ b/include/cinder/gl/ShaderPreprocessor.h
@@ -67,15 +67,13 @@ class CI_API ShaderPreprocessor {
 	//! Adds a define directive in the form of `define=value`
 	void	addDefine( const std::string &define, const std::string &value );
 	//! Specifies all define directives to add to the shader sources, overwriting any existing defines.
-	void	setDefines( const std::vector<std::string> &defines );
+	void	setDefines( const std::vector<std::pair<std::string, std::string>> &defines );
 	//! Returns all of the define directives to add to the shader sources.
-	const std::vector<std::string>&	getDefines() const	{ return mDefineDirectives; }
+	const std::vector<std::pair<std::string,std::string>>&	getDefines() const	{ return mDefineDirectives; }
 	//! Returns all of the define directives to add to the shader sources, modifiable version.
-	std::vector<std::string>&		getDefines()		{ return mDefineDirectives; }
+	std::vector<std::pair<std::string, std::string>>&		getDefines()		{ return mDefineDirectives; }
 	//! Removes a define directive
 	void	removeDefine( const std::string &define );
-	//! Removes a define directive in the form of `define=value`
-	void	removeDefine( const std::string &define, const std::string &value );
 	//! Clears all define directives
 	void	clearDefines();
 
@@ -101,7 +99,7 @@ class CI_API ShaderPreprocessor {
 	fs::path		findFullPath( const fs::path &includePath, const fs::path &currentPath );
 	
 	int								mVersion;
-	std::vector<std::string>		mDefineDirectives;
+	std::vector<std::pair<std::string,std::string>>		mDefineDirectives; // [macro, value]
 	std::vector<fs::path>			mSearchDirectories;
 	SignalIncludeHandler			mSignalInclude;
 

--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -357,6 +357,18 @@ void ShaderPreprocessor::removeSearchDirectory( const fs::path &directory )
 
 void ShaderPreprocessor::addDefine( const std::string &define )
 {
+	string defineUntilSpace = define.substr( 0, define.find( ' ' ) );
+
+	for( auto &dd : mDefineDirectives ) {
+		size_t pos = dd.find( defineUntilSpace, 0 );
+		if( pos == 0 ) {
+			// replace existing define
+			dd = define;
+			return;
+		}
+	}
+
+	// define is unique, add it to list
 	mDefineDirectives.push_back( define );
 }
 

--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -357,8 +357,8 @@ void ShaderPreprocessor::removeSearchDirectory( const fs::path &directory )
 
 void ShaderPreprocessor::addDefine( const std::string &define )
 {
+	// Check if there are any existing defines with this symbol name, and if so replace it.
 	string defineUntilSpace = define.substr( 0, define.find( ' ' ) );
-
 	for( auto &dd : mDefineDirectives ) {
 		size_t pos = dd.find( defineUntilSpace, 0 );
 		if( pos == 0 ) {
@@ -374,7 +374,20 @@ void ShaderPreprocessor::addDefine( const std::string &define )
 
 void ShaderPreprocessor::addDefine( const std::string &define, const std::string &value )
 {
-	addDefine( define + " " + value );
+	string defineLine = define + " " + value;
+
+	// Check if there are any existing defines with this symbol name, and if so replace it.
+	for( auto &dd : mDefineDirectives ) {
+		size_t pos = dd.find( define, 0 );
+		if( pos == 0 ) {
+			// replace existing define
+			dd = defineLine;
+			return;
+		}
+	}
+
+	// define is unique, add it to list
+	mDefineDirectives.push_back( defineLine );
 }
 
 void ShaderPreprocessor::setDefines( const std::vector<std::string> &defines )

--- a/src/cinder/gl/ShaderPreprocessor.cpp
+++ b/src/cinder/gl/ShaderPreprocessor.cpp
@@ -362,11 +362,22 @@ void ShaderPreprocessor::addDefine( const std::string &define )
 
 void ShaderPreprocessor::addDefine( const std::string &define, const std::string &value )
 {
-	mDefineDirectives.push_back( define + " " + value );
+	addDefine( define + " " + value );
 }
+
 void ShaderPreprocessor::setDefines( const std::vector<std::string> &defines )
 {
 	mDefineDirectives = defines;
+}
+
+void ShaderPreprocessor::removeDefine( const std::string &define )
+{
+	mDefineDirectives.erase( remove( mDefineDirectives.begin(), mDefineDirectives.end(), define ), mDefineDirectives.end() );
+}
+
+void ShaderPreprocessor::removeDefine( const std::string &define, const std::string &value )
+{
+	removeDefine( define + " " + value );
 }
 
 void ShaderPreprocessor::clearDefines()

--- a/test/unit/src/ShaderPreprocessorTest.cpp
+++ b/test/unit/src/ShaderPreprocessorTest.cpp
@@ -57,6 +57,37 @@ TEST_CASE( "ShaderPreprocessor" )
 		REQUIRE( result.find( "#define SOMEVAR 2" ) != string::npos );
 	}
 
+	SECTION( "test remove define" )
+	{
+		gl::ShaderPreprocessor preprocessor;
+		preprocessor.addDefine( "BLARG" );
+		preprocessor.addDefine( "SOMEVAR", "2" );
+
+		preprocessor.removeDefine( "BLARG" );
+		preprocessor.removeDefine( "SOMEVAR" );
+
+		REQUIRE( preprocessor.getDefines().size() == 0 );
+
+		const string result = preprocessor.parse( app::getAssetPath( "shader_preprocessor/simple.frag" ) );
+
+		REQUIRE( result.find( "#define BLARG" ) == string::npos );
+		REQUIRE( result.find( "#define SOMEVAR 2" ) == string::npos );
+	}
+	
+	SECTION( "test overwrite define" )
+	{
+		gl::ShaderPreprocessor preprocessor;
+		preprocessor.addDefine( "SOMEVAR", "1" );
+		preprocessor.addDefine( "SOMEVAR", "2" );
+
+		REQUIRE( preprocessor.getDefines().size() == 1 );
+
+		const string result = preprocessor.parse( app::getAssetPath( "shader_preprocessor/simple.frag" ) );
+
+		REQUIRE( result.find( "#define SOMEVAR 1" ) == string::npos );
+		REQUIRE( result.find( "#define SOMEVAR 2" ) != string::npos );
+	}
+
 	SECTION( "test nested includes" )
 	{
 		gl::ShaderPreprocessor preprocessor;


### PR DESCRIPTION
Solves the issue brought up in #1744, where the PostProcessingAA sample was issuing multiple `define()`s for the same macro, and due to `ShaderPreprocessor` being stored on the `GlslProg::Format` as a shared_ptr now, this resulted in duplicate defines. Solution we decided on was that additional `#define` directives will overwrite previous ones.

The directives are stored as a `<macro string, value string>` pair now, simplifies bookkeeping at basically no extra processing or memory cost.