### PR TITLE
linux Pulse Audio additions

### DIFF
--- a/docs/htmlsrc/guides/linux-notes/rpi2.html
+++ b/docs/htmlsrc/guides/linux-notes/rpi2.html
@@ -90,6 +90,11 @@ make</code></pre>
 		<p>Hit the <code>Esc</code> key to exit the BasicApp. Cinder for Linux on the Raspberry Pi 2 currently has <code>Esc</code> hardcoded to exit an application. Otherwise it's non-trivial to return to the OS. A future version will offer a more graceful way to handle this.</p>
 		<h1 id="troubleshooting">Troubleshooting</h1>
 		<h3 id="audio">Audio</h3>
+
+		<h4 id="context_create_failed">Starting the pulsedeamon</h4>
+		<p>Raspbian ships with Pulse Audio installed, however you must start the <code>pulsedeamon</code> before you can use audio in your application. Do that by running the following:</p>
+		<pre><code>pulseaudio -D</code></pre>
+
 		<h4 id="no-output-using-35-jack">No Output Using 3.5mm headphone jack</h4>
 		<p>Try the following, it will force output to the 3.5mm jack (<a href="https://www.raspberrypi.org/documentation/configuration/audio-config.md">more information here</a>):</p>
 		<pre><code>sudo amixer cset numid=3 1</code></pre>

--- a/docs/htmlsrc/guides/linux-notes/rpi3.html
+++ b/docs/htmlsrc/guides/linux-notes/rpi3.html
@@ -87,6 +87,11 @@ make</code></pre>
 		<p>Hit the <code>Esc</code> key to exit the BasicApp. Cinder for Linux on the Raspberry Pi 3 currently has <code>Esc</code> hardcoded to exit an application. Otherwise it's non-trivial to return to the OS. A future version will offer a more graceful way to handle this.</p>
 		<h1 id="troubleshooting">Troubleshooting</h1>
 		<h3 id="audio">Audio</h3>
+
+		<h4 id="context_create_failed">Starting the pulsedeamon</h4>
+		<p>Raspbian ships with Pulse Audio installed, however you must start the <code>pulsedeamon</code> before you can use audio in your application. Do that by running the following:</p>
+		<pre><code>pulseaudio -D</code></pre>
+
 		<h4 id="no-output-using-35-jack">No Output Using 3.5mm headphone jack</h4>
 		<p>Try the following, it will force output to the 3.5mm jack (<a href="https://www.raspberrypi.org/documentation/configuration/audio-config.md">more information here</a>):</p>
 		<pre><code>sudo amixer cset numid=3 1</code></pre>

--- a/include/cinder/audio/linux/ContextPulseAudio.h
+++ b/include/cinder/audio/linux/ContextPulseAudio.h
@@ -94,9 +94,7 @@ class ContextPulseAudio : public Context {
 	pulse::Context*     getPulseContext()   { return mPulseContext.get(); }
 
   private:
-	std::vector<OutputDeviceNodeRef>	mOutputDeviceNodes;
-	std::vector<InputDeviceNodeRef>		mInputDeviceNodes;
-
+	std::vector<std::weak_ptr<Node>>	mDeviceNodes;
 	std::unique_ptr<pulse::Context>     mPulseContext;
 };	
 

--- a/include/cinder/audio/linux/ContextPulseAudio.h
+++ b/include/cinder/audio/linux/ContextPulseAudio.h
@@ -25,6 +25,10 @@
 
 #include "cinder/audio/Context.h"
 
