### PR TITLE
Added Fbo::readPixels32f()

### DIFF
--- a/include/cinder/gl/Fbo.h
+++ b/include/cinder/gl/Fbo.h
@@ -171,9 +171,11 @@ class CI_API Fbo : public std::enable_shared_from_this<Fbo> {
 	//! Sets the debugging label associated with the Fbo. Calls glObjectLabel() when available.
 	void				setLabel( const std::string &label );
 	
-	//! Returns a copy of the pixels in \a attachment within \a area (cropped to the bounding rectangle of the attachment) as an 8-bit per channel Surface. \a attachment ignored on ES 2.
+	//! Returns a copy of the pixels in \a attachment within \a area (cropped to the bounding rectangle of the attachment) as a Surface8u. \a attachment ignored on ES 2.
 	Surface8u		readPixels8u( const Area &area, GLenum attachment = GL_COLOR_ATTACHMENT0 ) const;
-
+	//! Returns a copy of the pixels in \a attachment within \a area (cropped to the bounding rectangle of the attachment) as a Surface32f. \a attachment ignored on ES 2.
+	Surface32f		readPixels32f( const Area &area, GLenum attachment = GL_COLOR_ATTACHMENT0 ) const;
+	
 	//! \brief Defines the Format of the Fbo, which is passed in via create().
 	//!
 	//! The default provides an 8-bit RGBA color texture attachment and a 24-bit depth renderbuffer attachment, multi-sampling and stencil disabled.

--- a/include/cinder/gl/Fbo.h
+++ b/include/cinder/gl/Fbo.h
@@ -286,6 +286,8 @@ class CI_API Fbo : public std::enable_shared_from_this<Fbo> {
 	void		updateMipmaps( GLenum attachment ) const;
 	bool		checkStatus( class FboExceptionInvalidSpecification *resultExc );
 	void		setDrawBuffers( GLuint fbId, const std::map<GLenum,RenderbufferRef> &attachmentsBuffer, const std::map<GLenum,TextureBaseRef> &attachmentsTexture );
+	//! Helper function for readPixels8u() / readPixels32f(), returns read area
+	Area		prepareReadPixels( const Area &area, GLenum attachment ) const;
 
 	int					mWidth, mHeight;
 	Format				mFormat;

--- a/src/cinder/gl/Fbo.cpp
+++ b/src/cinder/gl/Fbo.cpp
@@ -755,40 +755,13 @@ Surface8u Fbo::readPixels8u( const Area &area, GLenum attachment ) const
 	resolveTextures();
 	ScopedFramebuffer readScp( GL_FRAMEBUFFER, mId );
 
-	// we need to determine the bounds of the attachment so that we can crop against it and subtract from its height
-	Area attachmentBounds = getBounds();
-	auto attachedBufferIt = mAttachmentsBuffer.find( attachment );
-	if( attachedBufferIt != mAttachmentsBuffer.end() )
-		attachmentBounds = attachedBufferIt->second->getBounds();
-	else {
-		auto attachedTextureIt = mAttachmentsTexture.find( attachment );	
-		// a texture attachment can be either of type Texture2d or TextureCubeMap but this only makes sense for the former
-		if( attachedTextureIt != mAttachmentsTexture.end() ) {
-			auto attachedTexturePtr = attachedTextureIt->second.get();
-			if( typeid(*attachedTexturePtr) == typeid(Texture2d) )
-				attachmentBounds = static_cast<const Texture2d*>( attachedTextureIt->second.get() )->getBounds();
-			else
-				CI_LOG_W( "Reading from an unsupported texture attachment" );	
-		}
-		else // the user has attempted to read from an attachment we have no record of
-			CI_LOG_W( "Reading from unknown attachment" );
-	}
-	
-	Area clippedArea = area.getClipBy( attachmentBounds );
+	Area readArea = prepareReadPixels( area, attachment );
+	Surface8u result( readArea.getWidth(), readArea.getHeight(), true );
+	glReadPixels( readArea.x1, readArea.y1, readArea.getWidth(), readArea.getHeight(), GL_RGBA, GL_UNSIGNED_BYTE, result.getData() );
 
-#if ! defined( CINDER_GL_ES_2 )	
-	glReadBuffer( attachment );
-#endif
-	Surface8u result( clippedArea.getWidth(), clippedArea.getHeight(), true );
-	glReadPixels( clippedArea.x1, attachmentBounds.getHeight() - clippedArea.y2, clippedArea.getWidth(), clippedArea.getHeight(), GL_RGBA, GL_UNSIGNED_BYTE, result.getData() );
-	
 	// glReadPixels returns pixels which are bottom-up
 	ip::flipVertical( &result );
-	
-	// by binding we marked ourselves as needing to be resolved, but since this was a read-only
-	// operation and we resolved at the top, we can mark ourselves as not needing resolve
-	mNeedsResolve = false;
-	
+
 	return result;
 }
 
@@ -798,6 +771,18 @@ Surface32f Fbo::readPixels32f( const Area &area, GLenum attachment ) const
 	resolveTextures();
 	ScopedFramebuffer readScp( GL_FRAMEBUFFER, mId );
 
+	Area readArea = prepareReadPixels( area, attachment );
+	Surface32f result( readArea.getWidth(), readArea.getHeight(), true );
+	glReadPixels( readArea.x1, readArea.y1, readArea.getWidth(), readArea.getHeight(), GL_RGBA, GL_FLOAT, result.getData() );
+
+	// glReadPixels returns pixels which are bottom-up
+	ip::flipVertical( &result );
+
+	return result;
+}
+
+Area Fbo::prepareReadPixels( const Area &area, GLenum attachment ) const
+{
 	// we need to determine the bounds of the attachment so that we can crop against it and subtract from its height
 	Area attachmentBounds = getBounds();
 	auto attachedBufferIt = mAttachmentsBuffer.find( attachment );
@@ -823,17 +808,11 @@ Surface32f Fbo::readPixels32f( const Area &area, GLenum attachment ) const
 	glReadBuffer( attachment );
 #endif
 
-	Surface32f result( clippedArea.getWidth(), clippedArea.getHeight(), true );
-	glReadPixels( clippedArea.x1, attachmentBounds.getHeight() - clippedArea.y2, clippedArea.getWidth(), clippedArea.getHeight(), GL_RGBA, GL_FLOAT, result.getData() );
-
-	// glReadPixels returns pixels which are bottom-up
-	ip::flipVertical( &result );
-
 	// by binding we marked ourselves as needing to be resolved, but since this was a read-only
 	// operation and we resolved at the top, we can mark ourselves as not needing resolve
 	mNeedsResolve = false;
 
-	return result;
+	return Area( clippedArea.x1, attachmentBounds.getHeight() - clippedArea.y2, clippedArea.x2,  attachmentBounds.getHeight() - clippedArea.y1 );
 }
 
 #if ! defined( CINDER_GL_ES )

