### PR TITLE
Adds sub-path functionality to Path2d

### DIFF
--- a/include/cinder/Path2d.h
+++ b/include/cinder/Path2d.h
@@ -209,9 +209,9 @@ class CI_API Path2dCalcCache {
 	float			getLength() const { return mLength; }
 
 	//! Calculates the t-value corresponding to \a relativeTime in the range [0,1) within epsilon of \a tolerance. For example, \a relativeTime of 0.5f returns the t-value corresponding to half the length. \a maxIterations dictates the number of refinement loop iterations allowed, setting an upper bound for worst-case performance.
-	float			calcNormalizedTime( float relativeTime, bool wrap = true, float tolerance = 1.0e-03f, int maxIterations = 16 ) const;
+	float			calcNormalizedTime( float relativeTime, bool wrap = false, float tolerance = 1.0e-03f, int maxIterations = 16 ) const;
 	//! Calculates a t-value corresponding to arc length \a distance. If \a wrap then the t-value loops inside the 0-1 range as \a distance exceeds the arc length.
-	float			calcTimeForDistance( float distance, bool wrap = true, float tolerance = 1.0e-03f, int maxIterations = 16 ) const;
+	float			calcTimeForDistance( float distance, bool wrap = false, float tolerance = 1.0e-03f, int maxIterations = 16 ) const;
 	//! Returns the point on the curve at parameter \a t, which lies in the range <tt>[0,1]</tt>
 	vec2			getPosition( float t ) const { return mPath.getPosition( t ); }
 

--- a/include/cinder/Path2d.h
+++ b/include/cinder/Path2d.h
@@ -87,6 +87,8 @@ class CI_API Path2d {
 	//! Returns a copy transformed by \a matrix.
 	Path2d		transformed( const mat3 &matrix ) const;
 
+	//! Returns a subsection of the Path2d starting from \a startT to \a endT, which lie in the range <tt>[0,1]</tt>.
+	Path2d		getSubPath( float startT, float endT ) const;
 
 	const std::vector<vec2>&	getPoints() const { return mPoints; }
 	std::vector<vec2>&			getPoints() { return mPoints; }
@@ -102,7 +104,9 @@ class CI_API Path2d {
 	const std::vector<SegmentType>&	getSegments() const { return mSegments; }
 	std::vector<SegmentType>&		getSegments() { return mSegments; }
 
-	void			removeSegment( size_t segment );
+	//! Appends a new segment of type \a segmentType to the Path2d. \a points must contain an appropriate number of points for the segment type. Note that while the first point for the segment is always required, it will only be used when the Path2d is initially empty.
+	void	appendSegment( SegmentType segmentType, const vec2 *points );
+	void	removeSegment( size_t segment );
 	
 	//! Returns the bounding box around all control points. As with Shape2d, note this is not necessarily the bounding box of the Path's shape.
 	Rectf	calcBoundingBox() const;

--- a/samples/BezierPath/src/BezierPathApp.cpp
+++ b/samples/BezierPath/src/BezierPathApp.cpp
@@ -20,6 +20,7 @@ class Path2dApp : public App {
 	void draw();
 	
 	Path2d	mPath;
+	Path2d	mSubPath1, mSubPath2;
 	int		mTrackedPoint;
 };
 
@@ -36,6 +37,10 @@ void Path2dApp::mouseDown( MouseEvent event )
 
 	console() << mPath << std::endl;	
 	console() << "Length: " << mPath.calcLength() << std::endl;
+	mSubPath1 = mPath.getSubPath( 0, 0.3f );
+	mSubPath2 = mPath.getSubPath( 0.3f, 1.0f );
+	mSubPath1.transform( glm::translate( mat3(), vec2( 0 ) ) );
+	mSubPath2.transform( glm::translate( mat3(), vec2( 0 ) ) );
 }
 
 void Path2dApp::mouseDrag( MouseEvent event )
@@ -78,7 +83,12 @@ void Path2dApp::mouseDrag( MouseEvent event )
 	}
 	
 	console() << mPath << std::endl;
-	console() << "Length: " << mPath.calcLength() << std::endl;	
+	console() << "Length: " << mPath.calcLength() << std::endl;
+	mSubPath1 = mPath.getSubPath( 0, 0.3f );
+	console() << mSubPath1 << std::endl;
+	mSubPath2 = mPath.getSubPath( 0.3f, 1.0f );
+	mSubPath1.transform( glm::translate( mat3(), vec2( 0 ) ) );
+	mSubPath2.transform( glm::translate( mat3(), vec2( 0 ) ) );
 }
 
 void Path2dApp::mouseUp( MouseEvent event )
