### PR TITLE
audio: Improve handling of overlapping scheduled enable / disable events.

### DIFF
--- a/include/cinder/audio/Context.h
+++ b/include/cinder/audio/Context.h
@@ -113,7 +113,7 @@ class CI_API Context : public std::enable_shared_from_this<Context> {
 
 	//! Schedule \a node to be enabled or disabled with with \a func on the audio thread, to be called at \a when seconds measured against getNumProcessedSeconds().
 	//! If \a \a callFuncBeforeProcess is true, then `func` will be called at the beginning of the processing block, if false will be called at the end.
-	//! \a node is owned until the scheduled event completes.
+	//! \note Should be called from the user thread. \a node is owned until the scheduled event completes.
 	void schedule( double when, const NodeRef &node, bool callFuncBeforeProcess, const std::function<void ()> &func );
 
 	//! Returns the mutex used to synchronize the audio thread. This is also used internally by the Node class when making connections.

--- a/include/cinder/audio/Context.h
+++ b/include/cinder/audio/Context.h
@@ -113,8 +113,12 @@ class CI_API Context : public std::enable_shared_from_this<Context> {
 
 	//! Schedule \a node to be enabled or disabled with with \a func on the audio thread, to be called at \a when seconds measured against getNumProcessedSeconds().
 	//! If \a \a callFuncBeforeProcess is true, then `func` will be called at the beginning of the processing block, if false will be called at the end.
-	//! \note Should be called from the user thread. \a node is owned until the scheduled event completes.
-	void schedule( double when, const NodeRef &node, bool callFuncBeforeProcess, const std::function<void ()> &func );
+	//! \note Should be called from the user thread. Currently only one event can be scheduled on a node at a time. \a node is owned until the scheduled event completes.
+	void scheduleEvent( double when, const NodeRef &node, bool callFuncBeforeProcess, const std::function<void ()> &func );
+	//! Immediately cancels any events scheduled with scheduleEvent().
+	void cancelScheduledEvents( const NodeRef &node );
+	//! \deprecated  use scheduleEvent() instead
+	//void schedule( double when, const NodeRef &node, bool callFuncBeforeProcess, const std::function<void ()> &func );
 
 	//! Returns the mutex used to synchronize the audio thread. This is also used internally by the Node class when making connections.
 	std::mutex& getMutex() const			{ return mMutex; }

--- a/include/cinder/audio/Context.h
+++ b/include/cinder/audio/Context.h
@@ -117,8 +117,8 @@ class CI_API Context : public std::enable_shared_from_this<Context> {
 	void scheduleEvent( double when, const NodeRef &node, bool callFuncBeforeProcess, const std::function<void ()> &func );
 	//! Immediately cancels any events scheduled with scheduleEvent().
 	void cancelScheduledEvents( const NodeRef &node );
-	//! \deprecated  use scheduleEvent() instead
-	//void schedule( double when, const NodeRef &node, bool callFuncBeforeProcess, const std::function<void ()> &func );
+	//! \deprecated  use scheduleEvent() instead.
+	void schedule( double when, const NodeRef &node, bool callFuncBeforeProcess, const std::function<void ()> &func )	{ scheduleEvent( when, node, callFuncBeforeProcess, func ); }
 
 	//! Returns the mutex used to synchronize the audio thread. This is also used internally by the Node class when making connections.
 	std::mutex& getMutex() const			{ return mMutex; }

--- a/include/cinder/audio/Node.h
+++ b/include/cinder/audio/Node.h
@@ -228,6 +228,7 @@ class CI_API Node : public std::enable_shared_from_this<Node>, private Noncopyab
 
 	std::weak_ptr<Context>	mContext;
 	std::atomic<bool>		mEnabled;
+	std::atomic<bool>		mEventScheduled;
 	bool					mInitialized;
 	bool					mAutoEnabled;
 	bool					mProcessInPlace;

--- a/src/cinder/audio/Context.cpp
+++ b/src/cinder/audio/Context.cpp
@@ -351,7 +351,7 @@ const std::vector<Node *>& Context::getAutoPulledNodes()
 void Context::scheduleEvent( double when, const NodeRef &node, bool callFuncBeforeProcess, const std::function<void ()> &func )
 {
 	const uint64_t framesPerBlock = (uint64_t)getFramesPerBlock();
-	uint64_t eventFrameThreshold = timeToFrame( when, static_cast<double>( getSampleRate() ) );
+	uint64_t eventFrameThreshold = std::max( mNumProcessedFrames.load(), timeToFrame( when, static_cast<double>( getSampleRate() ) ) );
 
 	// Place the threshold back one block so we can process the block first, guarding against wrap around
 	if( eventFrameThreshold >= framesPerBlock )

--- a/src/cinder/audio/SamplePlayerNode.cpp
+++ b/src/cinder/audio/SamplePlayerNode.cpp
@@ -55,12 +55,12 @@ void SamplePlayerNode::stop()
 
 void SamplePlayerNode::start( double when )
 {
-	getContext()->schedule( when, shared_from_this(), true, [this] { start(); } );
+	getContext()->scheduleEvent( when, shared_from_this(), true, [this] { start(); } );
 }
 
 void SamplePlayerNode::stop( double when )
 {
-	getContext()->schedule( when, shared_from_this(), false, [this] { stop(); } );
+	getContext()->scheduleEvent( when, shared_from_this(), false, [this] { stop(); } );
 }
 
 void SamplePlayerNode::setLoopBegin( size_t positionFrames )


### PR DESCRIPTION
This solves a problem I ran into where you could schedule an `audio::Node` to be `disable()`d in the future, then something else tries to immediately `enable()` it, only to directly afterwards be disabled by the already scheduled event.

For now, solving by only allowing one scheduled event per node. Scheduling a new one, or calling `Node::enable()` / `Node::disable()`, will cancel the previously scheduled event. Can think about a scheme in the future for allowing multiple events to be scheduled, which would require a more intricate system that what is currently in place.

Deprecated the old `Context::schedule()` method, as there is now a `scheduleEvent()` and `cancelEvent()` pair.