### PR TITLE
Cmake 2.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 # Configure the Android toolchain before the project start

--- a/blocks/OSC/samples/BroadcastSender/proj/cmake/CMakeLists.txt
+++ b/blocks/OSC/samples/BroadcastSender/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( OSC-BroadcastSender )

--- a/blocks/OSC/samples/SimpleMultiThreadedReceiver/proj/cmake/CMakeLists.txt
+++ b/blocks/OSC/samples/SimpleMultiThreadedReceiver/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( OSC-SimpleMultiThreadedReceiver )

--- a/blocks/OSC/samples/SimpleMultiThreadedSender/proj/cmake/CMakeLists.txt
+++ b/blocks/OSC/samples/SimpleMultiThreadedSender/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( OSC-SimpleMultiThreadedSender )

--- a/blocks/OSC/samples/SimpleReceiver/proj/cmake/CMakeLists.txt
+++ b/blocks/OSC/samples/SimpleReceiver/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( OSC-SimpleReceiver )

--- a/blocks/OSC/samples/SimpleSender/proj/cmake/CMakeLists.txt
+++ b/blocks/OSC/samples/SimpleSender/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( OSC-SimpleSender )

--- a/blocks/TUIO/samples/TuioListener/proj/cmake/CMakeLists.txt
+++ b/blocks/TUIO/samples/TuioListener/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( TUIO-TUIOListener )

--- a/blocks/TUIO/samples/TuioMultitouchBasic/proj/cmake/CMakeLists.txt
+++ b/blocks/TUIO/samples/TuioMultitouchBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( TUIO-TuioMultitouchBasic )

--- a/blocks/__AppTemplates/__Foundation/linux_cmake/CMakeLists.txt
+++ b/blocks/__AppTemplates/__Foundation/linux_cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Cube
-cmake_minimum_required( VERSION 3.1 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE on )
 
 get_filename_component( CINDER_DIR "_TBOX_CINDER_PATH_" ABSOLUTE )

--- a/docs/htmlsrc/guides/cmake/cmake.html
+++ b/docs/htmlsrc/guides/cmake/cmake.html
@@ -41,7 +41,7 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 <h1 id="building-libcinder-with-cmake">Building libcinder with CMake</h1>
-<p>To build libcinder from the command line, first make sure you have CMake version 3.0 or later installed. Then the process is similar to most other cmake projects you may have used, for example you can do the following from within the main cinder repo path:</p>
+<p>To build libcinder from the command line, first make sure you have CMake version 2.8 or later installed. Then the process is similar to most other cmake projects you may have used, for example you can do the following from within the main cinder repo path:</p>
 <pre><code>mkdir build
 cd build
 cmake ..
@@ -72,7 +72,7 @@ make -j4
 </code></pre>
 
 <p>To simplify configuring your project and the many platform-specific particulars, we use a utility function called <code>ci_make_app()</code>, which takes a number of arguments to build your application. For example, <a href="https://github.com/cinder/Cinder/blob/master/samples/_opengl/ObjLoader/proj/cmake/CMakeLists.txt">here</a> is the CMakeLists.txt file used for building the <code>_opengl/ObjLoader</code> sample:</p>
-<pre><code class="cmake">cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+<pre><code class="cmake">cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ObjLoader )

--- a/proj/android/CMakeLists.txt
+++ b/proj/android/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.1 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 # Suppress compiler checks. Why? CMake seems to be inconsistent

--- a/proj/cmake/libcinder_configure.cmake
+++ b/proj/cmake/libcinder_configure.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 
 ci_log_v( "Building Cinder for ${CINDER_TARGET}" )
 

--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 
 cmake_policy( SET CMP0022 NEW )
 

--- a/proj/cmake/platform_android.cmake
+++ b/proj/cmake/platform_android.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 set( CINDER_PLATFORM "Android" )

--- a/proj/cmake/platform_ios.cmake
+++ b/proj/cmake/platform_ios.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 set( CINDER_PLATFORM "Cocoa" )

--- a/proj/cmake/platform_linux.cmake
+++ b/proj/cmake/platform_linux.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 
 set( CMAKE_VERBOSE_MAKEFILE ON )
 

--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 
 set( CINDER_PLATFORM "Cocoa" )
 

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 
 set( CINDER_PLATFORM "MSW" )
 

--- a/samples/ArcballDemo/proj/cmake/CMakeLists.txt
+++ b/samples/ArcballDemo/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( ArcballDemo )

--- a/samples/BasicApp/proj/cmake/CMakeLists.txt
+++ b/samples/BasicApp/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( BasicApp )

