### PR TITLE
Added implementation of TargetFileOggVorbis

### DIFF
--- a/include/cinder/audio/FileOggVorbis.h
+++ b/include/cinder/audio/FileOggVorbis.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "cinder/audio/Source.h"
+#include "cinder/audio/Target.h"
 
 //! don't include ogg's static callbacks (we rely on cinder's stream utils instead)
 #define OV_EXCLUDE_STATIC_CALLBACKS
@@ -69,14 +70,31 @@ class SourceFileOggVorbis : public SourceFile {
 	size_t				mNumChannels, mSampleRate;
 };
 
-//class TargetFileImplOggVorbis : public TargetFile {
-//public:
-//	TargetFileImplOggVorbis( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, const std::string &extension );
-//	virtual TargetFileImplOggVorbis() {}
-//
-//	void write( const Buffer *buffer, size_t frameOffset, size_t numFrames ) override;
-//
-//private:
-//};
+//! TargetFile implementation for encoding ogg vorbis files.
+class TargetFileOggVorbis : public TargetFile {
+  public:
+	TargetFileOggVorbis( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType );
+	virtual ~TargetFileOggVorbis();
+
+	void performWrite( const Buffer *buffer, size_t numFrames, size_t frameOffset ) override;
+
+  private:
+	void processAndWriteVorbisBlocks();
+
+	vorbis_info			mVorbisInfo;
+	vorbis_comment		mVorbisComment;
+	vorbis_dsp_state	mVorbisDspState;
+	vorbis_block		mVorbisBlock;
+
+	ogg_stream_state	mOggStream;
+	ogg_page			mOggPage;
+	ogg_packet			mOggPacket;
+
+	float				mVorbisBaseQuality = 0.4f;	// desired quality level, from -0.1 to 1.0 (lo to hi).
+	size_t				mVorbisBufferSize = 1024;	// size of chunks processed by libvorbis
+
+	ci::DataTargetRef	mDataTarget;
+	ci::OStreamRef		mStream;
+};
 
 } } // namespace cinder::audio

--- a/src/cinder/audio/FileOggVorbis.cpp
+++ b/src/cinder/audio/FileOggVorbis.cpp
@@ -24,7 +24,6 @@
 #include "cinder/audio/FileOggVorbis.h"
 #include "cinder/audio/dsp/Converter.h"
 #include "cinder/audio/Exception.h"
-#include "cinder/Rand.h"
 
 #include "vorbis/vorbisenc.h"
 
