### PR TITLE
Zlib 1.2.11

### DIFF
--- a/include/freetype/config/ftoption.h
+++ b/include/freetype/config/ftoption.h
@@ -214,7 +214,7 @@ FT_BEGIN_HEADER
   /*   Do not #undef this macro here since the build system might define   */
   /*   it for certain configurations only.                                 */
   /*                                                                       */
-/* #define FT_CONFIG_OPTION_SYSTEM_ZLIB */
+#define FT_CONFIG_OPTION_SYSTEM_ZLIB
 
 
   /*************************************************************************/

--- a/test/unit/src/Utilities.cpp
+++ b/test/unit/src/Utilities.cpp
@@ -9,6 +9,28 @@ using namespace ci;
 
 TEST_CASE( "Utilities" )
 {
+	SECTION( "Compress Buffer" )
+	{
+		vector<int> d;
+		uint32_t sum = 0;
+		for( int i = 0; i < 1000; ++i ) {
+			d.push_back( i );
+			sum += i;
+		}
+		Buffer b( d.data(), d.size() * sizeof(int) );
+		Buffer compressed = compressBuffer( b );
+
+		REQUIRE( compressed.getSize() < b.getSize() );
+
+		Buffer decompressed = decompressBuffer( compressed );
+		REQUIRE( decompressed.getSize() == sizeof(int) * 1000 );
+		const int *dd = reinterpret_cast<const int*>( decompressed.getData() );
+		uint32_t dSum = 0;
+		for( int i = 0; i < 1000; ++i )
+			dSum += dd[i];
+		REQUIRE( dSum == sum );
+	}
+
 	SECTION( "string load / write" )
 	{
 		// Read the test string


### PR DESCRIPTION
This should address the issue the previous attempt to upgrade zlib surfaced - a conflict with Freetype. I've tweaked the FT config to use the "system" zlib for now - we may disable this entirely later as its primary utility seems to be limited to PCF fonts. This also adds a very basic zlib smoke test.