--- a/samples/BasicAppMultiWindow/proj/cmake/CMakeLists.txt
+++ b/samples/BasicAppMultiWindow/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( BasicAppMultiWindow )

--- a/samples/BezierPath/proj/cmake/CMakeLists.txt
+++ b/samples/BezierPath/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( BezierPath )

--- a/samples/BezierPathIteration/proj/cmake/CMakeLists.txt
+++ b/samples/BezierPathIteration/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( BezierPathIteration )

--- a/samples/CairoBasic/proj/cmake/CMakeLists.txt
+++ b/samples/CairoBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( CairoBasic )

--- a/samples/CameraPersp/proj/cmake/CMakeLists.txt
+++ b/samples/CameraPersp/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( CameraPersp )

--- a/samples/CaptureBasic/proj/cmake/CMakeLists.txt
+++ b/samples/CaptureBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( CaptureBasic )

--- a/samples/CaptureCube/proj/cmake/CMakeLists.txt
+++ b/samples/CaptureCube/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( CaptureCube )

--- a/samples/ClipboardBasic/proj/cmake/CMakeLists.txt
+++ b/samples/ClipboardBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( ClipboardBasic )

--- a/samples/Compass/proj/cmake/CMakeLists.txt
+++ b/samples/Compass/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Compass )

--- a/samples/ConvexHull/proj/cmake/CMakeLists.txt
+++ b/samples/ConvexHull/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( ConvexHull )

--- a/samples/Earthquake/proj/cmake/CMakeLists.txt
+++ b/samples/Earthquake/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Earthquake )

--- a/samples/EaseGallery/proj/cmake/CMakeLists.txt
+++ b/samples/EaseGallery/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( EaseGallery )

--- a/samples/Extrude/proj/cmake/CMakeLists.txt
+++ b/samples/Extrude/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Extrude )

--- a/samples/FallingGears/proj/cmake/CMakeLists.txt
+++ b/samples/FallingGears/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( FallingGears )

--- a/samples/FlickrTestMultithreaded/proj/cmake/CMakeLists.txt
+++ b/samples/FlickrTestMultithreaded/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( FlickrTestMultithreaded )

--- a/samples/FontSample/proj/cmake/CMakeLists.txt
+++ b/samples/FontSample/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( FontSample )

--- a/samples/FrustumCulling/proj/cmake/CMakeLists.txt
+++ b/samples/FrustumCulling/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( FrustumCulling )

--- a/samples/Geometry/proj/cmake/CMakeLists.txt
+++ b/samples/Geometry/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Geometry )

--- a/samples/ImageFileBasic/proj/cmake/CMakeLists.txt
+++ b/samples/ImageFileBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( ImageFileBasic )

--- a/samples/ImageHeightField/proj/cmake/CMakeLists.txt
+++ b/samples/ImageHeightField/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( ImageHeightField )

--- a/samples/Kaleidoscope/proj/cmake/CMakeLists.txt
+++ b/samples/Kaleidoscope/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Kaleidoscope )

--- a/samples/LocationManager/proj/cmake/CMakeLists.txt
+++ b/samples/LocationManager/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( LocationManager )

--- a/samples/Logging/proj/cmake/CMakeLists.txt
+++ b/samples/Logging/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Logging )

--- a/samples/MandelbrotGLSL/proj/cmake/CMakeLists.txt
+++ b/samples/MandelbrotGLSL/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( MandelbrotGLSL )

--- a/samples/MotionBasic/proj/cmake/CMakeLists.txt
+++ b/samples/MotionBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( MotionBasic )

--- a/samples/MultiTouchBasic/proj/cmake/CMakeLists.txt
+++ b/samples/MultiTouchBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( MultiTouchBasic )

--- a/samples/ParamsBasic/proj/cmake/CMakeLists.txt
+++ b/samples/ParamsBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( ParamsBasic )

--- a/samples/Picking3D/proj/cmake/CMakeLists.txt
+++ b/samples/Picking3D/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Picking3D )

--- a/samples/PolygonBoolean/proj/cmake/CMakeLists.txt
+++ b/samples/PolygonBoolean/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( PolygonBoolean )

--- a/samples/QuaternionAccum/proj/cmake/CMakeLists.txt
+++ b/samples/QuaternionAccum/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( QuaternionAccum )

--- a/samples/QuickTimeAdvanced/proj/cmake/CMakeLists.txt
+++ b/samples/QuickTimeAdvanced/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( QuickTimeAdvanced )

