### PR TITLE
Allow user to set platform toolset

### DIFF
--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -29,7 +29,7 @@ target_compile_definitions( cinder PUBLIC ${CINDER_DEFINES} )
 # Visual Studio and Xcode generators adds a ${CMAKE_BUILD_TYPE} to the ARCHIVE 
 # and LIBRARY directories. Override the directories so, ${CMAKE_BUILD_TYPE} doesn't double up.
 if( CINDER_MSW )
-	set( PLATFORM_TOOLSET "$(PlatformToolset)" )
+	set( PLATFORM_TOOLSET "$(PlatformToolset)" CACHE STRING "Visual Studio Toolset Version" )
 	if( NOT ( "${CMAKE_GENERATOR}" MATCHES "Visual Studio.+" ) )
 		# Assume Visual Studio 2015
 		set( PLATFORM_TOOLSET "v140" )


### PR DESCRIPTION
Fixes #1910

Without specifying PLATFORM_TOOLSET as a cache variable, there is no way to set it when configuring. This change allows the user to set the MSVC toolset like this:

```
cmake.exe -G"Visual Studio 14 2015 Win64" -DPLATFORM_TOOLSET=v140 ..
```