### PR TITLE
MSW audio: Gracefully handle unplugged device

### DIFF
--- a/include/cinder/audio/msw/ContextWasapi.h
+++ b/include/cinder/audio/msw/ContextWasapi.h
@@ -36,7 +36,7 @@ struct WasapiCaptureClientImpl;
 class OutputDeviceNodeWasapi : public OutputDeviceNode {
   public:
 	OutputDeviceNodeWasapi( const DeviceRef &device, const Format &format );
-
+	~OutputDeviceNodeWasapi();
 protected:
 	void initialize()				override;
 	void uninitialize()				override;
@@ -49,10 +49,6 @@ protected:
 
 	std::unique_ptr<WasapiRenderClientImpl>		mRenderImpl;
 	BufferInterleaved							mInterleavedBuffer;
-
-	// For managing a disconnected device
-	ci::signals::ConnectionList					mConnections;
-	bool										mWasEnabledBeforeDisconnection = false;
 
 	friend WasapiRenderClientImpl;
 };

--- a/include/cinder/audio/msw/ContextWasapi.h
+++ b/include/cinder/audio/msw/ContextWasapi.h
@@ -50,6 +50,10 @@ protected:
 	std::unique_ptr<WasapiRenderClientImpl>		mRenderImpl;
 	BufferInterleaved							mInterleavedBuffer;
 
+	// For managing a disconnected device
+	ci::signals::ConnectionList					mConnections;
+	bool										mWasEnabledBeforeDisconnection = false;
+
 	friend WasapiRenderClientImpl;
 };
 

--- a/include/cinder/audio/msw/DeviceManagerWasapi.h
+++ b/include/cinder/audio/msw/DeviceManagerWasapi.h
@@ -36,6 +36,9 @@ namespace cinder { namespace audio { namespace msw {
 
 class DeviceManagerWasapi : public DeviceManager {
   public:
+	  DeviceManagerWasapi();
+	~DeviceManagerWasapi();
+
 	DeviceRef getDefaultOutput() override;
 	DeviceRef getDefaultInput() override;
 
@@ -60,7 +63,7 @@ class DeviceManagerWasapi : public DeviceManager {
 		  std::string mKey;						//! mKey used by Device to get more info from manager
 		  std::string mName;						//! friendly mName
 		  enum Usage { INPUT, OUTPUT } mUsage;
-		  std::wstring			mDeviceId;		//! id used when creating XAudio2 master voice
+		  std::wstring			mDeviceId;		//! id used when creating XAudio2 master voice. // TODO: still needed? We no longer support xaudio2
 		  std::wstring			mEndpointId;		//! id used by Wasapi / MMDevice
 		  size_t mNumChannels, mSampleRate, mFramesPerBlock;
 	  };
@@ -70,6 +73,9 @@ class DeviceManagerWasapi : public DeviceManager {
 	  std::vector<std::wstring> parseDeviceIds( DeviceInfo::Usage usage );
 
 	  std::map<DeviceRef, DeviceInfo> mDeviceInfoSet;
+
+	  struct Impl;
+	  std::unique_ptr<Impl> mImpl;
 };
 
 } } } // namespace cinder::audio::msw

--- a/include/cinder/audio/msw/DeviceManagerWasapi.h
+++ b/include/cinder/audio/msw/DeviceManagerWasapi.h
@@ -68,10 +68,12 @@ class DeviceManagerWasapi : public DeviceManager {
 		  enum Usage { INPUT, OUTPUT } mUsage;
 		  std::wstring			mDeviceId;		//! id used when creating XAudio2 master voice. // TODO: still needed? We no longer support xaudio2
 		  std::wstring			mEndpointId;		//! id used by Wasapi / MMDevice
+		  unsigned long			mState;
 		  size_t mNumChannels, mSampleRate, mFramesPerBlock;
 	  };
 
 	  DeviceInfo& getDeviceInfo( const DeviceRef &device );
+	  void rebuildDeviceInfoSet();
 	  void parseDevices( DeviceInfo::Usage usage );
 	  std::vector<std::wstring> parseDeviceIds( DeviceInfo::Usage usage );
 

--- a/include/cinder/audio/msw/DeviceManagerWasapi.h
+++ b/include/cinder/audio/msw/DeviceManagerWasapi.h
@@ -57,6 +57,9 @@ class DeviceManagerWasapi : public DeviceManager {
 
 	std::shared_ptr<::IMMDevice> getIMMDevice( const DeviceRef &device );
 
+	ci::signals::Signal<void ( const DeviceRef &device )>&	getSignalDeviceActivated()		{ return mSignalDeviceActivated; }
+	ci::signals::Signal<void ( const DeviceRef &device )>&	getSignalDeviceDeactivated()	{ return mSignalDeviceDeactivated; }
+
   private:
 
 	  struct DeviceInfo {
@@ -76,6 +79,10 @@ class DeviceManagerWasapi : public DeviceManager {
 
 	  struct Impl;
 	  std::unique_ptr<Impl> mImpl;
+
+	  // TODO: integrate this with default device (re)connection work
+	  // - this is a temporary solution to allow wasapi audio devices to reconnect, for example if a mic cable is temporarily unplugged
+	  ci::signals::Signal<void ( const DeviceRef &device )>		mSignalDeviceActivated, mSignalDeviceDeactivated;
 };
 
 } } } // namespace cinder::audio::msw

