### PR TITLE
Fix path for xcode/fullbuild.sh in docs

### DIFF
--- a/docs/htmlsrc/guides/git/index.html
+++ b/docs/htmlsrc/guides/git/index.html
@@ -60,7 +60,7 @@ git clone --recursive git://github.com/cinder/Cinder.git cinder_master
 
 		<section>
 			<h2>Building on OS X</h2>
-			<p>The most straightforward way to build both the Debug and Release configurations of the OS X, iOS and iOS Simulator targets is to run the script located at <em>cinder/xcode/fullbuild.sh</em></p>
+			<p>The most straightforward way to build both the Debug and Release configurations of the OS X, iOS and iOS Simulator targets is to run the script located at <em>cinder/proj/xcode/fullbuild.sh</em></p>
 		
 <pre><code class="language-bash">
 cd xcode


### PR DESCRIPTION
- Path in docs is currently cinder/xcode/fullbuild.sh, but
the script is actually at cinder/proj/xcode/fullbuild.sh