### PR TITLE
setThreadName()

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -87,6 +87,9 @@ inline double fromString( const std::string &s ) { return atof( s.c_str() ); }
 //! Returns a stack trace (aka backtrace) where \c stackTrace()[0] == caller, \c stackTrace()[1] == caller's parent, etc
 CI_API std::vector<std::string> stackTrace();
 
+//! Sets the name of the current thread to \a name
+CI_API void setThreadName( const std::string &name );
+
 // ENDIANNESS
 CI_API inline int8_t	swapEndian( int8_t val ) { return val; }
 CI_API inline uint8_t	swapEndian( uint8_t val ) { return val; }

--- a/include/cinder/app/Platform.h
+++ b/include/cinder/app/Platform.h
@@ -129,6 +129,9 @@ class CI_API Platform {
 	//! Returns a stack trace (aka backtrace) where \c stackTrace()[0] == caller, \c stackTrace()[1] == caller's parent, etc
 	virtual std::vector<std::string>		stackTrace() = 0;
 
+	//! Sets the name of the current thread to \a name
+	virtual void setThreadName( const std::string &name ) = 0;
+
 	//! Returns a std::vector of Displays connected to the system.
 	virtual const std::vector<DisplayRef>&	getDisplays() = 0;
 

--- a/include/cinder/app/cocoa/PlatformCocoa.h
+++ b/include/cinder/app/cocoa/PlatformCocoa.h
@@ -95,6 +95,8 @@ class PlatformCocoa : public Platform {
 	void launchWebBrowser( const Url &url ) override;
 
 	std::vector<std::string>		stackTrace() override;
+
+	void							setThreadName( const std::string &name ) override;
 	
 	const std::vector<DisplayRef>& getDisplays() override;
 

--- a/include/cinder/app/linux/PlatformLinux.h
+++ b/include/cinder/app/linux/PlatformLinux.h
@@ -62,6 +62,9 @@ class PlatformLinux : public Platform {
 	virtual void 					launchWebBrowser( const Url &url ) override;
 
 	virtual std::vector<std::string>		stackTrace() override;
+
+	void setThreadName( const std::string &name ) override;
+
 	virtual const std::vector<DisplayRef>&	getDisplays() override;
 
 	//! Returns the Display which corresponds to a GLFWmonitor \a monitor. Returns main display on failure.

--- a/include/cinder/app/msw/PlatformMsw.h
+++ b/include/cinder/app/msw/PlatformMsw.h
@@ -61,6 +61,8 @@ class CI_API PlatformMsw : public Platform {
 
 	std::vector<std::string>	stackTrace() override;
 
+	void setThreadName( const std::string &name ) override;
+
 	const std::vector<DisplayRef>&	getDisplays() override;
 	void							refreshDisplays();
 	//! Returns the Display which corresponds to \a hMonitor. Returns main display on failure.

--- a/include/cinder/app/winrt/PlatformWinRt.h
+++ b/include/cinder/app/winrt/PlatformWinRt.h
@@ -67,6 +67,8 @@ class PlatformWinRt : public Platform {
 	
 	std::vector<std::string> stackTrace() override;
 
+	void setThreadName( const std::string &name ) override;
+
 	const std::vector<DisplayRef>&	getDisplays() override;
   
   private:

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -117,6 +117,11 @@ vector<string> stackTrace()
 	return app::Platform::get()->stackTrace();
 }
 
+void setThreadName( const std::string &name )
+{
+	app::Platform::get()->setThreadName( name );
+}
+
 int16_t swapEndian( int16_t val )
 {
 	return (int16_t) (	(((uint16_t) (val) & (uint16_t) 0x00ffU) << 8) |

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -40,6 +40,7 @@
 #endif
 #include <cxxabi.h>
 #include <execinfo.h>
+#include <pthread.h>
 
 using namespace std;
 
@@ -361,6 +362,13 @@ vector<string> PlatformCocoa::stackTrace()
 	free( strs );
 	
 	return result;
+}
+
+void PlatformCocoa::setThreadName( const std::string &name )
+{
+	int result = pthread_setname_np( name.c_str() ); // under macOS, arbitrarily long strings appear to be acceptable
+	if( result != 0 )
+		CI_LOG_E( "setThreadName failed" );
 }
 
 void PlatformCocoa::addDisplay( const DisplayRef &display )

--- a/src/cinder/app/linux/PlatformLinux.cpp
+++ b/src/cinder/app/linux/PlatformLinux.cpp
@@ -35,6 +35,7 @@
 #include <unistd.h>
 #include <limits.h>
 #include <pwd.h>
+#include <pthread.h>
 
 namespace cinder {
 
@@ -457,6 +458,15 @@ std::vector<std::string> PlatformLinux::stackTrace()
 {
 	// @TODO: Implement
 	return std::vector<std::string>();	
+}
+
+void PlatformLinux::setThreadName( const std::string &name )
+{
+	std::array<char,16> nameTrunc; // 16-byte maximum
+	strncpy( nameTrunc.data(), name.c_str(), 15 );
+	int result = pthread_setname_np( pthread_self(), nameTrunc.data() );
+	if( result != 0 )
+		CI_LOG_E( "setThreadName failed" );
 }
 
 void PlatformLinux::addDisplay( const DisplayRef &display )

--- a/src/cinder/app/winrt/PlatformWinRt.cpp
+++ b/src/cinder/app/winrt/PlatformWinRt.cpp
@@ -268,6 +268,33 @@ vector<string> PlatformWinRt::stackTrace()
 	return vector<string>();
 }
 
+void PlatformWinRt::setThreadName( const std::string &name )
+{
+#pragma pack(push,8)
+	typedef struct tagTHREADNAME_INFO {
+		DWORD dwType; // Must be 0x1000.
+		LPCSTR szName; // Pointer to name
+		DWORD dwThreadID; // Thread ID (-1=caller thread).
+		DWORD dwFlags; // Reserved for future use, must be zero.
+	 } THREADNAME_INFO;
+#pragma pack(pop)
+
+#pragma warning(push)
+#pragma warning(disable: 6320 6322)
+	__try {
+		THREADNAME_INFO info;
+		info.dwType = 0x1000;
+		info.szName = name.c_str();
+		info.dwThreadID = -1;
+		info.dwFlags = 0;
+
+		::RaiseException( 0x406D1388 /* MS_VC_EXCEPTION */, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info );
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+	}
+#pragma warning(pop)
+}
+
 const vector<DisplayRef>& PlatformWinRt::getDisplays()
 {
 	bool sInitialized = false;


### PR DESCRIPTION
This PR implements `setThreadName()` for MSW, UWP, iOS, macOS, and Linux.

The behavior of this method is environment-specific. For example, in Visual C++ the results are visible immediately. In Xcode, they are only visible if you attach to a running app, rather than launching from within the IDE. In Linux they can be seen by executing `info thread` from gdb.