### PR TITLE
Unrolled dependency on boost.preprocess

### DIFF
--- a/src/cinder/Stream.cpp
+++ b/src/cinder/Stream.cpp
@@ -30,7 +30,6 @@
 #include <limits>
 #include <boost/scoped_array.hpp>
 #include <iostream>
-#include <boost/preprocessor/seq/for_each.hpp>
 using std::string;
 
 namespace cinder {
@@ -792,7 +791,7 @@ StreamExc::StreamExc( const std::string &fontName ) throw()
 
 /////////////////////////////////////////////////////////////////////
 
-#define STREAM_PROTOTYPES(r,data,T)\
+#define STREAM_PROTOTYPES(T)\
 	template void OStream::write<T>( T t ); \
 	template void OStream::writeEndian<T>( T t, uint8_t endian ); \
 	template void OStream::writeBig<T>( T t ); \
@@ -802,7 +801,17 @@ StreamExc::StreamExc( const std::string &fontName ) throw()
 	template void IStreamCinder::readBig<T>( T *t ); \
 	template void IStreamCinder::readLittle<T>( T *t );
 
-BOOST_PP_SEQ_FOR_EACH( STREAM_PROTOTYPES, ~, (int8_t)(uint8_t)(int16_t)(uint16_t)(int32_t)(uint32_t)(int64_t)(uint64_t)(float)(double) )
+STREAM_PROTOTYPES(int8_t)
+STREAM_PROTOTYPES(uint8_t)
+STREAM_PROTOTYPES(int16_t)
+STREAM_PROTOTYPES(uint16_t)
+STREAM_PROTOTYPES(int32_t)
+STREAM_PROTOTYPES(uint32_t)
+STREAM_PROTOTYPES(int64_t)
+STREAM_PROTOTYPES(uint64_t)
+STREAM_PROTOTYPES(float)
+STREAM_PROTOTYPES(double)
+
 
 #if defined( CINDER_UWP )
 	#pragma warning(pop) 

--- a/src/cinder/ip/EdgeDetect.cpp
+++ b/src/cinder/ip/EdgeDetect.cpp
@@ -24,8 +24,6 @@
 #include "cinder/Surface.h"
 #include "cinder/CinderMath.h"
 
-#include <boost/preprocessor/seq.hpp>
-
 namespace cinder { namespace ip {
 
 //     X           Y
@@ -87,13 +85,15 @@ void edgeDetectSobel( const SurfaceT<T> &srcSurface, SurfaceT<T> *dstSuface )
 }
 
 
-#define edgeDetect_PROTOTYPES(r,data,T)\
+#define edgeDetect_PROTOTYPES(T)\
 	template CI_API void edgeDetectSobel( const ChannelT<T> &srcChannel, const Area &srcArea, const ivec2 &dstLT, ChannelT<T> *dstChannel ); \
 	template CI_API void edgeDetectSobel( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &dstLT, SurfaceT<T> *dstSurface ); \
 	template CI_API void edgeDetectSobel( const ChannelT<T> &srcChannel, ChannelT<T> *dstChannel );	\
 	template CI_API void edgeDetectSobel( const SurfaceT<T> &srcSurface, SurfaceT<T> *dstSurface );	
 
-BOOST_PP_SEQ_FOR_EACH( edgeDetect_PROTOTYPES, ~, (uint8_t)(uint16_t)(float) )
+edgeDetect_PROTOTYPES(uint8_t)
+edgeDetect_PROTOTYPES(uint16_t)
+edgeDetect_PROTOTYPES(float)
 
 
 } } // namespace cinder::ip

--- a/src/cinder/ip/Fill.cpp
+++ b/src/cinder/ip/Fill.cpp
@@ -22,8 +22,6 @@
 
 #include "cinder/ip/Fill.h"
 