--- a/include/cinder/audio/msw/DeviceManagerWasapi.h
+++ b/include/cinder/audio/msw/DeviceManagerWasapi.h
@@ -57,11 +57,8 @@ class DeviceManagerWasapi : public DeviceManager {
 
 	std::shared_ptr<::IMMDevice> getIMMDevice( const DeviceRef &device );
 
-	ci::signals::Signal<void ( const DeviceRef &device )>&	getSignalDeviceActivated()		{ return mSignalDeviceActivated; }
-	ci::signals::Signal<void ( const DeviceRef &device )>&	getSignalDeviceDeactivated()	{ return mSignalDeviceDeactivated; }
-
   private:
-
+	  // TODO: fix formatting
 	  struct DeviceInfo {
 		  std::string mKey;						//! mKey used by Device to get more info from manager
 		  std::string mName;						//! friendly mName
@@ -81,10 +78,6 @@ class DeviceManagerWasapi : public DeviceManager {
 
 	  struct Impl;
 	  std::unique_ptr<Impl> mImpl;
-
-	  // TODO: integrate this with default device (re)connection work
-	  // - this is a temporary solution to allow wasapi audio devices to reconnect, for example if a mic cable is temporarily unplugged
-	  ci::signals::Signal<void ( const DeviceRef &device )>		mSignalDeviceActivated, mSignalDeviceDeactivated;
 };
 
 } } } // namespace cinder::audio::msw

--- a/src/cinder/audio/msw/ContextWasapi.cpp
+++ b/src/cinder/audio/msw/ContextWasapi.cpp
@@ -300,7 +300,16 @@ void WasapiRenderClientImpl::renderAudio()
 	// the current padding represents the number of frames queued on the audio endpoint, waiting to be sent to hardware.
 	UINT32 numFramesPadding;
 	HRESULT hr = mAudioClient->GetCurrentPadding( &numFramesPadding );
-	CI_ASSERT( hr == S_OK );
+	//CI_ASSERT( hr == S_OK );
+	if( hr == AUDCLNT_E_DEVICE_INVALIDATED ) {
+		// TODO: need to handle reconnecting
+		CI_LOG_W( "mAudioClient->GetCurrentPadding() returned AUDCLNT_E_DEVICE_INVALIDATED, returning" );
+		return;
+	}
+	else {
+		//ASSERT_HR_OK( hr );
+		CI_ASSERT( hr == S_OK );
+	}
 
 	size_t numWriteFramesAvailable = mAudioClientNumFrames - numFramesPadding;
 