--- a/samples/QuickTimeAvfWriter/proj/cmake/CMakeLists.txt
+++ b/samples/QuickTimeAvfWriter/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( QuickTimeAvfWriter )

--- a/samples/QuickTimeBasic/proj/cmake/CMakeLists.txt
+++ b/samples/QuickTimeBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( QuickTimeBasic )

--- a/samples/QuickTimeIteration/proj/cmake/CMakeLists.txt
+++ b/samples/QuickTimeIteration/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( QuickTimeIteration )

--- a/samples/RDiffusion/proj/cmake/CMakeLists.txt
+++ b/samples/RDiffusion/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( RDiffusion )

--- a/samples/Renderer2dBasic/proj/cmake/CMakeLists.txt
+++ b/samples/Renderer2dBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Renderer2dBasic )

--- a/samples/RetinaSample/proj/cmake/CMakeLists.txt
+++ b/samples/RetinaSample/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( RetinaSample )

--- a/samples/SaveImage/proj/cmake/CMakeLists.txt
+++ b/samples/SaveImage/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( SaveImage )

--- a/samples/SerialCommunication/proj/cmake/CMakeLists.txt
+++ b/samples/SerialCommunication/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( SerialCommunication )

--- a/samples/StereoscopicRendering/proj/cmake/CMakeLists.txt
+++ b/samples/StereoscopicRendering/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( StereoscopicRendering )

--- a/samples/SurfaceBasic/proj/cmake/CMakeLists.txt
+++ b/samples/SurfaceBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( SurfaceBasic )

--- a/samples/TextBox/proj/cmake/CMakeLists.txt
+++ b/samples/TextBox/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( TextBox )

--- a/samples/TextTest/proj/cmake/CMakeLists.txt
+++ b/samples/TextTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( TextTest )

--- a/samples/TextureFont/proj/cmake/CMakeLists.txt
+++ b/samples/TextureFont/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( TextureFont )

--- a/samples/Triangulation/proj/cmake/CMakeLists.txt
+++ b/samples/Triangulation/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Triangulation )

--- a/samples/Tubular/proj/cmake/CMakeLists.txt
+++ b/samples/Tubular/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Tubular )

--- a/samples/VoronoiGpu/proj/cmake/CMakeLists.txt
+++ b/samples/VoronoiGpu/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( VoronoiGpu )

--- a/samples/Wisteria/proj/cmake/CMakeLists.txt
+++ b/samples/Wisteria/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( Wisteria )

--- a/samples/_audio/BufferPlayer/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/BufferPlayer/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-BufferPlayer )

--- a/samples/_audio/DelayFeedback/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/DelayFeedback/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-DelayFeedback )

--- a/samples/_audio/InputAnalyzer/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/InputAnalyzer/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-InputAnalyzer )

--- a/samples/_audio/MultichannelOutput/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/MultichannelOutput/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-MultichannelOutput )

--- a/samples/_audio/NodeAdvanced/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/NodeAdvanced/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-NodeAdvanced )

--- a/samples/_audio/NodeBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/NodeBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-NodeBasic )

--- a/samples/_audio/NodeSubclassing/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/NodeSubclassing/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-NodeSubclassing )

--- a/samples/_audio/VoiceBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/VoiceBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-VoiceBasic )

--- a/samples/_audio/VoiceBasicProcessing/proj/cmake/CMakeLists.txt
+++ b/samples/_audio/VoiceBasicProcessing/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-VoiceBasicProcessing )

--- a/samples/_opengl/ClothSimulation/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ClothSimulation/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ClothSimulation )

--- a/samples/_opengl/Cube/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/Cube/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-Cube )

--- a/samples/_opengl/CubeMapping/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/CubeMapping/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-CubeMapping )

--- a/samples/_opengl/DeferredShading/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/DeferredShading/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-DeferredShading )

--- a/samples/_opengl/DeferredShadingAdvanced/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/DeferredShadingAdvanced/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-DeferredShadingAdvanced )

--- a/samples/_opengl/DynamicCubeMapping/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/DynamicCubeMapping/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-DynamicCubeMapping )

--- a/samples/_opengl/FboBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/FboBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-FboBasic )

--- a/samples/_opengl/FboMultipleRenderTargets/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/FboMultipleRenderTargets/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-FboMultipleRenderTargets )

--- a/samples/_opengl/GeometryShaderBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/GeometryShaderBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-GeometryShaderBasic )

--- a/samples/_opengl/HighDynamicRange/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/HighDynamicRange/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-HighDynamicRange )

--- a/samples/_opengl/ImmediateMode/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ImmediateMode/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ImmediateMode )

