### PR TITLE
Fix documentation Converter::convert to match implementation

### DIFF
--- a/include/cinder/audio/dsp/Converter.h
+++ b/include/cinder/audio/dsp/Converter.h
@@ -40,7 +40,7 @@ class CI_API Converter {
 	virtual ~Converter() {}
 
 	//! Converts up to getSourceMaxFramesPerBlock() frames of audio data from \a sourceBuffer into \a destBuffer. Returns a \a std::pair<num source frames used, num dest frames written>
-	//! \note destBuffer must be large enough to complete the conversion, which is calculated as: \code minNumDestFrames = min( sourceBuffer->getNumFrames, getSourceMaxFramesPerBlock() ) * getDestSampleRate() * getSourceSampleRate() \endcode
+	//! \note destBuffer must be large enough to complete the conversion, which is calculated as: \code minNumDestFrames = min( sourceBuffer->getNumFrames, getSourceMaxFramesPerBlock() ) * getDestSampleRate() / getSourceSampleRate() \endcode
 	virtual std::pair<size_t, size_t> convert( const Buffer *sourceBuffer, Buffer *destBuffer ) = 0;
 
 	//! Clears the state of the converter, discarding / flushing accumulated samples. Optional for implementations.


### PR DESCRIPTION
Matches function documentation with the actual implementation: https://github.com/cinder/Cinder/blob/master/src/cinder/audio/cocoa/CinderCoreAudio.cpp#L92