### PR TITLE
Add optional sample rate conversion to audio::TargetFile and audio::BufferRecorderNode

### DIFF
--- a/include/cinder/audio/SampleRecorderNode.h
+++ b/include/cinder/audio/SampleRecorderNode.h
@@ -75,9 +75,9 @@ class CI_API BufferRecorderNode : public SampleRecorderNode {
 
 	//! \brief Writes the currently recorded samples to a file at \a filePath
 	//!
-	//! The encoding format is derived from \a filePath's extension and \a sampleType (default = SampleType::INT_16).
+	//! The encoding format is derived from \a filePath's extension, \a sampleType (default = SampleType::INT_16) and \a destSampleRate (default = getSampleRate()).
 	//! \note throws AudioFileExc if the write request cannot be completed.
-	void writeToFile( const ci::fs::path &filePath, SampleType sampleType = SampleType::INT_16 );
+	void writeToFile( const ci::fs::path &filePath, SampleType sampleType = SampleType::INT_16, size_t destSampleRate = 0 );
 
 	//! Returns the frame of the last buffer overrun or 0 if none since the last time this method was called. When this happens, it means the recorded buffer probably has skipped some frames.
 	uint64_t getLastOverrun();

--- a/include/cinder/audio/cocoa/FileCoreAudio.h
+++ b/include/cinder/audio/cocoa/FileCoreAudio.h
@@ -69,7 +69,7 @@ class SourceFileCoreAudio : public SourceFile {
 
 class TargetFileCoreAudio : public TargetFile {
   public:
-	TargetFileCoreAudio( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType, const std::string &extension );
+	TargetFileCoreAudio( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType, size_t targetSampleRate, const std::string &extension );
 	virtual ~TargetFileCoreAudio() {}
 
 	void performWrite( const Buffer *buffer, size_t numFrames, size_t frameOffset ) override;

--- a/src/cinder/audio/SampleRecorderNode.cpp
+++ b/src/cinder/audio/SampleRecorderNode.cpp
@@ -162,12 +162,12 @@ BufferRef BufferRecorderNode::getRecordedCopy() const
 	return mCopiedBuffer;
 }
 
-void BufferRecorderNode::writeToFile( const fs::path &filePath, SampleType sampleType )
+void BufferRecorderNode::writeToFile( const fs::path &filePath, SampleType sampleType, size_t destSampleRate )
 {
 	size_t currentWritePos = mWritePos;
 	BufferRef copiedBuffer = getRecordedCopy();
 
-	audio::TargetFileRef target = audio::TargetFile::create( filePath, getSampleRate(), getNumChannels(), sampleType );
+	audio::TargetFileRef target = audio::TargetFile::create( filePath, getSampleRate(), getNumChannels(), sampleType, destSampleRate );
 	target->write( copiedBuffer.get(), currentWritePos );
 }
 

--- a/src/cinder/audio/Target.cpp
+++ b/src/cinder/audio/Target.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "cinder/audio/Target.h"
+#include "cinder/audio/dsp/Converter.h"
 #include "cinder/CinderAssert.h"
 
 #include "cinder/Utilities.h"
@@ -38,7 +39,7 @@ namespace cinder { namespace audio {
 
 // TODO: these should be replaced with a generic registrar derived from the ImageIo stuff.
 
-std::unique_ptr<TargetFile> TargetFile::create( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType, const std::string &extension )
+std::unique_ptr<TargetFile> TargetFile::create( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType, size_t sampleRateTarget, const std::string &extension )
 {
 #if ! defined( CINDER_UWP ) || ( _MSC_VER > 1800 )
 	std::string ext = dataTarget->getFilePathHint().extension().string();
@@ -48,20 +49,42 @@ std::unique_ptr<TargetFile> TargetFile::create( const DataTargetRef &dataTarget,
 	ext = ( ( ! ext.empty() ) && ( ext[0] == '.' ) ) ? ext.substr( 1, string::npos ) : ext;
 
 #if defined( CINDER_COCOA )
-	return std::unique_ptr<TargetFile>( new cocoa::TargetFileCoreAudio( dataTarget, sampleRate, numChannels, sampleType, ext ) );
+	return std::unique_ptr<TargetFile>( new cocoa::TargetFileCoreAudio( dataTarget, sampleRate, numChannels, sampleType, sampleRateTarget, ext ) );
 #elif defined( CINDER_MSW )
+	CI_ASSERT_MSG( sampleRateTarget == 0 || sampleRateTarget == sampleRate, "sample rate conversion not yet implemented on MSW" );
 	return std::unique_ptr<TargetFile>( new msw::TargetFileMediaFoundation( dataTarget, sampleRate, numChannels, sampleType, ext ) );
 #endif
 }
 
-std::unique_ptr<TargetFile> TargetFile::create( const fs::path &path, size_t sampleRate, size_t numChannels, SampleType sampleType, const std::string &extension )
+std::unique_ptr<TargetFile> TargetFile::create( const fs::path &path, size_t sampleRate, size_t numChannels, SampleType sampleType, size_t targetSampleRate, const std::string &extension )
 {
-	return create( (DataTargetRef)writeFile( path ), sampleRate, numChannels, sampleType, extension );
+	return create( (DataTargetRef)writeFile( path ), sampleRate, numChannels, sampleType, targetSampleRate, extension );
+}
+
+TargetFile::TargetFile( size_t sampleRate, size_t numChannels, SampleType sampleType, size_t sampleRateTarget )
+	: mSampleRate( sampleRate ), mNumChannels( numChannels ), mSampleType( sampleType ), mSampleRateTarget( sampleRateTarget ), mMaxFramesPerConversion( 4092 )
+{
+	setupSampleRateConversion();
+}
+
+TargetFile::~TargetFile()
+{
+}
+
+void TargetFile::setupSampleRateConversion()
+{
+	if ( ! mSampleRateTarget ) {
+		mSampleRateTarget = mSampleRate;
+	} else if ( mSampleRateTarget != mSampleRate) {
+		mConverter = audio::dsp::Converter::create( mSampleRate, mSampleRateTarget, getNumChannels(), getNumChannels(), mMaxFramesPerConversion );
+		mConverterSourceBuffer.setSize( mMaxFramesPerConversion, getNumChannels() );
+		mConverterDestBuffer.setSize( mMaxFramesPerConversion, getNumChannels() );
+	}
 }
 
 void TargetFile::write( const Buffer *buffer )
 {
-	performWrite( buffer, buffer->getNumFrames(), 0 );
+	write( buffer, buffer->getNumFrames(), 0 );
 }
 
 void TargetFile::write( const Buffer *buffer, size_t numFrames )
@@ -71,7 +94,7 @@ void TargetFile::write( const Buffer *buffer, size_t numFrames )
 
 	CI_ASSERT_MSG( numFrames <= buffer->getNumFrames(), "numFrames out of bounds" );
 
-	performWrite( buffer, numFrames, 0 );
+	write( buffer, numFrames, 0 );
 }
 
 void TargetFile::write( const Buffer *buffer, size_t numFrames, size_t frameOffset )
@@ -81,7 +104,29 @@ void TargetFile::write( const Buffer *buffer, size_t numFrames, size_t frameOffs
 
 	CI_ASSERT_MSG( numFrames + frameOffset <= buffer->getNumFrames(), "numFrames + frameOffset out of bounds" );
 
-	performWrite( buffer, numFrames, frameOffset );
+	if( mConverter ) {
+		auto currFrame = frameOffset;
+		auto lastFrame = frameOffset + numFrames;
+
+		// process buffer in chunks of mMaxFramesPerConversion
+		while ( currFrame != lastFrame ) {
+			auto numSourceFrames = std::min( mMaxFramesPerConversion, lastFrame - currFrame );
+			auto numDestFrames = size_t( numSourceFrames * (float)getSampleRateTarget() / (float)getSampleRate() );
+
+			// copy buffer into temporary buffer to remove frame offset (needed for mConverter->convert)
+			mConverterSourceBuffer.copyOffset( *buffer, numSourceFrames, 0, currFrame );
+
+			mConverterSourceBuffer.setNumFrames( numSourceFrames );
+			mConverterDestBuffer.setNumFrames( numDestFrames );
+			tie( numSourceFrames, numDestFrames ) = mConverter->convert( &mConverterSourceBuffer, &mConverterDestBuffer );
+
+			performWrite( &mConverterDestBuffer, numDestFrames, 0 );
+
+			currFrame += numSourceFrames;
+		}
+	} else {
+		performWrite( buffer, numFrames, frameOffset );
+	}
 }
 
 } } // namespace cinder::audio

--- a/src/cinder/audio/cocoa/FileCoreAudio.cpp
+++ b/src/cinder/audio/cocoa/FileCoreAudio.cpp
@@ -147,8 +147,8 @@ vector<string> SourceFileCoreAudio::getSupportedExtensions()
 // MARK: - TargetFileCoreAudio
 // ----------------------------------------------------------------------------------------------------
 
-TargetFileCoreAudio::TargetFileCoreAudio( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType, const std::string &extension )
-	: TargetFile( sampleRate, numChannels, sampleType )
+TargetFileCoreAudio::TargetFileCoreAudio( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType, size_t targetSampleRate, const std::string &extension )
+	: TargetFile( sampleRate, numChannels, sampleType, targetSampleRate )
 {
 	::CFURLRef targetUrl = ci::cocoa::createCfUrl( Url( dataTarget->getFilePath().string() ) );
 	::AudioFileTypeID fileType = getFileTypeIdFromExtension( extension );
@@ -156,10 +156,10 @@ TargetFileCoreAudio::TargetFileCoreAudio( const DataTargetRef &dataTarget, size_
 	::AudioStreamBasicDescription fileAsbd;
 	switch( mSampleType ) {
 		case SampleType::INT_16:
-			fileAsbd = createInt16Asbd( mSampleRate, mNumChannels, true );
+			fileAsbd = createInt16Asbd( mSampleRateTarget, mNumChannels, true );
 			break;
 		case SampleType::FLOAT_32:
-			fileAsbd = createFloatAsbd( mSampleRate, mNumChannels, true );
+			fileAsbd = createFloatAsbd( mSampleRateTarget, mNumChannels, true );
 			break;
 		default:
 			CI_ASSERT_NOT_REACHABLE();
@@ -175,7 +175,7 @@ TargetFileCoreAudio::TargetFileCoreAudio( const DataTargetRef &dataTarget, size_
 	::CFRelease( targetUrl );
 	mExtAudioFile = ExtAudioFilePtr( audioFile );
 
-	::AudioStreamBasicDescription clientAsbd = createFloatAsbd( mSampleRate, mNumChannels, false );
+	::AudioStreamBasicDescription clientAsbd = createFloatAsbd( mSampleRateTarget, mNumChannels, false );
 
 	status = ::ExtAudioFileSetProperty( mExtAudioFile.get(), kExtAudioFileProperty_ClientDataFormat, sizeof( clientAsbd ), &clientAsbd );
 	CI_VERIFY( status == noErr );


### PR DESCRIPTION
As I was discussing with @richardeakin [on the forum](http://discourse.libcinder.org/t/audio-configure-sample-rate-of-bufferrecordernode/730), I've added the abillty to configure the sample rate of ``TargetFile``.
The sample rate conversion is implemented in ``audio::TargetFile`` and exposed in ``audio::BufferRecorderNode``.

I propose the following API changes:
 - ``TargetFile::create`` has an additional optional parameter ``targetSampleRate``.
I placed it before ``extension`` since this parameter is (for some reason) not used in the implementation of ``create``.
 - this extra parameter is propagated to ``TargetFileCoreAudio``.
 - I've added a new function ``TargetFile::getSampleRateNative`` similar as in ``Source``.
 - ``BufferRecorderNode::writeToFile`` has an additional optional parameter ``destSampleRate`` which is passed to ``TargetFile::create``.

I've not implemented these changes on MSW since I work on macOS, but instead added an assert firing when sample rate conversion is required.

I feel like my implementation of ``TargetFile::write`` is bit hacky, because ``dsp::Converter`` 1) processes data in fixed chunk sizes and 2) can't handle frame offsets in buffers. So I first have to copy data into a new buffer (removing the frame offset), convert it using a second buffer before writing it to file.
So could that could be improved imo.