### PR TITLE
only consider file to be an mp3 if the extension is '.mp3'

### DIFF
--- a/src/cinder/audio/linux/FileAudioLoader.cpp
+++ b/src/cinder/audio/linux/FileAudioLoader.cpp
@@ -163,12 +163,12 @@ struct IStreamMpg123 {
 };
 
 //!
-FileType determineFileType( const ci::IStreamRef& stream )
+FileType determineFileType( const std::string &extension, const ci::IStreamRef& stream )
 {
 	FileType result = FileType::UNKNOWN;
 
 	// Try MP3 first
-	if( FileType::UNKNOWN == result ) {
+	if( extension == ".mp3" ) {
 		ProcessScopedMpg123::initialize();
 
 		stream->seekAbsolute( 0 );
@@ -191,7 +191,7 @@ FileType determineFileType( const ci::IStreamRef& stream )
 		}
 	}
 
-	// WAV next
+	// If not an .mp3, try libsndfile
 	if( FileType::UNKNOWN == result ) {
 		stream->seekAbsolute( 0 );
 
@@ -497,7 +497,8 @@ void SourceFileAudioLoader::init()
 		mStream = mDataSource->createStream();
 	}
 
-	audioloader::FileType fileType = audioloader::determineFileType( mStream );
+	auto extension = mDataSource->getFilePathHint().extension().string();
+	audioloader::FileType fileType = audioloader::determineFileType( extension, mStream );
 
 	/*
 	switch( fileType ) {


### PR DESCRIPTION
Fixes a bug where some .wav files were trying to be loaded with mpg123. I believe they were 32-bit floating point .wav files causing this issue.