### PR TITLE
Fix warnings

### DIFF
--- a/include/cinder/app/msw/AppMsw.h
+++ b/include/cinder/app/msw/AppMsw.h
@@ -109,12 +109,12 @@ void AppMsw::main( const RendererRef &defaultRenderer, const char *title, const 
 	AppBase::cleanupLaunch();
 }
 
-#define CINDER_APP_MSW( APP, RENDERER, ... )													\
-int __stdcall WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow )\
-{																									\
-	cinder::app::RendererRef renderer( new RENDERER );												\
-	cinder::app::AppMsw::main<APP>( renderer, #APP, ##__VA_ARGS__ );							\
-	return 0;																						\
+#define CINDER_APP_MSW( APP, RENDERER, ... )                                                                        \
+int __stdcall WinMain( HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /*lpCmdLine*/, int /*nCmdShow*/ )\
+{                                                                                                                   \
+    cinder::app::RendererRef renderer( new RENDERER );                                                              \
+    cinder::app::AppMsw::main<APP>( renderer, #APP, ##__VA_ARGS__ );                                                \
+    return 0;                                                                                                       \
 }
 
 } } // namespace cinder::app

--- a/src/cinder/Font.cpp
+++ b/src/cinder/Font.cpp
@@ -292,12 +292,12 @@ FontManager* FontManager::instance()
 	if( ! FontManager::sInstance ) {
 		FontManager::sInstance =  new FontManager();
 	}
-	
+
 	return sInstance;
 }
 
 #if defined( CINDER_MSW_DESKTOP )
-int CALLBACK EnumFontFamiliesExProc( ENUMLOGFONTEX *lpelfe, NEWTEXTMETRICEX *lpntme, int FontType, LPARAM lParam )
+int CALLBACK EnumFontFamiliesExProc( ENUMLOGFONTEX *lpelfe, NEWTEXTMETRICEX * /*lpntme*/, int /*FontType*/, LPARAM lParam )
 {
 	reinterpret_cast<vector<string>*>( lParam )->push_back( toUtf8( (char16_t*)lpelfe->elfFullName ) );
 	return 1;

--- a/src/cinder/Ray.cpp
+++ b/src/cinder/Ray.cpp
@@ -30,8 +30,8 @@ bool Ray::calcTriangleIntersection( const vec3 &vert0, const vec3 &vert1, const 
 	vec3 edge1, edge2, tvec, pvec, qvec;
 	float det;
 	float u, v;
-	const float EPSILON = 0.000001f;
-	
+	const float epsilon = 0.000001f;
+
 	edge1 = vert1 - vert0;
 	edge2 = vert2 - vert0;
 	
@@ -39,7 +39,7 @@ bool Ray::calcTriangleIntersection( const vec3 &vert0, const vec3 &vert1, const 
 	det = dot( edge1, pvec );
 	
 #if 0 // we don't want to backface cull
-	if ( det < EPSILON )
+	if ( det < epsilon)
 		  return false;
 	tvec = getOrigin() - vert0;
 	
@@ -55,7 +55,7 @@ bool Ray::calcTriangleIntersection( const vec3 &vert0, const vec3 &vert1, const 
 	*result = dot( edge2, qvec ) / det;
 	return true;
 #else
-	if( det > -EPSILON && det < EPSILON )
+	if( det > -epsilon && det < epsilon)
 		return false;
 
 	float inv_det = 1.0f / det;


### PR DESCRIPTION
- Unused parameters in the CINDER_APP macro are causing unused parameter warnings on msvc on W4
- Local variable name EPSILON clashes with global `#define EPSILON EPSILON_VALUE` 