-#include <boost/preprocessor/seq.hpp>
-
 namespace cinder { namespace ip {
 
 template<typename T>
@@ -123,7 +121,7 @@ void fill( ChannelT<T> *channel, T value )
 	fill( channel, value, channel->getBounds() );
 }
 
-#define fill_PROTOTYPES(r,data,T)\
+#define fill_PROTOTYPES(T)\
 	template CI_API void fill<T,uint8_t>( SurfaceT<T> *surface, const ColorT<uint8_t> &color, const Area &area ); \
 	template CI_API void fill<T,uint8_t>( SurfaceT<T> *surface, const ColorT<uint8_t> &color ); \
 	template CI_API void fill<T,uint8_t>( SurfaceT<T> *surface, const ColorAT<uint8_t> &color, const Area &area ); \
@@ -139,7 +137,8 @@ void fill( ChannelT<T> *channel, T value )
 	template CI_API void fill<T>( ChannelT<T> *channel, const T value, const Area &area ); \
 	template CI_API void fill<T>( ChannelT<T> *channel, const T value );
 
-BOOST_PP_SEQ_FOR_EACH( fill_PROTOTYPES, ~, (uint8_t)(uint16_t)(float) )
-
+fill_PROTOTYPES(uint8_t)
+fill_PROTOTYPES(uint16_t)
+fill_PROTOTYPES(float)
 
 } } // namespace cinder::ip

--- a/src/cinder/ip/Flip.cpp
+++ b/src/cinder/ip/Flip.cpp
@@ -22,8 +22,6 @@
 
 #include "cinder/ip/Flip.h"
 
-#include <boost/preprocessor/seq.hpp>
-
 using namespace std;
 
 namespace cinder { namespace ip {
@@ -216,12 +214,15 @@ void flipHorizontal( SurfaceT<T> *surface )
 	}
 }
 
-#define flip_PROTOTYPES(r,data,T)\
+#define flip_PROTOTYPES(T)\
 	template CI_API void flipVertical<T>( SurfaceT<T> *surface );\
 	template CI_API void flipVertical<T>( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface );\
 	template CI_API void flipVertical<T>( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel );\
 	template CI_API void flipHorizontal<T>( SurfaceT<T> *surface );
 	
-BOOST_PP_SEQ_FOR_EACH( flip_PROTOTYPES, ~, (uint8_t)(uint16_t)(float) )
+	
+flip_PROTOTYPES(uint8_t)
+flip_PROTOTYPES(uint16_t)
+flip_PROTOTYPES(float)
 
 } } // namespace cinder::ip

--- a/src/cinder/ip/Grayscale.cpp
+++ b/src/cinder/ip/Grayscale.cpp
@@ -23,9 +23,6 @@
 #include "cinder/ip/Grayscale.h"
 #include "cinder/ChanTraits.h"
 
-#include <boost/preprocessor/seq.hpp>
-
-
 namespace cinder { namespace ip {
 
 template<typename T>
@@ -91,12 +88,14 @@ void grayscale( const Surface8u &srcSurface, Channel8u *dstChannel )
 	}
 }
 
-#define grayscale_PROTOTYPES(r,data,T)\
+#define grayscale_PROTOTYPES(T)\
 	template CI_API void grayscale( const SurfaceT<T> &srcSurface, SurfaceT<T> *dstSurface );
 	
 template CI_API void grayscale( const SurfaceT<float> &srcSurface, ChannelT<float> *dstChannel );
 
-BOOST_PP_SEQ_FOR_EACH( grayscale_PROTOTYPES, ~, CHANNEL_TYPES )
+// These should match CHANNEL_TYPES
+grayscale_PROTOTYPES(uint8_t)
+grayscale_PROTOTYPES(float)
 
 
 } } // namespace cinder::ip

--- a/src/cinder/ip/Resize.cpp
+++ b/src/cinder/ip/Resize.cpp
@@ -34,7 +34,6 @@ using std::unique_ptr;
 #include <limits>
 #include <fstream>
 #include <algorithm>
