### PR TITLE
Addressing #1863, JSON misrepresenting integer value

### DIFF
--- a/src/cinder/Json.cpp
+++ b/src/cinder/Json.cpp
@@ -247,12 +247,6 @@ void JsonTree::init( const string &key, const Json::Value &value, bool setType, 
 				mValueType = VALUE_BOOL;
 			}
 		}
-		else if ( value.isDouble() ) { 
-			mValue = toString( value.asDouble() );
-			if ( setType ) {
-				mValueType = VALUE_DOUBLE;
-			}
-		}
 		else if ( value.isInt() ) { 
 			mValue = toString( value.asLargestInt() );
 			if ( setType ) {
@@ -269,6 +263,12 @@ void JsonTree::init( const string &key, const Json::Value &value, bool setType, 
 			mValue = toString( value.asLargestUInt() );
 			if ( setType ) {
 				mValueType = VALUE_UINT;
+			}
+		}
+		else if ( value.isDouble() ) { // jsoncpp defines isDouble() to include integral types, so this must follow isInt() && isUint() 
+			mValue = toString( value.asDouble() );
+			if ( setType ) {
+				mValueType = VALUE_DOUBLE;
 			}
 		}
 	}


### PR DESCRIPTION
Proposed fix for #1863. jsoncpp appears to define `isDouble()` to be inclusive of integral types: https://github.com/cinder/Cinder/blob/master/src/jsoncpp/jsoncpp.cpp#L2706

I modified the `JsonTree::init()` method to consider doubles last so that integers are considered first. I believe this fixes the issue described.