### PR TITLE
Removing boost::lexical_cast

### DIFF
--- a/include/cinder/Json.h
+++ b/include/cinder/Json.h
@@ -227,8 +227,8 @@ class CI_API JsonTree {
 	{
 		try {
 			return fromString<T>( mValue );
-		} catch ( boost::bad_lexical_cast &) {
-			throw ExcNonConvertible( * this );
+		} catch( ... ) {
+			throw ExcNonConvertible( *this );
 		}
 		return (T)0; // Unreachable. Prevents warning.
 	}

--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -32,8 +32,7 @@
 #include "cinder/Url.h"
 #include "cinder/DataSource.h"
 #include "cinder/DataTarget.h"
-#undef check
-#include <boost/lexical_cast.hpp>
+#include <sstream>
 
 namespace cinder {
 
@@ -71,12 +70,11 @@ inline char getPathSeparator() { return '/'; }
 CI_API std::map<std::string, std::string> getEnvironmentVariables();
 
 template<typename T>
-inline std::string toString( const T &t ) { return boost::lexical_cast<std::string>( t ); }
+std::string toString( const T &t ) { std::ostringstream ss; ss << t; return ss.str(); }
+
 template<typename T>
-inline T fromString( const std::string &s ) { return boost::lexical_cast<T>( s ); }
-// This specialization seems to only be necessary with more recent versions of Boost
-template<>
-inline Url fromString( const std::string &s ) { return Url( s ); }
+T fromString( const std::string &s ) { std::stringstream ss; ss << s; T temp; ss >> temp; return temp; }
+
 #if defined(CINDER_COCOA_TOUCH)
 // Necessary because boost::lexical_cast crashes when trying to convert a string to a double on iOS
 template<>

--- a/include/cinder/Xml.h
+++ b/include/cinder/Xml.h
@@ -173,7 +173,7 @@ class CI_API XmlTree {
 		void					setValue( const std::string &value ) { mValue = value; }
 		/** Sets the value of the attribute to \a value, which is cast to a string first. Requires T to support the ostream<< operator. **/
 		template<typename T>
-		void					setValue( const T &value ) { mValue = boost::lexical_cast<std::string>( value ); }
+		void					setValue( const T &value ) { mValue = toString<T>( value ); }
 
 	  private:
 	  	XmlTree			*mXml;
@@ -259,16 +259,16 @@ class CI_API XmlTree {
 	std::string					getValue() const { return mValue; }
 	//! Returns the value of the node parsed as a T. Requires T to support the istream>> operator.
 	template<typename T>
-	T							getValue() const { return boost::lexical_cast<T>( mValue ); }
+	T							getValue() const { return fromString<T>( mValue ); }
 	//! Returns the value of the node parsed as a T. If the value is empty or fails to parse \a defaultValue is returned. Requires T to support the istream>> operator.
 	template<typename T>
-	T							getValue( const T &defaultValue ) const { try { return boost::lexical_cast<T>( mValue ); } catch( ... ) { return defaultValue; } }
+	T							getValue( const T &defaultValue ) const { try { return fromString<T>( mValue ); } catch( ... ) { return defaultValue; } }
 
 	//! Sets the value of the node to the string \a value.
 	void						setValue( const std::string &value ) { mValue = value; }
 	//! Sets the value of the node to \a value which is converted to a string first. Requires T to support the ostream<< operator.
 	template<typename T>
-	void						setValue( const T &value ) { mValue = boost::lexical_cast<std::string>( value ); }
+	void						setValue( const T &value ) { mValue = toString( value ); }
 
 	//! Returns whether this node has a parent node.
 	bool						hasParent() const { return mParent != NULL; }
@@ -334,7 +334,7 @@ class CI_API XmlTree {
 	XmlTree&					setAttribute( const std::string &attrName, const std::string &value );
 	/** Sets the value of the attribute \a attrName to \a value, which is cast to a string first. Requires T to support the ostream<< operator. If the attribute does not exist it is appended. **/
 	template<typename T>
-	XmlTree&					setAttribute( const std::string &attrName, const T &value ) { return setAttribute( attrName, boost::lexical_cast<std::string>( value ) ); }
+	XmlTree&					setAttribute( const std::string &attrName, const T &value ) { return setAttribute( attrName, toString( value ) ); }
 	/** Returns whether the node has an attribute named \a attrName. **/
 	bool						hasAttribute( const std::string &attrName ) const;
 	/** Returns a path to this node, separated by the character \a separator. **/	

--- a/src/cinder/Json.cpp
+++ b/src/cinder/Json.cpp
@@ -534,7 +534,7 @@ JsonTree* JsonTree::getNodePtr( const string &relativePath, bool caseSensitive, 
         // The key is numeric
 		if( isIndex( *pathIt ) ) {
             // Find child which uses this index as its key
-			uint32_t index = boost::lexical_cast<int32_t>( *pathIt );
+			uint32_t index = std::stoi( *pathIt );
 			uint32_t i = 0;
 			for ( node = curNode->getChildren().begin(); node != curNode->getChildren().end(); ++node, i++ ) {
 				if ( i == index ) {

--- a/src/cinder/Log.cpp
+++ b/src/cinder/Log.cpp
@@ -38,7 +38,8 @@
 	#include <android/log.h>
  	#define TAG "cinder"
 #elif defined( CINDER_LINUX )
-    #include <syslog.h>
+	#include <syslog.h>
+	#include <limits.h>
 #endif
 
 #if defined( CINDER_COCOA ) && ( ! defined( __OBJC__ ) )

--- a/src/cinder/audio/Source.cpp
+++ b/src/cinder/audio/Source.cpp
@@ -35,6 +35,8 @@
  	#include "cinder/audio/linux/FileAudioLoader.h"
 #endif
 
+#include <cmath>
+
 using namespace std;
 
 namespace cinder { namespace audio {

--- a/test/unit/src/Utilities.cpp
+++ b/test/unit/src/Utilities.cpp
@@ -4,8 +4,30 @@
 #include "cinder/Utilities.h"
 #include "cinder/app/App.h"
 
+#include <iostream>
+
 using namespace std;
 using namespace ci;
+
+struct CustomType {
+	CustomType() {}
+	CustomType( int v ) : var( v ) {}
+	bool operator==( const CustomType &rhs ) { return rhs.var == var; }
+
+	int var;
+};
+
+std::ostream& operator<<( std::ostream &o, CustomType const &t )
+{
+	o << t.var;
+	return o;
+}
+
+std::istream& operator>>( std::istream &i, CustomType &t )
+{
+	i >> t.var;
+	return i;
+}
 
 TEST_CASE( "Utilities" )
 {
@@ -29,6 +51,24 @@ TEST_CASE( "Utilities" )
 		for( int i = 0; i < 1000; ++i )
 			dSum += dd[i];
 		REQUIRE( dSum == sum );
+	}
+
+	SECTION( "toString / fromString" )
+	{
+		REQUIRE( toString( 123 ) == string( "123" ) );
+		REQUIRE( toString( 123.45 ) == string( "123.45" ) );
+		REQUIRE( toString( 123.45f ) == string( "123.45" ) );
+		REQUIRE( toString( "hello" ) == string( "hello" ) );
+		REQUIRE( toString( CustomType( 123 ) ) == string( "123" ) );
+
+		REQUIRE( fromString<int>( "123" ) == 123 );
+		REQUIRE( fromString<float>( "123.45" ) == Approx( 123.45f ) );
+		REQUIRE( fromString<double>( "123.45" ) == Approx( 123.45 ) );
+		REQUIRE( fromString<string>( "hello" ) == string( "hello" ) );
+		REQUIRE( fromString<CustomType>( "123" ) == CustomType( 123 ) );
+		
+		string s( "http://libcinder.org" );
+		REQUIRE( fromString<Url>( s ).str() == Url( "http://libcinder.org" ).str() );
 	}
 
 	SECTION( "string load / write" )


### PR DESCRIPTION
Removing `boost::lexical_cast`, particularly in `toString()` and `fromString()`. Note that this may represent a performance regression in some instances, but `toString()` and `fromString()` are meant purely for convenience.