### PR TITLE
VboMesh::allocateIndexVbo() incorrectly handles GL_UNSIGNED_BYTE

### DIFF
--- a/src/cinder/gl/VboMesh.cpp
+++ b/src/cinder/gl/VboMesh.cpp
@@ -384,8 +384,10 @@ void VboMesh::allocateIndexVbo()
 	if( mNumIndices == 0 )
 		return;
 
-	size_t bytesRequired = 1; // GL_UNSIGNED_BYTE
-	if( mIndexType == GL_UNSIGNED_SHORT )
+	size_t bytesRequired = 0;
+	if( mIndexType == GL_UNSIGNED_BYTE )
+		bytesRequired = 1;
+	else if( mIndexType == GL_UNSIGNED_SHORT )
 		bytesRequired = 2;
 	else if( mIndexType == GL_UNSIGNED_INT )
 		bytesRequired = 4;


### PR DESCRIPTION
In the original code, geom::ExcIllegalIndexType() is thrown if mIndexType is GL_UNSIGNED_BYTE.