### PR TITLE
Boost string removal

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -89,6 +89,9 @@ CI_API bool asciiCaseEqual( const std::string &a, const std::string &b );
 //! returns \c true if ASCII strings \a a and \a b are case-insensitively equal. Not Unicode-aware.
 CI_API bool asciiCaseEqual( const char *a, const char *b );
 
+//! returns a copy of \a str with all whitespace (as defined by std::isspace()) removed from beginning and end
+CI_API std::string trim( const std::string &str );
+
 //! Returns a stack trace (aka backtrace) where \c stackTrace()[0] == caller, \c stackTrace()[1] == caller's parent, etc
 CI_API std::vector<std::string> stackTrace();
 

--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -86,6 +86,8 @@ inline double fromString( const std::string &s ) { return atof( s.c_str() ); }
 
 //! returns \c true if ASCII strings \a a and \a b are case-insensitively equal. Not Unicode-aware.
 CI_API bool asciiCaseEqual( const std::string &a, const std::string &b );
+//! returns \c true if ASCII strings \a a and \a b are case-insensitively equal. Not Unicode-aware.
+CI_API bool asciiCaseEqual( const char *a, const char *b );
 
 //! Returns a stack trace (aka backtrace) where \c stackTrace()[0] == caller, \c stackTrace()[1] == caller's parent, etc
 CI_API std::vector<std::string> stackTrace();

--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -84,6 +84,9 @@ template<>
 inline double fromString( const std::string &s ) { return atof( s.c_str() ); }
 #endif
 
+//! returns \c true if ASCII strings \a a and \a b are case-insensitively equal. Not Unicode-aware.
+CI_API bool asciiCaseEqual( const std::string &a, const std::string &b );
+
 //! Returns a stack trace (aka backtrace) where \c stackTrace()[0] == caller, \c stackTrace()[1] == caller's parent, etc
 CI_API std::vector<std::string> stackTrace();
 

--- a/src/cinder/Color.cpp
+++ b/src/cinder/Color.cpp
@@ -23,7 +23,7 @@
 #include "cinder/Color.h"
 #include "cinder/Vector.h"
 #include "cinder/ImageIo.h"
