### PR TITLE
split string without boost

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -47,9 +47,9 @@ CI_API fs::path getDocumentsDirectory();
 CI_API void launchWebBrowser( const Url &url );
 	
 //! Returns a vector of substrings split by the separator \a separator. <tt>split( "one two three", ' ' ) -> [ "one", "two", "three" ]</tt> If \a compress is TRUE, it will consider consecutive separators as one.
-CI_API std::vector<std::string> split(const std::string& str, char separator, bool compress = true );
+CI_API std::vector<std::string> split(const std::string &str, char separator, bool compress = true );
 //! Returns a vector of substrings split by the characters in \a separators. <tt>split( "one, two, three", " ," ) -> [ "one", "two", "three" ]</tt> If \a compress is TRUE, it will consider consecutive separators as one.
-CI_API std::vector<std::string> split(const std::string& str, const std::string &separators, bool compress = true );
+CI_API std::vector<std::string> split(const std::string &str, const std::string &separators, bool compress = true );
 
 //! Loads the contents of \a dataSource and returns it as a std::string
 CI_API std::string loadString( const DataSourceRef &dataSource );

--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -47,9 +47,9 @@ CI_API fs::path getDocumentsDirectory();
 CI_API void launchWebBrowser( const Url &url );
 	
 //! Returns a vector of substrings split by the separator \a separator. <tt>split( "one two three", ' ' ) -> [ "one", "two", "three" ]</tt> If \a compress is TRUE, it will consider consecutive separators as one.
-CI_API std::vector<std::string> split( const std::string &str, char separator, bool compress = true );
+CI_API std::vector<std::string> split(std::string str, char separator, bool compress = true );
 //! Returns a vector of substrings split by the characters in \a separators. <tt>split( "one, two, three", " ," ) -> [ "one", "two", "three" ]</tt> If \a compress is TRUE, it will consider consecutive separators as one.
-CI_API std::vector<std::string> split( const std::string &str, const std::string &separators, bool compress = true );
+CI_API std::vector<std::string> split(std::string str, const std::string &separators, bool compress = true );
 
 //! Loads the contents of \a dataSource and returns it as a std::string
 CI_API std::string loadString( const DataSourceRef &dataSource );

--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -47,9 +47,9 @@ CI_API fs::path getDocumentsDirectory();
 CI_API void launchWebBrowser( const Url &url );
 	
 //! Returns a vector of substrings split by the separator \a separator. <tt>split( "one two three", ' ' ) -> [ "one", "two", "three" ]</tt> If \a compress is TRUE, it will consider consecutive separators as one.
-CI_API std::vector<std::string> split(std::string str, char separator, bool compress = true );
+CI_API std::vector<std::string> split(const std::string& str, char separator, bool compress = true );
 //! Returns a vector of substrings split by the characters in \a separators. <tt>split( "one, two, three", " ," ) -> [ "one", "two", "three" ]</tt> If \a compress is TRUE, it will consider consecutive separators as one.
-CI_API std::vector<std::string> split(std::string str, const std::string &separators, bool compress = true );
+CI_API std::vector<std::string> split(const std::string& str, const std::string &separators, bool compress = true );
 
 //! Loads the contents of \a dataSource and returns it as a std::string
 CI_API std::string loadString( const DataSourceRef &dataSource );

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -65,18 +65,16 @@ std::map<std::string, std::string> getEnvironmentVariables()
 	return app::Platform::get()->getEnvironmentVariables();
 }
 
-std::vector<std::string> split(const std::string& str, char separator, bool compress )
+std::vector<std::string> split(const std::string &str, char separator, bool compress )
 {
 	return split( str, string( 1, separator ), compress );
 }
 