--- a/samples/_opengl/InstancedTeapots/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/InstancedTeapots/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-InstancedTeapots )

--- a/samples/_opengl/LevelOfDetailIndirect/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/LevelOfDetailIndirect/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-LevelOfDetailIndirect )

--- a/samples/_opengl/MipMap/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/MipMap/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-MipMap )

--- a/samples/_opengl/MotionBlurFbo/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/MotionBlurFbo/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-MotionBlurFbo )

--- a/samples/_opengl/MotionBlurVelocityBuffer/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/MotionBlurVelocityBuffer/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-MotionBlurVelocityBuffer )

--- a/samples/_opengl/NVidiaComputeParticles/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/NVidiaComputeParticles/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-NVidiaComputeParticles )

--- a/samples/_opengl/NormalMapping/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/NormalMapping/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-NormalMapping )

--- a/samples/_opengl/NormalMappingBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/NormalMappingBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-NormalMappingBasic )

--- a/samples/_opengl/ObjLoader/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ObjLoader/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ObjLoader )

--- a/samples/_opengl/PBOReadBack/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/PBOReadBack/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-PBOReadBack )

--- a/samples/_opengl/ParticleSphereCPU/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ParticleSphereCPU/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ParticleSphereCPU )

--- a/samples/_opengl/ParticleSphereCS/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ParticleSphereCS/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ParticleSphereCS )

--- a/samples/_opengl/ParticleSphereGPU/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ParticleSphereGPU/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ParticleSphereGPU )

--- a/samples/_opengl/ParticlesBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ParticlesBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ParticlesBasic )

--- a/samples/_opengl/PickingFBO/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/PickingFBO/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-PickingFBO )

--- a/samples/_opengl/PostProcessingAA/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/PostProcessingAA/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-PostProcessingAA )

--- a/samples/_opengl/ShadowMapping/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ShadowMapping/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ShadowMapping )

--- a/samples/_opengl/ShadowMappingBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/ShadowMappingBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-ShadowMappingBasic )

--- a/samples/_opengl/StencilReflection/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/StencilReflection/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-StencilReflection )

--- a/samples/_opengl/SuperformulaGPU/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/SuperformulaGPU/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-SuperformulaGPU )

--- a/samples/_opengl/TessellationBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/TessellationBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-TessellationBasic )

--- a/samples/_opengl/TessellationBezier/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/TessellationBezier/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-TessellationBezier )

--- a/samples/_opengl/TransformFeedbackSmokeParticles/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/TransformFeedbackSmokeParticles/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-TransformFeedbackSmokeParticles )

--- a/samples/_opengl/VboMesh/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/VboMesh/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( opengl-VboMesh )

--- a/samples/_svg/AnimatedReveal/proj/cmake/CMakeLists.txt
+++ b/samples/_svg/AnimatedReveal/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( svg-AnimatedReveal )

--- a/samples/_svg/EuroMap/proj/cmake/CMakeLists.txt
+++ b/samples/_svg/EuroMap/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( svg-EuroMap )

--- a/samples/_svg/GoodNightMorning/proj/cmake/CMakeLists.txt
+++ b/samples/_svg/GoodNightMorning/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( svg-GoodNightMorning )

--- a/samples/_svg/SimpleViewer/proj/cmake/CMakeLists.txt
+++ b/samples/_svg/SimpleViewer/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( svg-SimpleViewer )

--- a/samples/_timeline/BasicAppendTween/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/BasicAppendTween/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-BasicAppendTween )

--- a/samples/_timeline/BasicTween/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/BasicTween/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-BasicTween )

--- a/samples/_timeline/CustomCallback/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/CustomCallback/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-CustomCallback )

--- a/samples/_timeline/CustomLerp/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/CustomLerp/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-CustomLerp )

--- a/samples/_timeline/DragTween/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/DragTween/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-DragTween )

--- a/samples/_timeline/ImageAccordion/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/ImageAccordion/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-ImageAccordion )

--- a/samples/_timeline/PaletteBrowser/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/PaletteBrowser/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-PaletteBrowser )

--- a/samples/_timeline/TextInputTween/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/TextInputTween/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-TextInputTween )

--- a/samples/_timeline/VisualDictionary/proj/cmake/CMakeLists.txt
+++ b/samples/_timeline/VisualDictionary/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( timeline-VisualDictionary )

--- a/samples/perlinTest/proj/cmake/CMakeLists.txt
+++ b/samples/perlinTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( perlinTest )