@@ -212,8 +211,8 @@ TargetFileOggVorbis::TargetFileOggVorbis( const DataTargetRef &dataTarget, size_
 	vorbis_analysis_init( &mVorbisDspState, &mVorbisInfo );
 	vorbis_block_init( &mVorbisDspState, &mVorbisBlock );
 
-	Rand::randomize();
-	ogg_stream_init( &mOggStream, randInt() );
+	// a constant stream serial number is used, this is okay since no streams are multiplexed
+	ogg_stream_init( &mOggStream, 0 );
 
 	ogg_packet header, headerComment, headerCodebook;
 

--- a/src/cinder/audio/FileOggVorbis.cpp
+++ b/src/cinder/audio/FileOggVorbis.cpp
@@ -24,12 +24,19 @@
 #include "cinder/audio/FileOggVorbis.h"
 #include "cinder/audio/dsp/Converter.h"
 #include "cinder/audio/Exception.h"
+#include "cinder/Rand.h"
+
+#include "vorbis/vorbisenc.h"
 
 #include <sstream>
 
 using namespace std;
 
 namespace cinder { namespace audio {
+
+// ----------------------------------------------------------------------------------------------------
+// SourceFileOggVorbis
+// ----------------------------------------------------------------------------------------------------
 
 SourceFileOggVorbis::SourceFileOggVorbis()
 	: SourceFile( 0 )
@@ -180,6 +187,98 @@ long SourceFileOggVorbis::tellFn( void *datasource )
 	auto sourceFile = (SourceFileOggVorbis *)datasource;
 	
 	return static_cast<long>( sourceFile->mStream->tell() );
+}
+
+// ----------------------------------------------------------------------------------------------------
+// TargetFileOggVorbis
+// ----------------------------------------------------------------------------------------------------
+
+TargetFileOggVorbis::TargetFileOggVorbis( const DataTargetRef &dataTarget, size_t sampleRate, size_t numChannels, SampleType sampleType )
+	: cinder::audio::TargetFile( sampleRate, numChannels, sampleType ), mDataTarget( dataTarget )
+{
+	CI_ASSERT( mDataTarget );
+	mStream = mDataTarget->getStream();
+
+	vorbis_info_init( &mVorbisInfo );
+
+	auto status = vorbis_encode_init_vbr( &mVorbisInfo, getNumChannels(), getSampleRate(), mVorbisBaseQuality );
+	if ( status ) {
+		throw AudioFormatExc( string( "TargetFileOggVorbis: invalid quality setting." ) );
+	}
+
+	vorbis_comment_init( &mVorbisComment );
+	vorbis_comment_add_tag( &mVorbisComment, "ENCODER", "libcinder" );
+
+	vorbis_analysis_init( &mVorbisDspState, &mVorbisInfo );
+	vorbis_block_init( &mVorbisDspState, &mVorbisBlock );
+
+	Rand::randomize();
+	ogg_stream_init( &mOggStream, randInt() );
+
+	ogg_packet header, headerComment, headerCodebook;
+
+	vorbis_analysis_headerout( &mVorbisDspState, &mVorbisComment, &header, &headerComment, &headerCodebook );
+	ogg_stream_packetin( &mOggStream, &header );
+	ogg_stream_packetin( &mOggStream, &headerComment );
+	ogg_stream_packetin( &mOggStream, &headerCodebook );
+
+	// flush ogg page so audio data starts on a new page
+	while ( ogg_stream_flush( &mOggStream, &mOggPage ) != 0 ) {
+		mStream->writeData( mOggPage.header, mOggPage.header_len );
+		mStream->writeData( mOggPage.body, mOggPage.body_len );
+	}
+}
+
+TargetFileOggVorbis::~TargetFileOggVorbis()
+{
+	// indicate end of input
+	vorbis_analysis_wrote( &mVorbisDspState, 0 );
+
+	processAndWriteVorbisBlocks();
+
+	ogg_stream_clear( &mOggStream );
+	vorbis_block_clear( &mVorbisBlock );
+	vorbis_dsp_clear( &mVorbisDspState );
+	vorbis_comment_clear( &mVorbisComment );
+	vorbis_info_clear( &mVorbisInfo );
+}
+
+void TargetFileOggVorbis::performWrite( const Buffer *buffer, size_t numFrames, size_t frameOffset )
+{
+	// process incoming buffer in chunks of maximum mVorbisBufferSize, this prevents memory allocation errors
+	auto currFrame = frameOffset;
+	auto lastFrame = frameOffset + numFrames;
+
+	while ( currFrame != lastFrame ) {
+		auto numFramesChunk = std::min( mVorbisBufferSize, lastFrame - currFrame );
+
+		float ** bufferOgg = vorbis_analysis_buffer( &mVorbisDspState, (int)numFramesChunk );
+		for ( size_t c = 0; c < getNumChannels(); ++c ) {
+			std::memcpy( bufferOgg[ c ], buffer->getChannel( c ) + currFrame, numFramesChunk * sizeof( float ) );
+		}
+		vorbis_analysis_wrote( &mVorbisDspState, (int)numFramesChunk );
+
+		processAndWriteVorbisBlocks();
+
+		currFrame += numFramesChunk;
+	}
+}
+
+void TargetFileOggVorbis::processAndWriteVorbisBlocks()
+{
+	while ( vorbis_analysis_blockout( &mVorbisDspState, &mVorbisBlock ) == 1 ) {
+		vorbis_analysis( &mVorbisBlock, NULL );
+		vorbis_bitrate_addblock( &mVorbisBlock );
+
+		while ( vorbis_bitrate_flushpacket( &mVorbisDspState, &mOggPacket ) == 1 ) {
+			ogg_stream_packetin( &mOggStream, &mOggPacket );
+
+			while ( ogg_stream_pageout( &mOggStream, &mOggPage ) != 0 ) {
+				mStream->writeData( mOggPage.header, mOggPage.header_len );
+				mStream->writeData( mOggPage.body, mOggPage.body_len );
+			}
+		}
+	}
 }
 
 } } // namespace cinder::audio

--- a/src/cinder/audio/Target.cpp
+++ b/src/cinder/audio/Target.cpp
@@ -23,6 +23,7 @@
 
 #include "cinder/audio/Target.h"
 #include "cinder/CinderAssert.h"
+#include "cinder/audio/FileOggVorbis.h"
 
 #include "cinder/Utilities.h"
 
@@ -47,11 +48,15 @@ std::unique_ptr<TargetFile> TargetFile::create( const DataTargetRef &dataTarget,
 #endif
 	ext = ( ( ! ext.empty() ) && ( ext[0] == '.' ) ) ? ext.substr( 1, string::npos ) : ext;
 
+	if ( ext == "ogg" ) {
+		return std::unique_ptr<TargetFile>( new TargetFileOggVorbis( dataTarget, sampleRate, numChannels, sampleType ) );
+	} else {
 #if defined( CINDER_COCOA )
-	return std::unique_ptr<TargetFile>( new cocoa::TargetFileCoreAudio( dataTarget, sampleRate, numChannels, sampleType, ext ) );
+		return std::unique_ptr<TargetFile>( new cocoa::TargetFileCoreAudio( dataTarget, sampleRate, numChannels, sampleType, ext ) );
 #elif defined( CINDER_MSW )
-	return std::unique_ptr<TargetFile>( new msw::TargetFileMediaFoundation( dataTarget, sampleRate, numChannels, sampleType, ext ) );
+		return std::unique_ptr<TargetFile>( new msw::TargetFileMediaFoundation( dataTarget, sampleRate, numChannels, sampleType, ext ) );
 #endif
+	}
 }
 
 std::unique_ptr<TargetFile> TargetFile::create( const fs::path &path, size_t sampleRate, size_t numChannels, SampleType sampleType, const std::string &extension )


### PR DESCRIPTION
I've added the ability to write .ogg files from ``TargetFile``.

Some work could still be done to expose encoder settings (e.g. the currently hardcoded ``mVorbisBaseQuality``). For now I've simply copied defaults from the Ogg Vorbis examples.

Questions:
 * what's the recommended method to generate a random integer within Cinder? I've used ``Rand::randomize()`` and ``randInt()`` now, but this has some side-effects.

Be aware that this PR is not compatible with #1869. To merge both PR's, the constructor should be updated and ``getSampleRate`` should be replaced by ``getSampleRateTarget``.