### PR TITLE
fix FilePlayerNode::initialize() when there is no source yet

### DIFF
--- a/src/cinder/audio/SamplePlayerNode.cpp
+++ b/src/cinder/audio/SamplePlayerNode.cpp
@@ -248,17 +248,17 @@ void FilePlayerNode::initialize()
 			mSourceFile = mSourceFile->cloneWithSampleRate( sampleRate );
 
 		mNumFrames = mSourceFile->getNumFrames();
+
+		mIoBuffer.setSize( mSourceFile->getMaxFramesPerRead(), getNumChannels() );
+
+		for( size_t i = 0; i < getNumChannels(); i++ )
+			mRingBuffers.emplace_back( mSourceFile->getMaxFramesPerRead() * mRingBufferPaddingFactor );
+
+		mBufferFramesThreshold = mRingBuffers[0].getSize() / 2;
 	}
 
 	if( ! mLoopEnd  || mLoopEnd > mNumFrames )
 		mLoopEnd = mNumFrames;
-
-	mIoBuffer.setSize( mSourceFile->getMaxFramesPerRead(), getNumChannels() );
-
-	for( size_t i = 0; i < getNumChannels(); i++ )
-		mRingBuffers.emplace_back( mSourceFile->getMaxFramesPerRead() * mRingBufferPaddingFactor );
-
-	mBufferFramesThreshold = mRingBuffers[0].getSize() / 2;
 
 	if( mIsReadAsync ) {
 		mAsyncReadShouldQuit = false;
@@ -269,6 +269,7 @@ void FilePlayerNode::initialize()
 void FilePlayerNode::uninitialize()
 {
 	destroyReadThreadImpl();
+	mRingBuffers.clear();
 }
 
 void FilePlayerNode::enableProcessing()


### PR DESCRIPTION
This can happen when you're loading an `audio::SourceFile` async, or in my case, when the source file fails to load. Beforehand, the `initialize()` method would crash.