--- a/src/cinder/gl/Fbo.cpp
+++ b/src/cinder/gl/Fbo.cpp
@@ -792,6 +792,50 @@ Surface8u Fbo::readPixels8u( const Area &area, GLenum attachment ) const
 	return result;
 }
 
+Surface32f Fbo::readPixels32f( const Area &area, GLenum attachment ) const
+{
+	// resolve first, before our own bind so that we don't force a resolve unnecessarily
+	resolveTextures();
+	ScopedFramebuffer readScp( GL_FRAMEBUFFER, mId );
+
+	// we need to determine the bounds of the attachment so that we can crop against it and subtract from its height
+	Area attachmentBounds = getBounds();
+	auto attachedBufferIt = mAttachmentsBuffer.find( attachment );
+	if( attachedBufferIt != mAttachmentsBuffer.end() )
+		attachmentBounds = attachedBufferIt->second->getBounds();
+	else {
+		auto attachedTextureIt = mAttachmentsTexture.find( attachment );	
+		// a texture attachment can be either of type Texture2d or TextureCubeMap but this only makes sense for the former
+		if( attachedTextureIt != mAttachmentsTexture.end() ) {
+			auto attachedTexturePtr = attachedTextureIt->second.get();
+			if( typeid(*attachedTexturePtr) == typeid(Texture2d) )
+				attachmentBounds = static_cast<const Texture2d*>( attachedTextureIt->second.get() )->getBounds();
+			else
+				CI_LOG_W( "Reading from an unsupported texture attachment" );	
+		}
+		else // the user has attempted to read from an attachment we have no record of
+			CI_LOG_W( "Reading from unknown attachment" );
+	}
+
+	Area clippedArea = area.getClipBy( attachmentBounds );
+
+#if ! defined( CINDER_GL_ES_2 )	
+	glReadBuffer( attachment );
+#endif
+
+	Surface32f result( clippedArea.getWidth(), clippedArea.getHeight(), true );
+	glReadPixels( clippedArea.x1, attachmentBounds.getHeight() - clippedArea.y2, clippedArea.getWidth(), clippedArea.getHeight(), GL_RGBA, GL_FLOAT, result.getData() );
+
+	// glReadPixels returns pixels which are bottom-up
+	ip::flipVertical( &result );
+
+	// by binding we marked ourselves as needing to be resolved, but since this was a read-only
+	// operation and we resolved at the top, we can mark ourselves as not needing resolve
+	mNeedsResolve = false;
+
+	return result;
+}
+
 #if ! defined( CINDER_GL_ES )
 void Fbo::blitTo( const FboRef &dst, const Area &srcArea, const Area &dstArea, GLenum filter, GLbitfield mask ) const
 {

--- a/src/cinder/gl/Fbo.cpp
+++ b/src/cinder/gl/Fbo.cpp
@@ -759,8 +759,10 @@ Surface8u Fbo::readPixels8u( const Area &area, GLenum attachment ) const
 	Surface8u result( readArea.getWidth(), readArea.getHeight(), true );
 	glReadPixels( readArea.x1, readArea.y1, readArea.getWidth(), readArea.getHeight(), GL_RGBA, GL_UNSIGNED_BYTE, result.getData() );
 
-	// glReadPixels returns pixels which are bottom-up
-	ip::flipVertical( &result );
+	if( result.getHeight() > 1 ) {
+		// glReadPixels returns pixels which are bottom-up
+		ip::flipVertical( &result );
+	}
 
 	return result;
 }
@@ -775,8 +777,10 @@ Surface32f Fbo::readPixels32f( const Area &area, GLenum attachment ) const
 	Surface32f result( readArea.getWidth(), readArea.getHeight(), true );
 	glReadPixels( readArea.x1, readArea.y1, readArea.getWidth(), readArea.getHeight(), GL_RGBA, GL_FLOAT, result.getData() );
 
-	// glReadPixels returns pixels which are bottom-up
-	ip::flipVertical( &result );
+	if( result.getHeight() > 1 ) {
+		// glReadPixels returns pixels which are bottom-up
+		ip::flipVertical( &result );
+	}
 
 	return result;
 }


### PR DESCRIPTION
Same as `Fbo::readPixels8u` but variant for HDR (floating point) attachments. Among other things pretty handy for debugging shaders, since you can write any variable out to that buffer and view it on the cpu side.