### PR TITLE
fixes compile error on OSC for localtime and sprintf

### DIFF
--- a/blocks/OSC/src/cinder/osc/Osc.cpp
+++ b/blocks/OSC/src/cinder/osc/Osc.cpp
@@ -1735,13 +1735,14 @@ void getDate( uint64_t ntpTime, uint32_t *year, uint32_t *month, uint32_t *day, 
 	// Convert to unix timestamp.
 	std::time_t sec_since_epoch = ( ntpTime - ( uint64_t( 0x83AA7E80 ) << 32 ) ) >> 32;
 	
-	auto tm = std::localtime( &sec_since_epoch );
-	if( year ) *year = tm->tm_year + 1900;
-	if( month ) *month = tm->tm_mon + 1;
-	if( day ) *day = tm->tm_mday;
-	if( hours ) *hours = tm->tm_hour;
-	if( minutes ) *minutes = tm->tm_min;
-	if( seconds )*seconds = tm->tm_sec;
+	std::tm tm;
+	localtime_s(&tm, &sec_since_epoch);
+	if( year ) *year = tm.tm_year + 1900;
+	if( month ) *month = tm.tm_mon + 1;
+	if( day ) *day = tm.tm_mday;
+	if( hours ) *hours = tm.tm_hour;
+	if( minutes ) *minutes = tm.tm_min;
+	if( seconds )*seconds = tm.tm_sec;
 }
 
 std::string getClockString( uint64_t ntpTime, bool includeDate )
@@ -1752,9 +1753,9 @@ std::string getClockString( uint64_t ntpTime, bool includeDate )
 	char buffer[128];
 	
 	if( includeDate )
-		sprintf( buffer, "%d/%d/%d %02d:%02d:%02d", month, day, year, hours, minutes, seconds );
+		sprintf_s( buffer, "%d/%d/%d %02d:%02d:%02d", month, day, year, hours, minutes, seconds );
 	else
-		sprintf( buffer, "%02d:%02d:%02d", hours, minutes, seconds );
+		sprintf_s( buffer, "%02d:%02d:%02d", hours, minutes, seconds );
 	
 	return std::string( buffer );
 }


### PR DESCRIPTION
This fixes OSC block for deprecated methods sprintf and localtime (and replaces them with sprintf_s and localtime_s).