### PR TITLE
Retry on wglMakeCurrent() failure

### DIFF
--- a/include/cinder/gl/Context.h
+++ b/include/cinder/gl/Context.h
@@ -590,4 +590,7 @@ class CI_API Context {
 class CI_API ExcContextAllocation : public Exception {
 };
 
+class CI_API ExcContextMakeCurrent : public Exception {
+};
+
 } } // namespace cinder::gl

--- a/src/cinder/gl/Environment.cpp
+++ b/src/cinder/gl/Environment.cpp
@@ -24,6 +24,7 @@
 
 #include "cinder/gl/Environment.h"
 #include "cinder/gl/Context.h"
+#include "cinder/Utilities.h"
 
 #if defined( CINDER_COCOA ) && ( ! defined( __OBJC__ ) )
 	#error "This file must be compiled as Objective-C++ on the Mac"
@@ -239,8 +240,12 @@ void Environment::makeContextCurrent( const Context *context )
 #elif defined( CINDER_MSW )
 	if( context ) {
 		auto platformData = dynamic_pointer_cast<PlatformDataMsw>( context->getPlatformData() );
-		if( ! ::wglMakeCurrent( platformData->mDc, platformData->mGlrc ) ) {
-			// DWORD error = GetLastError();
+		int attemptCount = 10;
+		while( ! ::wglMakeCurrent( platformData->mDc, platformData->mGlrc ) ) {
+			DWORD error = GetLastError();
+			if( attemptCount-- <= 0 )
+				throw ExcContextMakeCurrent();
+			ci::sleep( 1 );
 		}
 	}
 	else {

--- a/src/cinder/gl/Environment.cpp
+++ b/src/cinder/gl/Environment.cpp
@@ -241,6 +241,8 @@ void Environment::makeContextCurrent( const Context *context )
 	if( context ) {
 		auto platformData = dynamic_pointer_cast<PlatformDataMsw>( context->getPlatformData() );
 		int attemptCount = 10;
+		// wglMakeCurrent() can fail (vewry infrequently) if it's called from two threads simultaneously (ostensibly due to driver bugs)
+		// this reattempts 10 times before throwing
 		while( ! ::wglMakeCurrent( platformData->mDc, platformData->mGlrc ) ) {
 			DWORD error = GetLastError();
 			if( attemptCount-- <= 0 )


### PR DESCRIPTION
This is an imperfect solution to what appears to be a driver issue. When two threads call `wglMakeCurrent()` simultaneously, one can fail with either `ERROR_INVALID_HANDLE` or `ERROR_TRANSFORM_NOT_SUPPORTED`. Making the same call again succeeds. This PR attempts the same call a maximum of 10 times (with a millisecond of sleep in between) before throwing `gl::ExcContextMakeCurrent`. I've seen this behavior on both a GTX 970 and a GTX 780 under Windows 10, with a few different (recent) driver versions. I've created a stress-test app which (empirically) demonstrates this as a working fix. Not the most satisfying circumstances, but this was a really brutal failure to track down, and anecdotal Internet evidence points to others having similar issues and this approach fixing them.