@@ -388,7 +397,16 @@ void WasapiCaptureClientImpl::captureAudio()
 {
 	UINT32 numPacketFrames;
 	HRESULT hr = mCaptureClient->GetNextPacketSize( &numPacketFrames );
-	CI_ASSERT( hr == S_OK );
+	if( hr == AUDCLNT_E_DEVICE_INVALIDATED ) {
+		// TODO: need to handle reconnecting
+		CI_LOG_W( "mCaptureClient->GetNextPacketSize() returned AUDCLNT_E_DEVICE_INVALIDATED, returning" );
+		return;
+	}
+	else {
+		//ASSERT_HR_OK( hr );
+		CI_ASSERT( hr == S_OK );
+	}
+
 
 	while( numPacketFrames ) {
 		if( numPacketFrames > ( mMaxReadFrames - mNumFramesBuffered ) ) {

--- a/src/cinder/audio/msw/DeviceManagerWasapi.cpp
+++ b/src/cinder/audio/msw/DeviceManagerWasapi.cpp
@@ -480,36 +480,15 @@ STDMETHODIMP DeviceManagerWasapi::Impl::OnDeviceStateChanged( LPCWSTR device_id,
 	}
 
 	device = getDevice( device_id );
-	CI_ASSERT( device );
-
-	string devName = ( (bool)device ? device->getName() : "(null)" );
+	string devName = ( (bool)device ? device->getName() : "(???)" );
 	CI_LOG_I( "State changed to " << stateStr << " for device: " << devName );
-
-	// Dispatch signals on the main thread.
-	auto app = app::App::get();
-	if( app && device ) {
-		app->dispatchAsync(
-			[this, device, new_state] {
-				if( new_state == DEVICE_STATE_ACTIVE ) {
-					mParent->mSignalDeviceActivated.emit( device );
-				}
-				else {
-					// All other states fall into 'device won't work right now' category
-					mParent->mSignalDeviceDeactivated.emit( device );
-				}
-			}
-		);
-	}
-	else {
-		// TODO: this needs to support app-less situations too
-		CI_LOG_W( "No app, cannot dispatch signal for new device state." );
-	}
 
 	return S_OK;
 }
 
 HRESULT DeviceManagerWasapi::Impl::OnDefaultDeviceChanged( EDataFlow flow, ERole role, LPCWSTR new_default_device_id )
 {
+#if 0
 	auto devName = getDevice( new_default_device_id )->getName();
 	
 	CI_LOG_I( "device name: " << devName << ", flow: " << deviceFlowToStr( flow ) << ", role: " << deviceRoloToStr( role ) );
@@ -521,7 +500,6 @@ HRESULT DeviceManagerWasapi::Impl::OnDefaultDeviceChanged( EDataFlow flow, ERole
 		return E_FAIL;
 	}
 
-#if 0
 	// TODO: if playing with a default device and user changes it, update to new default
 	if( flow == eRender && role == device_role_ ) {
 		// Initiate a stream switch if not already initiated by signaling the


### PR DESCRIPTION
In current master branch, your app will crash if the audio device being used on windows gets unplugged or disabled (originally reported in https://github.com/cinder/Cinder/issues/784). These changes will avoid that crash, and log to the console that the device was invalidated, along with which devices are connected / disconnected.

In order to play audio again, you will have to manually re-initialize the `audio::Context`'s `OutputDeviceNode`.  You can do this simply with:

```
ci::audio::master()->setOutput( ctx->createOutputDeviceNode() );
```

This is a temporary fix. The way I'd like to ultimately handle this is more involved, and parallels the work I began on OS X for keeping in sync with the system's default device. I plan to revisit that shortly, with a unified approach for both mac and windows, but I'd like to get this crash fix in first.