### PR TITLE
Fix FindGStreamer for cases when GStreamer_FIND_VERSION is undefined

### DIFF
--- a/proj/cmake/modules/FindGStreamer.cmake
+++ b/proj/cmake/modules/FindGStreamer.cmake
@@ -57,7 +57,7 @@ find_package(PkgConfig)
 macro(FIND_GSTREAMER_COMPONENT _component_prefix _pkgconfig_name _library)
 
     string(REGEX MATCH "(.*)>=(.*)" _dummy "${_pkgconfig_name}")
-    if ("${CMAKE_MATCH_2}" STREQUAL "")
+    if ("${CMAKE_MATCH_2}" STREQUAL "" AND DEFINED "${GStreamer_FIND_VERSION}")
         pkg_check_modules(PC_${_component_prefix} "${_pkgconfig_name} >= ${GStreamer_FIND_VERSION}")
     else ()
         pkg_check_modules(PC_${_component_prefix} ${_pkgconfig_name})


### PR DESCRIPTION
GStreamer_FIND_VERSION isn't defined anywhere for me, so I had to do this change to FindGStreamer.cmake otherwise the gstreamer-1.0 include path wouldn't be passed to the compiler and compilation would fail.

I'm running Fedora 26.