@@ -92,37 +102,50 @@ void Path2dApp::keyDown( KeyEvent event )
 		mPath.clear();
 }
 
+Path2d calcQuadSub( const Path2d &p, float t0, float t1 )
+{
+	Path2d result;
+	result.moveTo( p.getPosition( t0 ) );
+	vec2 i0 = (1 - t0) * p.getPoint( 1 ) + t0 * p.getPoint( 2 );
+	float u1 = ( t1 - t0 ) / ( 1 - t0 );
+	vec2 i1 = (1 - u1) * p.getPosition( t0 ) + u1 * i0;
+	result.quadTo( i1, p.getPosition( t1 ) );
+	return result;
+}
+
 void Path2dApp::draw()
 {
 	gl::clear( Color( 0.0f, 0.1f, 0.2f ) );
 	
+Path2d p;
+p.moveTo( 100, 200 + getElapsedSeconds() + 10 );
+p.quadTo( 180, 20, 300, 300 );
+gl::draw( p );
+gl::color( Color( 1, 1, 0 ) );
+float t0 = 0.1f, t1 = 0.3f + fmod( getElapsedSeconds(), 0.7f );
+gl::drawSolidCircle( p.getPosition( t0 ), 2.5f );
+gl::drawSolidCircle( p.getPosition( t1 ), 2.5f );
+
+gl::color( Color( 0, 1, 0 ) );
+gl::draw( calcQuadSub( p, t0, t1 ) );
+
 	// draw the control points
 	gl::color( Color( 1, 1, 0 ) );
 	for( size_t p = 0; p < mPath.getNumPoints(); ++p )
 		gl::drawSolidCircle( mPath.getPoint( p ), 2.5f );
 
-	// draw the precise bounding box
-	if( mPath.getNumSegments() > 1 ) {
-		gl::color( ColorA( 0, 1, 1, 0.2f ) );
-		gl::drawSolidRect( mPath.calcPreciseBoundingBox() );
-	}
-
 	// draw the curve itself
 	gl::color( Color( 1.0f, 0.5f, 0.25f ) );
 	gl::draw( mPath );
 	
-	if( mPath.getNumSegments() > 1 ) {	
-		// draw some tangents
-		gl::color( Color( 0.2f, 0.9f, 0.2f ) );	
-		for( float t = 0; t < 1; t += 0.2f )
-			gl::drawLine( mPath.getPosition( t ), mPath.getPosition( t ) + normalize( mPath.getTangent( t ) ) * 80.0f );
-		
-		// draw circles at 1/4, 2/4 and 3/4 the length
-		gl::color( ColorA( 0.2f, 0.9f, 0.9f, 0.5f ) );
-		for( float t = 0.25f; t < 1.0f; t += 0.25f )
-			gl::drawSolidCircle( mPath.getPosition( mPath.calcNormalizedTime( t ) ), 5.0f );
+	if( mPath.getNumSegments() >= 1 ) {
+		gl::lineWidth( 4.0f );
+		gl::color( 0.9f, 0.2f, 0.3f );
+		gl::draw( mSubPath1 );
+		gl::color( 0.1f, 0.9f, 0.3f );
+		gl::draw( mSubPath2 );
 	}
 }
 
 
-CINDER_APP( Path2dApp, RendererGl )
+CINDER_APP( Path2dApp, RendererGl( RendererGl::Options().msaa( 16 ) ) )

--- a/src/cinder/Path2d.cpp
+++ b/src/cinder/Path2d.cpp
@@ -32,6 +32,7 @@
 #include "cinder/Path2d.h"
 
 #include <algorithm>
+#include <iterator>
 
 using std::vector;
 
@@ -405,7 +406,7 @@ void Path2d::getSegmentRelativeT( float t, size_t *segment, float *relativeT ) c
 
 	size_t totalSegments = mSegments.size();
 	float segParamLength = 1.0f / totalSegments;
-	*segment = t * totalSegments;
+	*segment = static_cast<size_t>( t * totalSegments );
 	if( relativeT )
 		*relativeT = ( t - *segment * segParamLength ) / segParamLength;
 }