-#include <boost/preprocessor/seq.hpp>
 
 namespace cinder { namespace ip {
 
@@ -360,13 +359,15 @@ void resize( const ChannelT<T> &srcChannel, ChannelT<T> *dstChannel, const Filte
 	resize( srcChannel, srcChannel.getBounds(), dstChannel, dstChannel->getBounds(), filter );
 }
 
-#define resize_PROTOTYPES(r,data,T)\
+#define resize_PROTOTYPES(T)\
 	template CI_API void resize( const SurfaceT<T> &srcSurface, SurfaceT<T> *dstSurface, const FilterBase &filter ); \
 	template CI_API void resize( const SurfaceT<T> &srcSurface, const Area &srcArea, SurfaceT<T> *dstSurface, const Area &dstArea, const FilterBase &filter ); \
 	template CI_API void resize( const ChannelT<T> &srcChannel, ChannelT<T> *dstChannel, const FilterBase &filter ); \
 	template CI_API SurfaceT<T> resizeCopy( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter ); \
 	template CI_API void resize( const ChannelT<T> &srcChannel, const Area &srcArea, ChannelT<T> *dstChannel, const Area &dstArea, const FilterBase &filter );
 
-BOOST_PP_SEQ_FOR_EACH( resize_PROTOTYPES, ~, CHANNEL_TYPES )
+// These should match CHANNEL_TYPES
+resize_PROTOTYPES(uint8_t)
+resize_PROTOTYPES(float)
 
 } } // namespace cinder::ip

--- a/src/cinder/ip/Threshold.cpp
+++ b/src/cinder/ip/Threshold.cpp
@@ -24,8 +24,6 @@
 #include "cinder/ChanTraits.h"
 
 #include <stdlib.h>
-#include <boost/preprocessor/seq.hpp>
-
 
 namespace cinder { namespace ip {
 
@@ -351,7 +349,7 @@ void AdaptiveThresholdT<T>::calculate( int32_t windowSize, float percentageDelta
 template class CI_API AdaptiveThresholdT<uint8_t>;
 template class CI_API AdaptiveThresholdT<float>;
 
-#define threshold_PROTOTYPES(r,data,T)\
+#define threshold_PROTOTYPES(T)\
 	template CI_API void threshold( SurfaceT<T> *surface, T value ); \
 	template CI_API void threshold( SurfaceT<T> *surface, T value, const Area &area ); \
 	template CI_API void threshold( const SurfaceT<T> &srcSurface, T value, SurfaceT<T> *dstSurface );\
@@ -361,7 +359,6 @@ template class CI_API AdaptiveThresholdT<float>;
 	template CI_API void adaptiveThresholdZero( ChannelT<T> *channel, int32_t windowSize ); \
 	template CI_API void adaptiveThresholdZero( const ChannelT<T> &srcChannel, int32_t windowSize, ChannelT<T> *dstChannel );
 
-BOOST_PP_SEQ_FOR_EACH( threshold_PROTOTYPES, ~, (uint8_t) )
-
+threshold_PROTOTYPES(uint8_t)
 
 } } // namespace cinder::ip

--- a/src/cinder/ip/Trim.cpp
+++ b/src/cinder/ip/Trim.cpp
@@ -21,8 +21,6 @@
 */
 
 #include "cinder/ip/Trim.h"
-
-#include <boost/preprocessor/seq.hpp>
 #include <algorithm>
 
 namespace cinder { namespace ip {
@@ -92,9 +90,11 @@ Area findNonTransparentArea( const SurfaceT<T> &surface, const Area &unclippedBo
 	return Area( leftColumn, topLine, rightColumn, bottomLine );
 }
 
-#define TRIM_PROTOTYPES(r,data,T)\
+#define TRIM_PROTOTYPES(T)\
 	template CI_API Area findNonTransparentArea( const SurfaceT<T> &surface, const Area &unclippedBounds );
 
-BOOST_PP_SEQ_FOR_EACH( TRIM_PROTOTYPES, ~, CHANNEL_TYPES )
+// These should match CHANNEL_TYPES
+TRIM_PROTOTYPES(uint8_t)
+TRIM_PROTOTYPES(float)
 
 } } // namespace cinder::ip


### PR DESCRIPTION
Removed the dependency on `BOOST_PP_*`, but using @vinjn's advice to keep the original macros