-std::vector<std::string> split(const std::string& str, const std::string &separators, bool compress )
+std::vector<std::string> split(const std::string &str, const std::string &separators, bool compress )
 {
 	std::vector<std::string> result;
 	
-	
 	std::size_t searchPrevPos = 0, searchPos;
-	
 	while ((searchPos = str.find_first_of( separators, searchPrevPos )) != std::string::npos)
 	{
 		

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -76,10 +76,13 @@ std::vector<std::string> split(std::string str, const std::string &separators, b
 	
 	
 	std::size_t searchPrevPos = 0, searchPos;
+	
 	while ((searchPos = str.find_first_of(separators, searchPrevPos)) != std::string::npos)
 	{
-		if (searchPos >= searchPrevPos && !compress)
-			result.push_back(str.substr(searchPrevPos, searchPos - searchPrevPos + 1));
+		
+		if (searchPos >= searchPrevPos && !compress){
+			result.push_back(str.substr(searchPrevPos, searchPos - searchPrevPos));
+		}
 		else if(searchPos > searchPrevPos){
 			result.push_back(str.substr(searchPrevPos, searchPos - searchPrevPos));
 		}
@@ -87,9 +90,8 @@ std::vector<std::string> split(std::string str, const std::string &separators, b
 		searchPrevPos = searchPos+1;
 	}
 	
-	if (searchPrevPos < str.length()){
+	if (searchPrevPos <= str.length())
 		result.push_back(str.substr(searchPrevPos, std::string::npos));
-	}
 	
 	return result;
 }

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -77,21 +77,21 @@ std::vector<std::string> split(std::string str, const std::string &separators, b
 	
 	std::size_t searchPrevPos = 0, searchPos;
 	
-	while ((searchPos = str.find_first_of(separators, searchPrevPos)) != std::string::npos)
+	while ((searchPos = str.find_first_of( separators, searchPrevPos )) != std::string::npos)
 	{
 		
-		if (searchPos >= searchPrevPos && !compress){
-			result.push_back(str.substr(searchPrevPos, searchPos - searchPrevPos));
+		if ( searchPos >= searchPrevPos && ! compress ){
+			result.push_back( str.substr( searchPrevPos, searchPos - searchPrevPos ));
 		}
-		else if(searchPos > searchPrevPos){
-			result.push_back(str.substr(searchPrevPos, searchPos - searchPrevPos));
+		else if( searchPos > searchPrevPos ){
+			result.push_back( str.substr( searchPrevPos, searchPos - searchPrevPos ));
 		}
 		
 		searchPrevPos = searchPos+1;
 	}
 	
 	if (searchPrevPos <= str.length())
-		result.push_back(str.substr(searchPrevPos, std::string::npos));
+		result.push_back( str.substr( searchPrevPos, std::string::npos ));
 	
 	return result;
 }

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -33,8 +33,6 @@
 
 #include <vector>
 #include <fstream>
-#include <boost/tokenizer.hpp>
-#include <boost/algorithm/string.hpp>
 
 using std::vector;
 using std::string;
@@ -67,18 +65,32 @@ std::map<std::string, std::string> getEnvironmentVariables()
 	return app::Platform::get()->getEnvironmentVariables();
 }
 
-std::vector<std::string> split( const std::string &str, char separator, bool compress )
+std::vector<std::string> split(std::string str, char separator, bool compress )
 {
 	return split( str, string( 1, separator ), compress );
 }
 
-std::vector<std::string> split( const std::string &str, const std::string &separators, bool compress )
+std::vector<std::string> split(std::string str, const std::string &separators, bool compress )
 {
-	vector<string> result;
-
-	boost::algorithm::split( result, str, boost::is_any_of(separators),
-		compress ? boost::token_compress_on : boost::token_compress_off );
-
+	std::vector<std::string> result;
+	
+	
+	std::size_t searchPrevPos = 0, searchPos;
+	while ((searchPos = str.find_first_of(separators, searchPrevPos)) != std::string::npos)
+	{
+		if (searchPos >= searchPrevPos && !compress)
+			result.push_back(str.substr(searchPrevPos, searchPos - searchPrevPos + 1));
+		else if(searchPos > searchPrevPos){
+			result.push_back(str.substr(searchPrevPos, searchPos - searchPrevPos));
+		}
+		
+		searchPrevPos = searchPos+1;
+	}
+	
+	if (searchPrevPos < str.length()){
+		result.push_back(str.substr(searchPrevPos, std::string::npos));
+	}
+	
 	return result;
 }
 

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -65,12 +65,12 @@ std::map<std::string, std::string> getEnvironmentVariables()
 	return app::Platform::get()->getEnvironmentVariables();
 }
 
-std::vector<std::string> split(std::string str, char separator, bool compress )
+std::vector<std::string> split(const std::string& str, char separator, bool compress )
 {
 	return split( str, string( 1, separator ), compress );
 }
 
-std::vector<std::string> split(std::string str, const std::string &separators, bool compress )
+std::vector<std::string> split(const std::string& str, const std::string &separators, bool compress )
 {
 	std::vector<std::string> result;
 	

--- a/test/unit/src/Utilities.cpp
+++ b/test/unit/src/Utilities.cpp
@@ -102,4 +102,33 @@ TEST_CASE( "Utilities" )
 		REQUIRE( str1.size() == str2.size() );
 		REQUIRE( str1 == str2 );
 	}
+    
+    SECTION( "split string " )
+    {
+        // one separator type
+        string str1 = "one two three four";
+        std::vector<string> resultStr1{"one", "two", "three", "four"};
+        REQUIRE( ci::split(str1, ' ', false) == resultStr1 );
+        
+        // multiple separators
+        string str2 = "one,two---three four";
+        std::vector<string> resultStr2{"one", "two", "", "", "three", "four"};
+        REQUIRE( ci::split(str2, ",- ", false) == resultStr2 );
+        
+        
+        // one separator, compress = true
+        string str3 = "one,two,three,four";
+        std::vector<string> resultStr3{"one", "two", "three", "four"};
+        REQUIRE( ci::split(str3, ',', true) == resultStr3 );
+        
+        
+        // multiple separators, compress = true
+        string str4 = "one,two---three four";
+        std::vector<string> resultStr4{"one", "two", "three", "four"};
+        REQUIRE( ci::split(str4, ",- ", true) == resultStr4 );
+        
+    }
+    
+
+    
 }


### PR DESCRIPTION
As requested in here:
http://discourse.libcinder.org/t/request-for-contribution/892

Some observations:
1. When using **_compress = true_**, the current version adds some empty strings to a vector and removes the separator, is that expected?

2. made a little test using this string: "Cinder,OpenFrameworks-- ThreeJs, Processing-";
[link](https://gist.github.com/Hperigo/d991b64a663cb796825377b02047f2ce)

```
Custom impl took: 1.5974e-05
0. 'Cinder' 
1. 'OpenFrameworks' 
2. '' 
3. '' 
4. 'ThreeJs' 
5. '' 
6. 'Processing' 
7. '' 
--------

boost took: 3.79682e-05
0. 'Cinder' 
1. 'OpenFrameworks' 
2. '' 
3. '' 
4. 'ThreeJs' 
5. '' 
6. 'Processing' 
7. '' 
```




