### PR TITLE
64-bit Stream and endian operations

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -94,6 +94,8 @@ extern CI_API int16_t	swapEndian( int16_t val );
 extern CI_API uint16_t	swapEndian( uint16_t val );
 extern CI_API int32_t	swapEndian( int32_t val );
 extern CI_API uint32_t	swapEndian( uint32_t val );
+extern CI_API int64_t	swapEndian( int64_t val );
+extern CI_API uint64_t	swapEndian( uint64_t val );
 extern CI_API float		swapEndian( float val );
 extern CI_API double	swapEndian( double val );
 

--- a/src/cinder/Stream.cpp
+++ b/src/cinder/Stream.cpp
@@ -802,7 +802,7 @@ StreamExc::StreamExc( const std::string &fontName ) throw()
 	template void IStreamCinder::readBig<T>( T *t ); \
 	template void IStreamCinder::readLittle<T>( T *t );
 
-BOOST_PP_SEQ_FOR_EACH( STREAM_PROTOTYPES, ~, (int8_t)(uint8_t)(int16_t)(uint16_t)(int32_t)(uint32_t)(float)(double) )
+BOOST_PP_SEQ_FOR_EACH( STREAM_PROTOTYPES, ~, (int8_t)(uint8_t)(int16_t)(uint16_t)(int32_t)(uint32_t)(int64_t)(uint64_t)(float)(double) )
 
 #if defined( CINDER_UWP )
 	#pragma warning(pop) 

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -145,6 +145,23 @@ uint32_t swapEndian( uint32_t val )
 					 (((uint32_t) (val) & (uint32_t) 0xFF000000U) >> 24));
 }
 
+int64_t swapEndian( int64_t val )
+{
+	uint64_t	x = reinterpret_cast<uint64_t&>( val );
+				x = (x & 0x00000000FFFFFFFF) << 32 | (x & 0xFFFFFFFF00000000) >> 32;
+				x = (x & 0x0000FFFF0000FFFF) << 16 | (x & 0xFFFF0000FFFF0000) >> 16;
+				x = (x & 0x00FF00FF00FF00FF) << 8  | (x & 0xFF00FF00FF00FF00) >> 8;
+	return reinterpret_cast<int64_t&>( x );
+}
+
+uint64_t swapEndian( uint64_t val )
+{
+	uint64_t	x = (val & 0x00000000FFFFFFFF) << 32 | (val & 0xFFFFFFFF00000000) >> 32;
+				x = (x & 0x0000FFFF0000FFFF) << 16 | (x & 0xFFFF0000FFFF0000) >> 16;
+				x = (x & 0x00FF00FF00FF00FF) << 8  | (x & 0xFF00FF00FF00FF00) >> 8;
+	return x;
+}
+
 float swapEndian( float val )
 {
 	uint32_t temp = swapEndian( * reinterpret_cast<uint32_t*>( &val ) );

--- a/test/unit/src/Utilities.cpp
+++ b/test/unit/src/Utilities.cpp
@@ -31,6 +31,22 @@ std::istream& operator>>( std::istream &i, CustomType &t )
 
 TEST_CASE( "Utilities" )
 {
+	SECTION( "swapEndian" )
+	{
+		// 8-bit; should be no-op
+		REQUIRE( swapEndian( (int8_t)-127 ) == (int8_t)-127 );
+		REQUIRE( swapEndian( (uint8_t)255 ) == (uint8_t)255 );
+		// 16-bit
+		REQUIRE( swapEndian( (int16_t)-129 ) == (int16_t)0x7FFF );
+		REQUIRE( swapEndian( (uint16_t)0xFFEF ) == (uint16_t)0xEFFF );
+		// 32-bit
+		REQUIRE( swapEndian( (int32_t)-129 ) == (int32_t)0x7FFFFFFF );
+		REQUIRE( swapEndian( (uint32_t)0xBBAAFFEF ) == (uint32_t)0xEFFFAABB );
+		// 64-bit
+		REQUIRE( swapEndian( (int64_t)-129 ) == (int64_t)0x7FFFFFFFFFFFFFFF );
+		REQUIRE( swapEndian( (uint64_t)0xAABBCCDDEEFFEEEF ) == (uint64_t)0xEFEEFFEEDDCCBBAA );
+	}
+
 	SECTION( "Compress Buffer" )
 	{
 		vector<int> d;


### PR DESCRIPTION
Adds `swapEndian()` variants for 64-bit, some rudimentary unit tests to match, and Stream read/write methods.