--- a/samples/slerpBasic/proj/cmake/CMakeLists.txt
+++ b/samples/slerpBasic/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( slerpBasic )

--- a/src/cinder/audio/linux/ContextPulseAudio.cpp
+++ b/src/cinder/audio/linux/ContextPulseAudio.cpp
@@ -615,7 +615,7 @@ struct OutputDeviceNodePulseAudioImpl {
 
 	void initPlayer( size_t numChannels, size_t sampleRate, size_t framesPerBlock )
 	{
-		mPulseStream = std::make_unique<pulse::OutputStream>( mPulseContext, numChannels, sampleRate, framesPerBlock, mParent->getDevice()->getName() );
+		mPulseStream = std::unique_ptr<pulse::OutputStream>( new pulse::OutputStream( mPulseContext, numChannels, sampleRate, framesPerBlock, mParent->getDevice()->getName() ) );
 		mPulseStream->open();
 
 		// Allocate a big enough buffer size that will accomodate most hardware. This is a workaround
@@ -690,7 +690,7 @@ struct InputDeviceNodePulseAudioImpl {
 
 	void initStream( size_t numChannels, size_t sampleRate, size_t framesPerBlock )
 	{
-		mPulseStream = std::make_unique<pulse::InputStream>( mPulseContext, numChannels, sampleRate, framesPerBlock, mParent->getDevice()->getName() );
+		mPulseStream = std::unique_ptr<pulse::InputStream>( new pulse::InputStream( mPulseContext, numChannels, sampleRate, framesPerBlock, mParent->getDevice()->getName() ) );
 		mPulseStream->open();
 	}
 

--- a/src/cinder/linux/GstPlayer.cpp
+++ b/src/cinder/linux/GstPlayer.cpp
@@ -101,7 +101,7 @@ void GstData::updateState( const GstState& current )
 {
     currentState = current;
 
-    switch ( currentState ) {
+    switch ( static_cast<int>( currentState ) ) {
         case GST_STATE_NULL: {
             reset();
             break;
@@ -265,7 +265,7 @@ gboolean checkBusMessagesAsync( GstBus* bus, GstMessage* message, gpointer userD
             break;
         }
         case GST_MESSAGE_ASYNC_DONE: {
-            switch( data.currentState ) {
+            switch( static_cast<int>( data.currentState ) ) {
                 case GST_STATE_PAUSED: {
                     if( data.isSeeking ) {
                         if( data.requestedSeek  ) {

--- a/test/DisplayTest/proj/cmake/CMakeLists.txt
+++ b/test/DisplayTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( DisplayTest )

--- a/test/Linux/AudioLoader/proj/cmake/CMakeLists.txt
+++ b/test/Linux/AudioLoader/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( AudioLoader )

--- a/test/Linux/GstPlayerRefactorTest/proj/cmake/CMakeLists.txt
+++ b/test/Linux/GstPlayerRefactorTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( GstPlayerTestApp )

--- a/test/Linux/Input/proj/cmake/CMakeLists.txt
+++ b/test/Linux/Input/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( InputApp )

--- a/test/Linux/LoadUrl/proj/cmake/CMakeLists.txt
+++ b/test/Linux/LoadUrl/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( LoadUrl )

--- a/test/Linux/PlatformTest/proj/cmake/CMakeLists.txt
+++ b/test/Linux/PlatformTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( PlatformTest )

--- a/test/Video/VideoPlayerScrubTest/proj/cmake/CMakeLists.txt
+++ b/test/Video/VideoPlayerScrubTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( VideoPlayerScrubTestApp )

--- a/test/_audio/DeviceTest/proj/cmake/CMakeLists.txt
+++ b/test/_audio/DeviceTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( audio-DeviceTest )

--- a/test/_opengl/SamplerObject/proj/cmake/CMakeLists.txt
+++ b/test/_opengl/SamplerObject/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( SamplerObject )

--- a/test/eventTest/proj/cmake/CMakeLists.txt
+++ b/test/eventTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( EventTest )

--- a/test/unit/proj/cmake/CMakeLists.txt
+++ b/test/unit/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( UnitTests )

--- a/test/windowTest/proj/cmake/CMakeLists.txt
+++ b/test/windowTest/proj/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 
 project( WindowTest )


### PR DESCRIPTION
This changeset reduces our minimum required CMake version from 3.0 to 2.8. There are a variety of CMake use cases so this PR is a poll as much as anything. The primary motivation for the reduction is to allow Cinder to be built on more platforms without requiring CMake to be built from source - Ubuntu 14.04 and the NVIDIA Jetson platforms in particular.