### PR TITLE
assertion handlers use ci::log

### DIFF
--- a/include/cinder/CinderAssert.h
+++ b/include/cinder/CinderAssert.h
@@ -48,9 +48,10 @@
 
 	// defined in CinderAssert.cpp
 	namespace cinder { namespace detail {
+		CI_API void assertionFailedAbort( char const *expr, char const *function, char const *file, long line );
+		CI_API void assertionFailedMessageAbort( char const *expr, char const *msg, char const *function, char const *file, long line );
 		CI_API void assertionFailedBreak( char const *expr, char const *function, char const *file, long line );
 		CI_API void assertionFailedMessageBreak( char const *expr, char const *msg, char const *function, char const *file, long line );
-		CI_API void assertionFailedMessageAbort( char const *expr, char const *msg, char const *function, char const *file, long line );
 	} } // namespace cinder::detail
 
 	#if defined( CI_ASSERT_DEBUG_BREAK )
@@ -73,7 +74,7 @@
 
 	#else // defined( CI_ENABLE_ASSERT_HANDLER )
 
-		#define CI_ASSERT( expr )				assert( expr )
+		#define CI_ASSERT( expr )				( (expr) ? ( (void)0) : ::cinder::detail::assertionFailedAbort( #expr, CINDER_CURRENT_FUNCTION, __FILE__, __LINE__ ) )
 		#define CI_ASSERT_MSG( expr, msg )		( (expr) ? ( (void)0) : ::cinder::detail::assertionFailedMessageAbort( #expr, msg, CINDER_CURRENT_FUNCTION, __FILE__, __LINE__ ) )
 
 	#endif // defined( CI_ASSERT_DEBUG_BREAK )

--- a/src/cinder/CinderAssert.cpp
+++ b/src/cinder/CinderAssert.cpp
@@ -26,14 +26,6 @@
 #include "cinder/Breakpoint.h"
 #include "cinder/Log.h"
 
- // TODO: remove headers below
-#include <iostream>
-
-#if defined( CINDER_ANDROID )
-#include <android/log.h>
-#include <sstream>
-#endif
-
 namespace cinder { namespace detail {
 
 void assertionFailedAbort( char const *expr, char const *function, char const *file, long line )

--- a/src/cinder/CinderAssert.cpp
+++ b/src/cinder/CinderAssert.cpp
@@ -24,7 +24,9 @@
 #include "cinder/Cinder.h"
 #include "cinder/CinderAssert.h"
 #include "cinder/Breakpoint.h"
+#include "cinder/Log.h"
 
+ // TODO: remove headers below
 #include <iostream>
 
 #if defined( CINDER_ANDROID )
@@ -34,29 +36,40 @@
 
 namespace cinder { namespace detail {
 
+void assertionFailedAbort( char const *expr, char const *function, char const *file, long line )
+{
+	{
+		log::Entry entry( log::LEVEL_FATAL, log::Location( function, file, line ) );
+		entry << "*** Assertion Failed *** | expression: ( " << expr << " )";
+	}
+	std::abort();
+}
+
+void assertionFailedMessageAbort( char const *expr, char const *msg, char const *function, char const *file, long line )
+{
+	{
+		log::Entry entry( log::LEVEL_FATAL, log::Location( function, file, line ) );
+		entry << "*** Assertion Failed *** | expression: ( " << expr << " ), message: " << msg;
+	}
+	std::abort();
+}
+
 void assertionFailedBreak( char const *expr, char const *function, char const *file, long line )
 {
-	std::cerr << "*** Assertion Failed (break) *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << std::endl;
+	{
+		log::Entry entry( log::LEVEL_FATAL, log::Location( function, file, line ) );
+		entry << "*** Assertion Failed (break) *** | expression: ( " << expr << " )";
+	}
 	CI_BREAKPOINT();
 }
 
 void assertionFailedMessageBreak( char const *expr, char const *msg, char const *function, char const *file, long line )
 {
-	std::cerr << "*** Assertion Failed (break) *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << "\n\tmessage: " << msg << std::endl;
+	{
+		log::Entry entry( log::LEVEL_FATAL, log::Location( function, file, line ) );
+		entry << "*** Assertion Failed (break) *** | expression: ( " << expr << " ), message: " << msg;
+	}
 	CI_BREAKPOINT();
-}
-
-void assertionFailedMessageAbort( char const *expr, char const *msg, char const *function, char const *file, long line )
-{
-#if defined( CINDER_ANDROID )
-	std::stringstream ss;
-	ss << "*** Assertion Failed *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << "\n\tmessage: " << msg << std::endl;
-	__android_log_print( ANDROID_LOG_FATAL, "cinder", ss.str().c_str() );
-	std::terminate();
-#else
-	std::cerr << "*** Assertion Failed *** | expression: ( " << expr << " ), location: " << file << "[" << line << "], " << function << "\n\tmessage: " << msg << std::endl;
-	std::abort();
-#endif
 }
 
 } } // namespace cinder::detail

--- a/test/DebugTest/src/DebugTestApp.cpp
+++ b/test/DebugTest/src/DebugTestApp.cpp
@@ -5,7 +5,7 @@
 #include "cinder/Log.h"
 #include <sstream>
 
-#define CI_ASSERT_DEBUG_BREAK
+//#define CI_ASSERT_DEBUG_BREAK
 #include "cinder/CinderAssert.h"
 
 using namespace ci;

--- a/test/DebugTest/vc2015/DebugTest.vcxproj
+++ b/test/DebugTest/vc2015/DebugTest.vcxproj
@@ -93,8 +93,8 @@
       <AdditionalIncludeDirectories>"..\..\..\include";..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>cinder-$(PlatformToolset)_d.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>"..\..\..\lib\msw\$(PlatformTarget)"</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib\msw\$(PlatformTarget);..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -119,8 +119,8 @@
       <AdditionalIncludeDirectories>"..\..\..\include";..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>cinder-$(PlatformToolset)_d.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>"..\..\..\lib\msw\$(PlatformTarget)"</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib\msw\$(PlatformTarget);..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -145,8 +145,8 @@
       <AdditionalIncludeDirectories>"..\..\..\include";..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>cinder-$(PlatformToolset).lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>"..\..\..\lib\msw\$(PlatformTarget)"</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib\msw\$(PlatformTarget);..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
       <SubSystem>Windows</SubSystem>
@@ -174,8 +174,8 @@
       <AdditionalIncludeDirectories>"..\..\..\include";..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>cinder-$(PlatformToolset).lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>"..\..\..\lib\msw\$(PlatformTarget)"</AdditionalLibraryDirectories>
+      <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\lib\msw\$(PlatformTarget);..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Addresses issue brought up in #1804. This is important so that failed asserts show up in file logs.

Added a new handler for `CI_ASSERT()` so we can route it to `ci::log()` too, as before it was using the std version of `assert()`.