### PR TITLE
Only checkout boost submodule.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ image:
   - Visual Studio 2015
 
 install:
-  - git submodule update --init --recursive
+  - git submodule update --init include/boost
 
 clone_depth: 10
 

--- a/.appveyor_winrt.yml
+++ b/.appveyor_winrt.yml
@@ -17,6 +17,6 @@ image:
   - Visual Studio 2015
 
 install:
-  - git submodule update --init --recursive
+  - git submodule update --init include/boost
 
 clone_depth: 10


### PR DESCRIPTION
For AppVeyor this will only checkout boost, not tinderbox, which will speed things up slightly.

Currently can not do this on TravisCI