### PR TITLE
Clang builds with cpp11

### DIFF
--- a/src/cinder/audio/linux/ContextPulseAudio.cpp
+++ b/src/cinder/audio/linux/ContextPulseAudio.cpp
@@ -615,7 +615,7 @@ struct OutputDeviceNodePulseAudioImpl {
 
 	void initPlayer( size_t numChannels, size_t sampleRate, size_t framesPerBlock )
 	{
-		mPulseStream = std::make_unique<pulse::OutputStream>( mPulseContext, numChannels, sampleRate, framesPerBlock, mParent->getDevice()->getName() );
+		mPulseStream = std::unique_ptr<pulse::OutputStream>( new pulse::OutputStream( mPulseContext, numChannels, sampleRate, framesPerBlock, mParent->getDevice()->getName() ) );
 		mPulseStream->open();
 
 		// Allocate a big enough buffer size that will accomodate most hardware. This is a workaround
@@ -690,7 +690,7 @@ struct InputDeviceNodePulseAudioImpl {
 
 	void initStream( size_t numChannels, size_t sampleRate, size_t framesPerBlock )
 	{
-		mPulseStream = std::make_unique<pulse::InputStream>( mPulseContext, numChannels, sampleRate, framesPerBlock, mParent->getDevice()->getName() );
+		mPulseStream = std::unique_ptr<pulse::InputStream>( new pulse::InputStream( mPulseContext, numChannels, sampleRate, framesPerBlock, mParent->getDevice()->getName() ) );
 		mPulseStream->open();
 	}
 

--- a/src/cinder/linux/GstPlayer.cpp
+++ b/src/cinder/linux/GstPlayer.cpp
@@ -101,7 +101,7 @@ void GstData::updateState( const GstState& current )
 {
     currentState = current;
 
-    switch ( currentState ) {
+    switch ( static_cast<int>( currentState ) ) {
         case GST_STATE_NULL: {
             reset();
             break;
@@ -265,7 +265,7 @@ gboolean checkBusMessagesAsync( GstBus* bus, GstMessage* message, gpointer userD
             break;
         }
         case GST_MESSAGE_ASYNC_DONE: {
-            switch( data.currentState ) {
+            switch( static_cast<int>( data.currentState ) ) {
                 case GST_STATE_PAUSED: {
                     if( data.isSeeking ) {
                         if( data.requestedSeek  ) {


### PR DESCRIPTION
Clang is unhappy using `libstdc++` in cpp14 (described [here](https://stackoverflow.com/questions/17775390/clang-3-3-in-c1y-mode-cannot-parse-cstdio-header)). These small tweaks allow Cinder to build with `-std=c++11`