+namespace pulse {
+struct Context;
+} // namespace pulse
+
 namespace cinder { namespace audio { namespace linux {
 
 struct OutputDeviceNodePulseAudioImpl;
@@ -86,9 +90,14 @@ class ContextPulseAudio : public Context {
 	OutputDeviceNodeRef	createOutputDeviceNode( const DeviceRef &device = Device::getDefaultOutput(), const Node::Format &format = Node::Format() ) override;
 	InputDeviceNodeRef	createInputDeviceNode( const DeviceRef &device = Device::getDefaultInput(), const Node::Format &format = Node::Format()  ) override;
 
+	//! TODO: this is a private class, remove
+	pulse::Context*     getPulseContext()   { return mPulseContext.get(); }
+
   private:
 	std::vector<OutputDeviceNodeRef>	mOutputDeviceNodes;
 	std::vector<InputDeviceNodeRef>		mInputDeviceNodes;
+
+	std::unique_ptr<pulse::Context>     mPulseContext;
 };	
 
 } } } // namespace cinder::audio::linux

--- a/include/cinder/audio/linux/ContextPulseAudio.h
+++ b/include/cinder/audio/linux/ContextPulseAudio.h
@@ -53,10 +53,6 @@ class OutputDeviceNodePulseAudio : public OutputDeviceNode {
 	BufferInterleaved									mInterleavedBuffer;
 
 	friend struct OutputDeviceNodePulseAudioImpl;
-
-  private:
-	void destroyPulseObjects();
-	friend class ContextPulseAudio;
 };
 
 class InputDeviceNodePulseAudio : public InputDeviceNode {
@@ -72,14 +68,9 @@ class InputDeviceNodePulseAudio : public InputDeviceNode {
 	void process( Buffer *buffer )	override;
 
   private:
-
 	std::unique_ptr<InputDeviceNodePulseAudioImpl>   mImpl;
 
 	friend struct InputDeviceNodePulseAudioImpl;
-
-  private:
-	void destroyPulseObjects();
-	friend class ContextPulseAudio;
 };
 
 class ContextPulseAudio : public Context {

--- a/include/cinder/gl/platform.h
+++ b/include/cinder/gl/platform.h
@@ -231,7 +231,7 @@
 #endif
 
 #if defined( CINDER_GL_ES )
-	#if defined( GL_KHR_debug ) && ( CINDER_GL_ES_VERSION <= CINDER_GL_ES_VERSION_3_1 )
+	#if defined( GL_KHR_debug ) && ( CINDER_GL_ES_VERSION >= CINDER_GL_ES_VERSION_3_1 )
 		#define CINDER_GL_HAS_KHR_DEBUG
 		#if ! defined( CINDER_GL_ANGLE )
 			#define GL_BUFFER 		GL_BUFFER_KHR

--- a/include/cinder/gl/platform.h
+++ b/include/cinder/gl/platform.h
@@ -231,7 +231,7 @@
 #endif
 
 #if defined( CINDER_GL_ES )
-	#if defined( GL_KHR_debug ) && ( CINDER_GL_ES_VERSION >= CINDER_GL_ES_VERSION_3_1 )
+	#if defined( GL_KHR_debug ) && ( CINDER_GL_ES_VERSION <= CINDER_GL_ES_VERSION_3_1 )
 		#define CINDER_GL_HAS_KHR_DEBUG
 		#if ! defined( CINDER_GL_ANGLE )
 			#define GL_BUFFER 		GL_BUFFER_KHR

--- a/samples/_audio/InputAnalyzer/src/InputAnalyzerApp.cpp
+++ b/samples/_audio/InputAnalyzer/src/InputAnalyzerApp.cpp
@@ -109,7 +109,7 @@ void InputAnalyzer::drawSpectralCentroid()
 void InputAnalyzer::drawLabels()
 {
 	if( ! mTextureFont )
-		mTextureFont = gl::TextureFont::create( Font( Font::getDefault().getName(), 16 ) );
+		mTextureFont = gl::TextureFont::create( ci::Font( ci::Font::getDefault().getName(), 16 ) );
 
 	gl::color( 0, 0.9f, 0.9f );
 

--- a/src/cinder/audio/linux/ContextPulseAudio.cpp
+++ b/src/cinder/audio/linux/ContextPulseAudio.cpp
@@ -287,13 +287,18 @@ void OutputStream::open()
 		pa_stream_set_write_callback( mPaStream, &OutputStream::writeCallback, static_cast<void*>( this ) );
 
 		pa_buffer_attr bufferAttr;
-		bufferAttr.maxlength	= static_cast<uint32_t>(-1);
-		bufferAttr.minreq		= mBytesPerBuffer / 2;
-		bufferAttr.prebuf		= static_cast<uint32_t>(-1);
-		bufferAttr.tlength		= mBytesPerBuffer * 3;
-		bufferAttr.fragsize		= static_cast<uint32_t>(-1);
+		bufferAttr.maxlength	= uint32_t( mFramesPerBlock * mBytesPerFrame );
+		bufferAttr.minreq		= UINT32_MAX;
+		bufferAttr.prebuf		= 0;
+		bufferAttr.tlength		= bufferAttr.maxlength;
+		bufferAttr.fragsize		= UINT32_MAX;
 
-		pa_stream_flags_t streamFlags = pa_stream_flags_t( PA_STREAM_START_CORKED | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_INTERPOLATE_TIMING );
+		pa_stream_flags_t streamFlags = pa_stream_flags_t(
+				PA_STREAM_START_CORKED |
+				PA_STREAM_AUTO_TIMING_UPDATE |
+				PA_STREAM_INTERPOLATE_TIMING |
+				PA_STREAM_ADJUST_LATENCY );
+
 		int status = pa_stream_connect_playback( mPaStream, mDeviceName.c_str(), &bufferAttr, streamFlags, nullptr, nullptr );
 		if( status ) {
 			throw AudioContextExc( "Could not connect PulseAudio output stream playback" );	
@@ -468,13 +473,18 @@ void InputStream::open()
 		pa_stream_set_read_callback( mPaStream, &InputStream::readCallback, static_cast<void*>( this ) );
 
 		pa_buffer_attr bufferAttr;
-		bufferAttr.maxlength	= static_cast<uint32_t>(-1);
-		bufferAttr.minreq		= mBytesPerBuffer / 2;
-		bufferAttr.prebuf		= static_cast<uint32_t>(-1);
-		bufferAttr.tlength		= mBytesPerBuffer * 3;
-		bufferAttr.fragsize		= static_cast<uint32_t>(-1);
+		bufferAttr.maxlength	= UINT32_MAX;
+		bufferAttr.minreq		= UINT32_MAX;
+		bufferAttr.prebuf		= 0;
+		bufferAttr.tlength		= UINT32_MAX;
+		bufferAttr.fragsize		= uint32_t( mFramesPerBlock * mBytesPerFrame );
 
-		pa_stream_flags_t streamFlags = pa_stream_flags_t( PA_STREAM_START_CORKED | PA_STREAM_AUTO_TIMING_UPDATE | PA_STREAM_INTERPOLATE_TIMING );
+		pa_stream_flags_t streamFlags = pa_stream_flags_t(
+				PA_STREAM_START_CORKED |
+				PA_STREAM_AUTO_TIMING_UPDATE |
+				PA_STREAM_INTERPOLATE_TIMING |
+				PA_STREAM_ADJUST_LATENCY );
+
 		int status = pa_stream_connect_record( mPaStream, mDeviceName.c_str(), &bufferAttr, streamFlags );
 		if( status ) {
 			throw AudioContextExc( "Could not connect PulseAudio output stream playback" );

--- a/src/cinder/audio/linux/ContextPulseAudio.cpp
+++ b/src/cinder/audio/linux/ContextPulseAudio.cpp
@@ -813,7 +813,9 @@ void InputDeviceNodePulseAudio::initialize()
 
 	mImpl->initStream( numChannels, getSampleRate(), framesPerBlock );
 	mImpl->mPulseStream->mMarkOverrunFn = [this] {
-		markOverrun();
+		auto ctx = getContext(); // don't report if the overrun happens when we're shutting down.
+		if( ctx )
+			markOverrun();
 	};
 }
 

--- a/src/cinder/audio/linux/ContextPulseAudio.cpp
+++ b/src/cinder/audio/linux/ContextPulseAudio.cpp
@@ -735,12 +735,6 @@ OutputDeviceNodePulseAudio::OutputDeviceNodePulseAudio( const DeviceRef &device,
 {
 }
 
-void OutputDeviceNodePulseAudio::destroyPulseObjects()
-{
-	disableProcessing();
-	uninitialize();	
-}
-
 void OutputDeviceNodePulseAudio::initialize()
 {
 	const size_t sampleRate = getOutputSampleRate();

--- a/src/cinder/audio/linux/ContextPulseAudio.cpp
+++ b/src/cinder/audio/linux/ContextPulseAudio.cpp
@@ -99,7 +99,7 @@ Context::Context()
 		throw AudioContextExc( "Could not create PulseAudio threaded mainloop" );
 	}
 
-#if PA_API_VERSION >= 5
+#if PA_MAJOR >= 5
 	pa_threaded_mainloop_set_name( mPaMainLoop, "cinder::audio (PulseAudio)" );
 #endif
 

--- a/src/cinder/audio/linux/ContextPulseAudio.cpp
+++ b/src/cinder/audio/linux/ContextPulseAudio.cpp
@@ -99,7 +99,9 @@ Context::Context()
 		throw AudioContextExc( "Could not create PulseAudio threaded mainloop" );
 	}
 
-	pa_threaded_mainloop_set_name( mPaMainLoop, "cinder::audio::linux (PulseAudio)" );
+#if PA_API_VERSION >= 5
+	pa_threaded_mainloop_set_name( mPaMainLoop, "cinder::audio (PulseAudio)" );
+#endif
 
 	if( 0 != pa_threaded_mainloop_start( mPaMainLoop ) ) {
 		throw AudioContextExc( "Could not start PulseAudio threaded mainloop" );

--- a/src/cinder/audio/linux/ContextPulseAudio.cpp
+++ b/src/cinder/audio/linux/ContextPulseAudio.cpp
@@ -572,8 +572,14 @@ void InputStream::enqueueSamples( pa_stream *s, size_t nbytes )
 		// resize mReadBuffer if necessary
 		mReadBuffer.setSize( numFramesRead, mNumChannels );
 
-		// de-interleave and write data to a ringbuffer that will be consumed in InpudeDeviceNode's process method
-		ci::audio::dsp::deinterleave( (const float *)data, mReadBuffer.getData(), numFramesRead, mNumChannels, numFramesRead );
+		if( data ) {
+			// de-interleave and write data to a ringbuffer that will be consumed in InpudeDeviceNode's process method
+			ci::audio::dsp::deinterleave( (const float *)data, mReadBuffer.getData(), numFramesRead, mNumChannels, numFramesRead );
+		}
+		else {
+			// there is a hole in the stream, generate silence
+			mReadBuffer.zero();
+		}
 
 		size_t framesBuffered = 0;
 		for( size_t ch = 0; ch < mRingBuffers.size(); ch++ ) {

--- a/src/cinder/audio/linux/DeviceManagerPulseAudio.cpp
+++ b/src/cinder/audio/linux/DeviceManagerPulseAudio.cpp
@@ -252,8 +252,6 @@ namespace cinder { namespace audio { namespace linux {
 
 DeviceManagerPulseAudio::DeviceManagerPulseAudio()
 {
-	parseDevices( DeviceInfo::INPUT );
-	parseDevices( DeviceInfo::OUTPUT );
 }
 
 DeviceManagerPulseAudio::~DeviceManagerPulseAudio()

--- a/src/cinder/audio/linux/DeviceManagerPulseAudio.cpp
+++ b/src/cinder/audio/linux/DeviceManagerPulseAudio.cpp
@@ -22,13 +22,16 @@
 */
 
 #include "cinder/audio/linux/DeviceManagerPulseAudio.h"
-#include <pulse/pulseaudio.h>
+#include "cinder/audio/Exception.h"
 
-#include <iostream>
+#include <pulse/pulseaudio.h>
 
 // Similar to Windows - there doesn't seem to be a way to get
 // the preferred frame size in PulseAudio.
+// TODO (rte): this is true, but we can set a preferred latency later on. update docs to reflect this
 #define PREFERRED_FRAMES_PER_BLOCK 512
+
+using namespace std;
 
 namespace pulse {
 
@@ -88,7 +91,8 @@ void processSinkInfo( pa_context* context, const pa_sink_info* info, int eol, vo
 	StateData* stateData = static_cast<StateData*>( userData );
 
 	if( eol < 0 ) {
-		return;
+		string errorMsg = "Failed to get Pulse Audio sink information, eol: " + to_string( eol ) + ", error: " + pa_strerror( pa_context_errno( context ) );
+		throw cinder::audio::AudioDeviceExc( errorMsg );
 	}
 
 	if( eol ) {
@@ -107,7 +111,8 @@ void processSourceInfo( pa_context* context, const pa_source_info* info, int eol
 	StateData* stateData = static_cast<StateData*>( userData );
 
 	if( eol < 0 ) {
-		return;
+		string errorMsg = "Failed to get Pulse Audio source information, eol: " + to_string( eol ) + ", error: " + pa_strerror( pa_context_errno( context ) );
+		throw cinder::audio::AudioDeviceExc( errorMsg );
 	}
 
 	if( eol ) {
@@ -201,9 +206,12 @@ void executeRequest( StateData* stateData )
 	// Connect context
 	if( pa_context_connect( context, nullptr, PA_CONTEXT_NOFLAGS, nullptr ) >= 0 ) {
 		// Run mainloop
-		int result = 0;
-		if( pa_mainloop_run( mainLoop, &result ) < 0 ) {
-			// Handle error
+		int retVal = 0;
+		int status = pa_mainloop_run( mainLoop, &retVal );
+		if( status < 0 ) {
+			string errorMsg = "Pulse Audio failed to execute request (" + to_string( (int)stateData->request );
+			errorMsg += "), pa_mainloop_run returned code: " + to_string( retVal );
+			throw cinder::audio::AudioDeviceExc( errorMsg );
 		}
 	}
 	pa_context_unref( context );

--- a/test/_audio/DeviceTest/proj/cmake/CMakeLists.txt
+++ b/test/_audio/DeviceTest/proj/cmake/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE ON )
+
+project( audio-DeviceTest )
+
+get_filename_component( CINDER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
+
+include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
+
+ci_make_app(
+	SOURCES     ${APP_PATH}/src/DeviceTestApp.cpp
+	CINDER_PATH ${CINDER_PATH}
+)

--- a/test/_audio/common/AudioTestGui.h
+++ b/test/_audio/common/AudioTestGui.h
@@ -38,7 +38,7 @@ using namespace ci;
 static gl::TextureFontRef getTestWidgetTexFont() {
 	static gl::TextureFontRef sTestWidgetTexFont;
 	if( ! sTestWidgetTexFont )
-		sTestWidgetTexFont = gl::TextureFont::create( Font( Font::getDefault().getName(), 22 ) );
+		sTestWidgetTexFont = gl::TextureFont::create( ci::Font( ci::Font::getDefault().getName(), 22 ) );
 	return sTestWidgetTexFont;
 }
 


### PR DESCRIPTION
New features:

- implemented `InputeDeviceNode` (microphone input)
- you can specify a hardware device with `Device::findDeviceByName()`
- latency improvements. Default is set to 512 frames per block, as is the default on other platforms. You can adjust that to be whatever size you want (rounded to a power of 2) with the usual `Device::updateFormat()` method.

I also added a bunch of error handling, in the way of exceptions or asserts. So if something was silently failing before, it might not be so silent anymore. :)

I think that the pulse stuff could use a refactor to use less private classes and be a little more direct, but I'm going to hold off on that for now as there will be a larger hardware versus offline audio pass at some point, and I'd rather wait for that to be in the works before refactoring code that works fine.

Todo:

- [X]  there's a temp fix in this branch for #1847 that should be properly resolved before this PR is merged. (addressed in efad6052b2fd112b5625e56f997f76a9a86d32aa)