### PR TITLE
Isolating attribution and if condition

### DIFF
--- a/src/glfw/src/mir_window.c
+++ b/src/glfw/src/mir_window.c
@@ -555,9 +555,9 @@ int _glfwPlatformWindowMaximized(_GLFWwindow* window)
 
 void _glfwPlatformPollEvents(void)
 {
-    EventNode* node = NULL;
+    EventNode* node = dequeueEvent(_glfw.mir.event_queue);
 
-    while ((node = dequeueEvent(_glfw.mir.event_queue)))
+    while (node)
     {
         handleEvent(node->event, node->window);
         deleteNode(_glfw.mir.event_queue, node);


### PR DESCRIPTION
I'm suggesting a code style change that I would use in my code. I heard some discussions about this issue, and I would like to suggest it to see if it is more a personal preference or whether it makes sense. 

It is just to make explicit that an assignment expression has the value of the left operand after the assignment. 