-#include <boost/algorithm/string/case_conv.hpp>
+#include "cinder/Utilities.h"
 
 namespace cinder {
 
@@ -294,11 +294,10 @@ vec3 rgbToHsv( const Colorf &c )
 
 ColorT<uint8_t> svgNameToRgb( const char *name, bool *found )
 {
-	std::string value = boost::to_lower_copy( std::string( name ) );
 	int minIdx = 0, maxIdx = sTotalColors - 1;
 	while( minIdx <= maxIdx ) {
 		int curIdx = ( minIdx + maxIdx ) / 2;
-		int cmp = strcmp( value.c_str(), sColorNames[curIdx] );
+		int cmp = asciiCaseEqual( name, sColorNames[curIdx] );
 		if( cmp == 0 ) {
 			if( found )
 				*found = true;

--- a/src/cinder/Json.cpp
+++ b/src/cinder/Json.cpp
@@ -551,7 +551,7 @@ JsonTree* JsonTree::getNodePtr( const string &relativePath, bool caseSensitive, 
                 string key2 = *pathIt;
                 if( caseSensitive && key1 == key2 ) {
                     keysMatch = true;
-                } else if ( !caseSensitive && ( boost::iequals( key1, key2 ) ) ) {
+                } else if ( !caseSensitive && ( ci::asciiCaseEqual( key1, key2 ) ) ) {
                     keysMatch = true;
                 }
                 

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -33,6 +33,7 @@
 
 #include <vector>
 #include <fstream>
+#include <cctype>
 
 using std::vector;
 using std::string;

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -137,6 +137,13 @@ bool asciiCaseEqual( const char *a, const char *b )
 	return result;
 }
 
+std::string trim( const std::string &str )
+{
+	auto wsFront = std::find_if_not( str.begin(), str.end(), [](int c){ return std::isspace(c); } );
+	auto wsBack = std::find_if_not( str.rbegin(), str.rend(),[](int c){ return std::isspace(c); } ).base();
+	return wsBack <= wsFront ? std::string() : std::string( wsFront, wsBack );
+}
+
 void sleep( float milliseconds )
 {
 	app::Platform::get()->sleep( milliseconds );

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -117,6 +117,16 @@ void writeString( const DataTargetRef &dataTarget, const std::string &str )
 	ofs.close();
 }
 
+bool asciiCaseEqual( const std::string &a, const std::string &b )
+{
+	if( a.size() != b.size() )
+		return false;
+	else
+		return equal( a.cbegin(), a.cend(), b.cbegin(), []( std::string::value_type ac, std::string::value_type bc ) {
+				return std::toupper(ac) == std::toupper(bc);
+		});
+}
+
 void sleep( float milliseconds )
 {
 	app::Platform::get()->sleep( milliseconds );

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -127,6 +127,16 @@ bool asciiCaseEqual( const std::string &a, const std::string &b )
 		});
 }
 
+bool asciiCaseEqual( const char *a, const char *b )
+{
+	bool result;
+	while( (result = std::toupper(*a) == std::toupper(*b++)) == true )
+	if( *a++ == '\0' )
+		break;
+
+	return result;
+}
+
 void sleep( float milliseconds )
 {
 	app::Platform::get()->sleep( milliseconds );

--- a/src/cinder/Xml.cpp
+++ b/src/cinder/Xml.cpp
@@ -26,7 +26,6 @@
 
 #include "cinder/Xml.h"
 #include "cinder/Utilities.h"
-#include <boost/algorithm/string.hpp>
 
 #include "rapidxml/rapidxml.hpp"
 #include "rapidxml/rapidxml_print.hpp"
@@ -42,7 +41,7 @@ bool tagsMatch( const std::string &tag1, const std::string &tag2, bool caseSensi
 {
 	if( caseSensitive && ( tag1 == tag2 ) )
 		return true;
-	else if( ( ! caseSensitive ) && ( boost::iequals( tag1, tag2 ) ) )
+	else if( ( ! caseSensitive ) && ( asciiCaseEqual( tag1, tag2 ) ) )
 		return true;
 	else
 		return false;

--- a/src/cinder/svg/Svg.cpp
+++ b/src/cinder/svg/Svg.cpp
@@ -158,6 +158,7 @@ vector<string> readStringList( const std::string &s, bool stripQuotes = false )
 			trimmed.erase( std::remove( trimmed.begin(), trimmed.end(), '"' ), trimmed.end() );
 			trimmed.erase( std::remove( trimmed.begin(), trimmed.end(), '\'' ), trimmed.end() );
 		}
+		*resultIt = trimmed;
 	}
 	
 	return result;

--- a/src/cinder/svg/Svg.cpp
+++ b/src/cinder/svg/Svg.cpp
@@ -31,8 +31,6 @@
 #include "cinder/Text.h"
 #include "cinder/Log.h"
 
-#include <boost/algorithm/string.hpp>
-	
 using namespace std;
 
 namespace cinder { namespace svg {
@@ -157,8 +155,8 @@ vector<string> readStringList( const std::string &s, bool stripQuotes = false )
 	for( vector<string>::iterator resultIt = result.begin(); resultIt != result.end(); ++resultIt ) {
 		auto trimmed = ci::trim( *resultIt );
 		if( stripQuotes ) {
-			boost::erase_all( trimmed, "\"" );
-			boost::erase_all( trimmed, "\'" );
+			trimmed.erase( std::remove( trimmed.begin(), trimmed.end(), '"' ), trimmed.end() );
+			trimmed.erase( std::remove( trimmed.begin(), trimmed.end(), '\'' ), trimmed.end() );
 		}
 	}
 	
@@ -443,7 +441,7 @@ bool Style::parseProperty( const std::string &key, const std::string &value, con
 		return true;
 	}
 	else if( key == "font-weight" ) {
-		string weightString = boost::to_lower_copy( ci::trim( value ) );
+		string weightString = ci::trim( value );
 		if( isdigit( weightString[0] ) ) {
 			int v = atoi( weightString.c_str() );
 			if( v > 900 ) v = 900;
@@ -451,13 +449,13 @@ bool Style::parseProperty( const std::string &key, const std::string &value, con
 			mFontWeight = FontWeight( static_cast<int>(WEIGHT_100) + ( ( v / 100 ) - 1 ) );
 			mSpecifiesFontWeight = true;
 		}
-		else if( weightString == "normal" ) {
+		else if( ci::asciiCaseEqual( weightString, "normal" ) ) {
 			mFontWeight = WEIGHT_NORMAL;
 			mSpecifiesFontWeight = true;
 		}
-		else if( weightString == "bold" ) {
+		else if( ci::asciiCaseEqual( weightString, "bold" ) ) {
 			mFontWeight = WEIGHT_BOLD;
-			mSpecifiesFontWeight = true;			
+			mSpecifiesFontWeight = true;
 		}
 		return true;
 	}

--- a/src/cinder/svg/Svg.cpp
+++ b/src/cinder/svg/Svg.cpp
@@ -32,7 +32,6 @@
 #include "cinder/Log.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/case_conv.hpp>
 	
 using namespace std;
 
@@ -156,10 +155,10 @@ vector<string> readStringList( const std::string &s, bool stripQuotes = false )
 {
 	vector<string> result = ci::split( s, "," );
 	for( vector<string>::iterator resultIt = result.begin(); resultIt != result.end(); ++resultIt ) {
-		boost::trim( *resultIt );
+		auto trimmed = ci::trim( *resultIt );
 		if( stripQuotes ) {
-			boost::erase_all( *resultIt, "\"" );
-			boost::erase_all( *resultIt, "\'" );
+			boost::erase_all( trimmed, "\"" );
+			boost::erase_all( trimmed, "\'" );
 		}
 	}
 	
@@ -444,7 +443,7 @@ bool Style::parseProperty( const std::string &key, const std::string &value, con
 		return true;
 	}
 	else if( key == "font-weight" ) {
-		string weightString = boost::to_lower_copy( boost::trim_copy( value ) );
+		string weightString = boost::to_lower_copy( ci::trim( value ) );
 		if( isdigit( weightString[0] ) ) {
 			int v = atoi( weightString.c_str() );
 			if( v > 900 ) v = 900;

--- a/test/unit/src/Utilities.cpp
+++ b/test/unit/src/Utilities.cpp
@@ -128,9 +128,24 @@ TEST_CASE( "Utilities" )
         REQUIRE( ci::split(str4, ",- ", true) == resultStr4 );
         
     }
-    
-	SECTION( "asciiCaseEqual" )
+
+	SECTION( "asciiCaseEqual std::string" )
     {
+		REQUIRE( ci::asciiCaseEqual( string(""), string("") ) );
+		REQUIRE( ! ci::asciiCaseEqual( string(""), string("A") ) );
+		REQUIRE( ! ci::asciiCaseEqual( string("A"), string("") ) );
+		REQUIRE( ci::asciiCaseEqual( string("a"), string("A") ) );
+		REQUIRE( ! ci::asciiCaseEqual( string("a"), string("b") ) );
+		REQUIRE( ci::asciiCaseEqual( string("abc"), string("ABC") ) );
+		REQUIRE( ! ci::asciiCaseEqual( string("abc"), string("abd") ) );
+		REQUIRE( ! ci::asciiCaseEqual( string("abc"), string("abcd") ) );
+	}
+    
+	SECTION( "asciiCaseEqual const char*" )
+    {
+		REQUIRE( ci::asciiCaseEqual( "", "" ) );
+		REQUIRE( ! ci::asciiCaseEqual( "", "A" ) );
+		REQUIRE( ! ci::asciiCaseEqual( "A", "" ) );
 		REQUIRE( ci::asciiCaseEqual( "a", "A" ) );
 		REQUIRE( ! ci::asciiCaseEqual( "a", "b" ) );
 		REQUIRE( ci::asciiCaseEqual( "abc", "ABC" ) );

--- a/test/unit/src/Utilities.cpp
+++ b/test/unit/src/Utilities.cpp
@@ -129,6 +129,12 @@ TEST_CASE( "Utilities" )
         
     }
     
-
-    
+	SECTION( "asciiCaseEqual" )
+    {
+		REQUIRE( ci::asciiCaseEqual( "a", "A" ) );
+		REQUIRE( ! ci::asciiCaseEqual( "a", "b" ) );
+		REQUIRE( ci::asciiCaseEqual( "abc", "ABC" ) );
+		REQUIRE( ! ci::asciiCaseEqual( "abc", "abd" ) );
+		REQUIRE( ! ci::asciiCaseEqual( "abc", "abcd" ) );
+	}
 }

--- a/test/unit/src/Utilities.cpp
+++ b/test/unit/src/Utilities.cpp
@@ -142,7 +142,7 @@ TEST_CASE( "Utilities" )
 	}
     
 	SECTION( "asciiCaseEqual const char*" )
-    {
+	{
 		REQUIRE( ci::asciiCaseEqual( "", "" ) );
 		REQUIRE( ! ci::asciiCaseEqual( "", "A" ) );
 		REQUIRE( ! ci::asciiCaseEqual( "A", "" ) );
@@ -151,5 +151,18 @@ TEST_CASE( "Utilities" )
 		REQUIRE( ci::asciiCaseEqual( "abc", "ABC" ) );
 		REQUIRE( ! ci::asciiCaseEqual( "abc", "abd" ) );
 		REQUIRE( ! ci::asciiCaseEqual( "abc", "abcd" ) );
+	}
+
+	SECTION( "trim(std::string)" )
+	{
+		REQUIRE( ci::trim( "" ) == "" );
+		REQUIRE( ci::trim( "none" ) == "none" );
+		REQUIRE( ci::trim( " one" ) == "one" );
+		REQUIRE( ci::trim( "one " ) == "one" );
+		REQUIRE( ci::trim( " one " ) == "one" );
+		REQUIRE( ci::trim( "two  " ) == "two" );
+		REQUIRE( ci::trim( "  two" ) == "two" );
+		REQUIRE( ci::trim( "  two  " ) == "two" );
+		REQUIRE( ci::trim( " \t\n\rtwo  " ) == "two" );
 	}
 }


### PR DESCRIPTION
This removes additional dependencies on Boost, particularly of the string variety. It adds a `trim()` and `asciiCaseEqual()` method to _Utilities.h_, and matching unit tests.

I did not make the equivalent modifications to `JsonTree` as we are likely to deprecate this class soon.