### PR TITLE
Misc CMake improvements

### DIFF
--- a/proj/cmake/configure.cmake
+++ b/proj/cmake/configure.cmake
@@ -1,7 +1,6 @@
 # This file is consumed by the main libcinder cmake configuration and any other targets within the library that depend on it (such as samples and tests).
 # Other applications can include it as well to set the same build variables that libcinder uses
 
-set( CINDER_TARGET "" CACHE STRING "Target platform to build for." )
 option( CINDER_VERBOSE "Print verbose build configuration messages. " OFF )
 option( BUILD_SHARED_LIBS "Build Cinder as a shared library. " OFF )
 
@@ -18,7 +17,19 @@ endif()
 
 ci_log_v( "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" )
 
-# If there's a target specified, try to build for that. Otherwise, build based on the current host OS.
+# Set default target to build for
+if( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
+	set( CINDER_TARGET_DEFAULT "macosx" )
+elseif( CMAKE_SYSTEM_NAME MATCHES "Linux" )
+	set( CINDER_TARGET_DEFAULT "linux" )
+elseif( CMAKE_SYSTEM_NAME MATCHES "Windows" )
+	set( CINDER_TARGET_DEFAULT "msw" )
+else()
+	# no default target, user must specify
+	set( CINDER_TARGET_DEFAULT "" )
+endif()
+
+set( CINDER_TARGET ${CINDER_TARGET_DEFAULT} CACHE STRING "Target platform to build for. Default will match the current OS. Vaid options: linux, macosx, msw, ios, android" )
 if( CINDER_TARGET )
 	string( TOLOWER "${CINDER_TARGET}" CINDER_TARGET_LOWER )
 	if( "android" STREQUAL "${CINDER_TARGET_LOWER}" )
@@ -35,19 +46,7 @@ if( CINDER_TARGET )
 		message( FATAL_ERROR "unexpected CINDER_TARGET '${CINDER_TARGET}'." )
 	endif()
 else()
-	if( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
-		set( CINDER_TARGET "macosx" )
-		set( CINDER_MAC TRUE )
-	elseif( CMAKE_SYSTEM_NAME MATCHES "Linux" )
-		set( CINDER_TARGET "linux" )
-		set( CINDER_LINUX TRUE )
-	elseif( CMAKE_SYSTEM_NAME MATCHES "Windows" )
-		message( WARNING "CMake support on Windows is experimental and may be incomplete." )
-		set( CINDER_TARGET "msw" )
-		set( CINDER_MSW TRUE )
-	else()
-		message( FATAL_ERROR "CINDER_TARGET not defined, and no default for platform '${CMAKE_SYSTEM_NAME}.'" )
-	endif()
+	message( FATAL_ERROR "CINDER_TARGET not defined, and no default for platform '${CMAKE_SYSTEM_NAME}.'" )
 endif()
 
 # Configure which gl target to build for, currently only used on linux.

--- a/proj/cmake/configure.cmake
+++ b/proj/cmake/configure.cmake
@@ -56,7 +56,7 @@ else()
 	set( CINDER_TARGET_GL_DEFAULT "" )
 endif()
 
-set( CINDER_TARGET_GL ${CINDER_TARGET_GL_DEFAULT} CACHE STRING "Target GL for the system. Valid options : ogl, es2, es3, es31, es32, es2-rpi" )
+set( CINDER_TARGET_GL ${CINDER_TARGET_GL_DEFAULT} CACHE STRING "Target GL for the system. Valid options: ogl, es2, es3, es31, es32, es2-rpi" )
 
 if( CINDER_TARGET_GL )
 	ci_log_v( "CINDER_TARGET_GL: ${CINDER_TARGET_GL}" )

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -115,6 +115,9 @@ list( APPEND SRC_SET_CINDER_AUDIO
 	${CINDER_SRC_DIR}/cinder/audio/Utilities.cpp
 	${CINDER_SRC_DIR}/cinder/audio/Voice.cpp
 	${CINDER_SRC_DIR}/cinder/audio/WaveTable.cpp
+)
+
+list( APPEND SRC_SET_CINDER_AUDIO_DSP
 	${CINDER_SRC_DIR}/cinder/audio/dsp/Biquad.cpp
 	${CINDER_SRC_DIR}/cinder/audio/dsp/Converter.cpp
 	${CINDER_SRC_DIR}/cinder/audio/dsp/Dsp.cpp
@@ -123,6 +126,9 @@ list( APPEND SRC_SET_CINDER_AUDIO
 
 list( APPEND CINDER_SRC_FILES           ${SRC_SET_CINDER_AUDIO} )
 source_group( "cinder\\audio" FILES     ${SRC_SET_CINDER_AUDIO} )
+
+list( APPEND CINDER_SRC_FILES           	${SRC_SET_CINDER_AUDIO_DSP} )
+source_group( "cinder\\audio\\dsp" FILES    ${SRC_SET_CINDER_AUDIO_DSP} )
 
 # ----------------------------------------------------------------------------------------------------------------------
 # cinder::gl

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -184,8 +184,6 @@ function( ci_make_app )
 	get_filename_component( ASSETS_DEST_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets" ABSOLUTE )
 	if( EXISTS "${ARG_ASSETS_PATH}" AND IS_DIRECTORY "${ARG_ASSETS_PATH}" )
 
-		message( "ARG_ASSETS_PATH: ${ARG_ASSETS_PATH}, ASSETS_DEST_PATH: ${ASSETS_DEST_PATH}" )
-
 		if( EXISTS "${ASSETS_DEST_PATH}" )
 			message( STATUS "assets destination path already exists, removing first." )
 			file( REMOVE_RECURSE "${ASSETS_DEST_PATH}" )

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -23,22 +23,15 @@ function( ci_make_app )
 	include( "${ARG_CINDER_PATH}/proj/cmake/configure.cmake" )
 
 	if( "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" STREQUAL "" )
-		if( DEFINED ENV{CLION_IDE} )
-			# By default, CLion places its binary outputs in a global cache location, where assets can't be found in the current
-			# folder heirarchy. So we override that, unless the user has specified a custom binary output dir (then they're on their own).
-			set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build/${CMAKE_BUILD_TYPE} )
-			# message( WARNING "CLion detected, set CMAKE_RUNTIME_OUTPUT_DIRECTORY to: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" )
+		if( ( "${CMAKE_GENERATOR}" MATCHES "Visual Studio.+" ) OR ( "Xcode" STREQUAL "${CMAKE_GENERATOR}" ) )
+			set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
 		else()
-            if( ( "${CMAKE_GENERATOR}" MATCHES "Visual Studio.+" ) OR ( "Xcode" STREQUAL "${CMAKE_GENERATOR}" ) )
-			    set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
-            else()
-			    # Append the build type to the output dir
-			    set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE} )
-            endif()
-			message( STATUS "set CMAKE_RUNTIME_OUTPUT_DIRECTORY to: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}" )
+			# Append the build type to the output dir
+			set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE} )
 		endif()
 	endif()
 