--- a/src/cinder/gl/draw.cpp
+++ b/src/cinder/gl/draw.cpp
@@ -328,7 +328,7 @@ void draw( const TextureRef &texture, const vec2 &dstOffset )
 
 void draw( const Path2d &path, float approximationScale )
 {
-	if( path.getNumSegments() == 0 )
+	if( path.getNumSegments() == 0 || path.getNumPoints() == 0 )
 		return;
 
 	auto ctx = context();

--- a/test/unit/src/Path2dTest.cpp
+++ b/test/unit/src/Path2dTest.cpp
@@ -1,5 +1,6 @@
 #include "cinder/app/App.h"
 #include "cinder/Path2d.h"
+#include "cinder/Rand.h"
 
 #include "catch.hpp"
 
@@ -7,9 +8,84 @@ using namespace ci;
 using namespace ci::app;
 using namespace std;
 
-TEST_CASE("Path2d", "Distance")
+bool subPathHelper( const Path2d &p, float start, float end )
 {
-	SECTION("Vertical line")
+	float targetLength = ( end - start ) * p.calcLength();
+	Path2d sub = p.getSubPath( p.calcNormalizedTime( start, false ), p.calcNormalizedTime( end, false ) );
+	float subLength = sub.calcLength();
+	return abs( targetLength - subLength ) <= (0.01f * targetLength);
+}
+
+TEST_CASE("Path2d")
+{
+	// getSubPath()
+		SECTION("getSubPath: Single Segment")
+	{
+		Path2d line;
+		line.moveTo( 50, 50 ); line.lineTo( 150, 150 );
+		REQUIRE( subPathHelper( line, 0.3f, 0.7f ) );
+		REQUIRE( subPathHelper( line, 0.0f, 1.0f ) );
+		
+		Path2d quad;
+		quad.moveTo( 50, 50 ); quad.quadTo( 75, 123, 150, 147 );
+		REQUIRE( subPathHelper( quad, 0.3f, 0.7f ) );
+		REQUIRE( subPathHelper( quad, 0.0f, 1.0f ) );
+
+		Path2d cubic;
+		cubic.moveTo( 50, 50 ); cubic.curveTo( 75, 123, 150, 147, 200, 233 );
+		REQUIRE( subPathHelper( cubic, 0.3f, 0.7f ) );
+		REQUIRE( subPathHelper( cubic, 0.0f, 1.0f ) );
+	}
+	
+	SECTION("getSubPath: Multi Segment")
+	{
+		Path2d p1;
+		p1.moveTo( 50, 50 ); p1.lineTo( 123, 345 );
+		REQUIRE( subPathHelper( p1, 0.3f, 0.7f ) );
+		REQUIRE( subPathHelper( p1, 0.2f, 1.0f ) );
+		REQUIRE( subPathHelper( p1, 0.0f, 0.7f ) );
+		
+		Path2d p2;
+		p2.moveTo( 50, 50 ); p2.lineTo( 123, 345 ); p2.quadTo( 77, 88, 111, 121 );
+		REQUIRE( subPathHelper( p2, 0.3f, 0.7f ) );
+		REQUIRE( subPathHelper( p2, 0.2f, 1.0f ) );
+		REQUIRE( subPathHelper( p2, 0.0f, 0.7f ) );
+
+		Path2d p3;
+		p3.moveTo( 50, 50 ); p3.lineTo( 123, 345 ); p3.curveTo( 77, 88, 111, 121, 99, 144 );
+		REQUIRE( subPathHelper( p3, 0.3f, 0.7f ) );
+		REQUIRE( subPathHelper( p3, 0.2f, 1.0f ) );
+		REQUIRE( subPathHelper( p3, 0.0f, 0.7f ) );
+		
+		Rand r1;
+		for( int p = 0; p < 50; ++p ) {
+			Path2d p4;
+			p4.moveTo( 123, 345 );
+			int count = r1.nextInt( 20 );
+			for( int i = 0; i < count; ++i ) {
+				switch( r1.nextInt() % 3 ) {
+					case 0:
+						p4.lineTo( r1.nextFloat( 500 ), r1.nextFloat( 500 ) );
+					break;
+					case 1:
+						p4.quadTo( r1.nextFloat( 500 ), r1.nextFloat( 500 ), r1.nextFloat( 500 ), r1.nextFloat( 500 ) );
+					break;
+					case 2:
+						p4.curveTo( r1.nextFloat( 500 ), r1.nextFloat( 500 ), r1.nextFloat( 500 ), r1.nextFloat( 500 ),
+							r1.nextFloat( 500 ), r1.nextFloat( 500 ) );
+					break;
+				}
+			}
+			std::cout << p4 << std::endl;   
+			REQUIRE( subPathHelper( p4, 0.3f, 0.7f ) );
+			REQUIRE( subPathHelper( p4, 0.2f, 1.0f ) );
+			REQUIRE( subPathHelper( p4, 0.0f, 0.7f ) );			
+		}
+		
+	}
+
+	// Distance
+	SECTION("Distance: Vertical line")
 	{
 		vector<vec2> input({
 			vec2( 0, 100 ),
@@ -30,7 +106,7 @@ TEST_CASE("Path2d", "Distance")
 		REQUIRE( glm::distance( p.calcClosestPoint( vec2( 0, 100 ) ), vec2( 0, 100 ) ) == Approx( 0 ) ); // co-sited with top*/
 	}
 
-	SECTION("Triangle")
+	SECTION("Distance: Triangle")
 	{
 		vector<vec2> input({
 			vec2( 0, 100 ),
@@ -51,7 +127,7 @@ TEST_CASE("Path2d", "Distance")
 		REQUIRE( p.calcSignedDistance( vec2( 1, 150 ) ) == Approx( -1 ) ); // interior, one unit right of the left vertical line
 	}
 
-	SECTION("Quadratic")
+	SECTION("Distance: Quadratic")
 	{
 		Path2d p; // shape matches Path2d guide from the docs
 		p.moveTo( vec2( 300.0f, 270.0f ) );
@@ -63,7 +139,7 @@ TEST_CASE("Path2d", "Distance")
 		REQUIRE( glm::distance( p.calcClosestPoint( vec2( 300.0f, 70.0f ) ), vec2( 350.0f, 120.0f ) ) == Approx( 0 ) ); // middle control point
 	}
 
-	SECTION("Cubic")
+	SECTION("Distance: Cubic")
 	{
 		Path2d p; // shape matches Path2d guide from the docs
 		p.moveTo( vec2( 300.0f, 270.0f ) );


### PR DESCRIPTION
Adds a new `Path2d::getSubPath()` method, which allows extracting a range of a Path2d, similar to trim curves in After Effects.

The image below shows a subPath extracted at (0,⅓), (⅓,⅔), and (⅔,1).

![image](https://cloud.githubusercontent.com/assets/227107/25320955/91a061b0-2878-11e7-9d4a-66efc5cb2f53.png)

Note this PR also changes the `wrap` parameter's default value to `false` for `calcNormalizedTime()` and `calcTimeForDistance()`.