### PR TITLE
Fixed outdated link to git guide

### DIFF
--- a/docs/htmlsrc/guides/windows-setup/index.html
+++ b/docs/htmlsrc/guides/windows-setup/index.html
@@ -36,7 +36,7 @@
             <p>The first step is to install Visual C++ itself - click the <em>Download Community Free</em> button on the <a href="https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx">Visual Studio download page</a>. Next, launch the installer. Make sure that the Visual C++ option is selected under <em>Programming Languages</em> and press the <em>Install</em> button.
             </p>
 
-            <p>If you are using one of our <a href="https://libcinder.org/download">packaged releases</a>, you should be all set. If you're working from GitHub you'll want to follow the build instructions in our <a href="GitSetup.html">Cinder + Git</a> guide.</p>
+            <p>If you are using one of our <a href="https://libcinder.org/download">packaged releases</a>, you should be all set. If you're working from GitHub you'll want to follow the build instructions in our <a href="../git/index.html">Cinder + Git</a> guide.</p>
             
             <p>To verify your installation, try opening and building one of the samples. From Windows Explorer, navigate to the <em>cinder\samples\_opengl\CubeMapping\vc2013</em> folder and open <em>CubeMapping.sln</em>.</p>
             
@@ -57,7 +57,7 @@
 
         <section>    
         <h2>Cinder + Git</h2>
-            <p>If you would like to keep up with the latest Cinder development, the project is <a href="https://github.com/cinder">hosted on GitHub</a>. A guide for setting up Cinder using git is <a href="GitSetup.html">available here</a>.</p>
+            <p>If you would like to keep up with the latest Cinder development, the project is <a href="https://github.com/cinder">hosted on GitHub</a>. A guide for setting up Cinder using git is <a href="../git/index.html">available here</a>.</p>
         </section>
 
         <script type="text/javascript" src="../_common/js/jquery-1.4.2.min.js"></script>


### PR DESCRIPTION
As noted here: http://discourse.libcinder.org/t/links-to-cinder-git-broken-in-windows-setup-page/869