+	# place the binary one level deeper, so that the assets folder can live next to it when building out-of-source.
 	set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${ARG_APP_NAME} )
 
 	ci_log_v( "APP_NAME: ${ARG_APP_NAME}" )

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -31,13 +31,29 @@ list( APPEND SRC_SET_APP_MSW
 	${CINDER_SRC_DIR}/cinder/app/msw/RendererImplGlMsw.cpp
 )
 
+list( APPEND SRC_SET_AUDIO_MSW
+	${CINDER_SRC_DIR}/cinder/audio/msw/ContextWasapi.cpp
+	${CINDER_SRC_DIR}/cinder/audio/msw/DeviceManagerWasapi.cpp
+	${CINDER_SRC_DIR}/cinder/audio/msw/FileMediaFoundation.cpp
+	${CINDER_SRC_DIR}/cinder/audio/msw/MswUtil.cpp
+)
+
+list( APPEND SRC_SET_CINDER_AUDIO_DSP
+	${CINDER_SRC_DIR}/cinder/audio/dsp/ooura/fftsg.cpp
+	${CINDER_SRC_DIR}/cinder/audio/dsp/ConverterR8brain.cpp
+)
+
 list( APPEND CINDER_SRC_FILES
 	${SRC_SET_MSW}
 	${SRC_SET_APP_MSW}
+	${SRC_SET_AUDIO_MSW}
+	${SRC_SET_CINDER_AUDIO_DSP}
 )
 
-source_group( "cinder\\msw"       FILES ${SRC_SET_MSW} )
-source_group( "cinder\\app\\msw"  FILES ${SRC_SET_APP_MSW} )
+source_group( "cinder\\msw"       	FILES ${SRC_SET_MSW} )
+source_group( "cinder\\app\\msw"  	FILES ${SRC_SET_APP_MSW} )
+source_group( "cinder\\audio\\msw"  FILES ${SRC_SET_AUDIO_MSW} )
+source_group( "cinder\\audio\\dsp"  FILES ${SRC_SET_CINDER_AUDIO_DSP} )
 
 list( APPEND CINDER_INCLUDE_SYSTEM_PRIVATE
     ${CINDER_INC_DIR}/msw/zlib

--- a/proj/cmake/utilities.cmake
+++ b/proj/cmake/utilities.cmake
@@ -1,27 +1,24 @@
-function( _ci_build_message )
-	# get the path of the CMakeLists file evaluating this macro relative to the project's root source directory
-	file( RELATIVE_PATH _curr_file "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_FILE}" )
-
-	# Build up all remaining arguments into the _msg var
-	set( _msg )
-	foreach( i RANGE ${ARGC} )
-		set( _msg "${_msg}${ARGV${i}}" )
-	endforeach()
-
-	# deposit the concatenated message into 'msg' var for the parent function to use
-	set( msg "(${_curr_file}) -- ${_msg}" PARENT_SCOPE )
-endfunction()
 
 # Only prints if CINDER_VERBOSE is On
 function( ci_log_v )
 	if( CINDER_VERBOSE )
-		_ci_build_message( "${ARGV}" )
-		message( "verbose ${msg}" )
+		file( RELATIVE_PATH curr_file "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_FILE}" )
+		set( msg )
+		foreach( arg IN LISTS ARGN )
+			set( msg "${msg}${arg}" )
+		endforeach()
+
+		message( "verbose (${curr_file}) ${msg}" )
 	endif()
 endfunction()
 
 # Alawys prints
 function( ci_log_i )
-	_ci_build_message( "${ARGV}" )
-	message( "info ${msg}" )
+	file( RELATIVE_PATH curr_file "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_FILE}" )
+	set( msg )
+	foreach( arg IN LISTS ARGN )
+		set( msg "${msg}${arg}" )
+	endforeach()
+
+	message( "info (${curr_file}) ${msg}" )
 endfunction()


### PR DESCRIPTION
A bunch of cmake stuff I've been meaning to take care of for a while:

- fixed logging utilities (`ci_log_v` and `ci_log_i`)
- added audio sources on Windows - successfully built and ran audio samples with a VS2015 generated project
- removed CLion workaround from before we were symlinking assets folders
- `CINDER_TARGET` gets populated in the CMakeCache.txt