### PR TITLE
Added unit tests to check issue #1863 and pr #1866.

### DIFF
--- a/test/unit/src/JsonTest.cpp
+++ b/test/unit/src/JsonTest.cpp
@@ -169,4 +169,35 @@ TEST_CASE("Json", "[noisy]")
 		doc.write( writeFile( "/tmp/testoutput.json" ), JsonTree::WriteOptions() );
 		doc.write( writeFile( "/tmp/testoutput_fast.json" ), JsonTree::WriteOptions().indented( false ) );
 	}
+	
+	SECTION("Cinder can accurately serialize and deserialize JSON values")
+	{
+		JsonTree test32u( "uint32", uint32_t( math<uint64_t>::pow( 2, 32 ) ) - 1 );
+		CHECK( test32u.getValue() == JsonTree( test32u.serialize() )["uint32"].getValue() );
+		
+		JsonTree test32( "int32", int32_t( math<int32_t>::pow( 2, 32 ) ) - 1 );
+		CHECK( test32.getValue() == JsonTree( test32.serialize() )["int32"].getValue() );
+		
+		JsonTree test64u( "uint64", uint64_t( math<uint64_t>::pow( 2, 64 ) ) - 1 );
+		CHECK( test64u.getValue() == JsonTree( test64u.serialize() )["uint64"].getValue() );
+		
+		JsonTree test64( "int64", int64_t( math<int64_t>::pow( 2, 64 ) ) - 1 );
+		CHECK( test64.getValue() == JsonTree( test64.serialize() )["int64"].getValue() );
+
+		JsonTree testFloat( "float", float( M_PI ));
+		CHECK( testFloat.getValue() == JsonTree( testFloat.serialize() )["float"].getValue() );
+		
+		JsonTree testDouble( "double", double( M_PI ));
+		CHECK( testDouble.getValue() == JsonTree( testDouble.serialize() )["double"].getValue() );
+		
+		JsonTree testString( "string", "Every machine is the spiritualization of an organism.");
+		CHECK( testString.getValue() == JsonTree( testString.serialize() )["string"].getValue() );
+		
+		JsonTree testBooleanTrue( "boolean", true);
+		CHECK( testBooleanTrue.getValue() == JsonTree( testBooleanTrue.serialize() )["boolean"].getValue() );
+		
+		JsonTree testBooleanFalse( "boolean", false);
+		CHECK( testBooleanFalse.getValue() == JsonTree( testBooleanFalse.serialize() )["boolean"].getValue() );
+	}
+	
 } // json


### PR DESCRIPTION
Unit tests to confirm that JsonTree can make the serialization / deserialization round trip without incident.

These tests confirm issue #1863, and verify that pull request #1866 works.

Before #1866:

```
-------------------------------------------------------------------------------
Json
  Cinder can accurately serialize and deserialize JSON values
-------------------------------------------------------------------------------
/Users/mika/Code/Cinder/test/unit/src/JsonTest.cpp:12
...............................................................................

/Users/mika/Code/Cinder/test/unit/src/JsonTest.cpp:176: FAILED:
  CHECK( test32u.getValue() == JsonTree( test32u.serialize() )["uint32"].getValue() )
with expansion:
  "4.29497e+09" == "4"

/Users/mika/Code/Cinder/test/unit/src/JsonTest.cpp:179: FAILED:
  CHECK( test32.getValue() == JsonTree( test32.serialize() )["int32"].getValue() )
with expansion:
  "2.14748e+09" == "2"

...

===============================================================================
test cases:      15 |      14 passed | 1 failed
assertions: 1147520 | 1147518 passed | 2 failed
```

After #1866:

```
===============================================================================
All tests passed (1088520 assertions in 15 test cases)
```




