### PR TITLE
Fix GLES/EGL on Linux

### DIFF
--- a/proj/cmake/platform_linux.cmake
+++ b/proj/cmake/platform_linux.cmake
@@ -10,9 +10,8 @@ list( APPEND SRC_SET_GLFW
 	${CINDER_SRC_DIR}/glfw/src/input.c
 	${CINDER_SRC_DIR}/glfw/src/monitor.c
 	${CINDER_SRC_DIR}/glfw/src/window.c
-
+	${CINDER_SRC_DIR}/glfw/src/glx_context.c
 	${CINDER_SRC_DIR}/glfw/src/egl_context.c
-	${CINDER_SRC_DIR}/glfw/src/window.c
 	${CINDER_SRC_DIR}/glfw/src/x11_init.c
 	${CINDER_SRC_DIR}/glfw/src/x11_monitor.c
 	${CINDER_SRC_DIR}/glfw/src/x11_window.c
@@ -52,16 +51,10 @@ list( APPEND SRC_SET_CINDER_LINUX ${CINDER_SRC_DIR}/cinder/UrlImplCurl.cpp )
 # Relevant source files depending on target GL.
 if( NOT CINDER_GL_ES_2_RPI )
 	if( CINDER_GL_ES )
-		list( APPEND SRC_SET_GLFW 
-			${CINDER_SRC_DIR}/glfw/src/egl_context.c
-		)
 		list( APPEND SRC_SET_CINDER_LINUX
 			${CINDER_SRC_DIR}/cinder/linux/gl_es_load.cpp
 		)
 	else()
-		list( APPEND SRC_SET_GLFW 
-			${CINDER_SRC_DIR}/glfw/src/glx_context.c
-		)
 		list( APPEND SRC_SET_CINDER_LINUX
 			${CINDER_SRC_DIR}/glload/glx_load.c
 			${CINDER_SRC_DIR}/glload/glx_load_cpp.cpp
@@ -200,7 +193,7 @@ list( APPEND CINDER_INCLUDE_USER_PRIVATE
 
 # Cinder GL defines depending on target GL.
 if( CINDER_GL_ES AND NOT CINDER_GL_ES_2_RPI ) # es2, es3, es31, es32
-	list( APPEND GLFW_FLAGS "-D_GLFW_X11 -D_GLFW_EGL -D_GLFW_USE_GLESV2" )
+	list( APPEND GLFW_FLAGS "-D_GLFW_X11" )
 	if( CINDER_GL_ES_2 )
 		list( APPEND CINDER_DEFINES "-DCINDER_GL_ES_2" )
 	elseif( CINDER_GL_ES_3 )
@@ -211,7 +204,7 @@ if( CINDER_GL_ES AND NOT CINDER_GL_ES_2_RPI ) # es2, es3, es31, es32
 		list( APPEND CINDER_DEFINES "-DCINDER_GL_ES_3_2" )
 	endif()
 elseif( NOT CINDER_GL_ES ) # Core Profile
-	list( APPEND GLFW_FLAGS "-D_GLFW_X11 -D_GLFW_GLX -D_GLFW_USE_OPENGL" )
+	list( APPEND GLFW_FLAGS "-D_GLFW_X11" )
 else() # Rpi
 	list( APPEND CINDER_DEFINES "-DCINDER_GL_ES_2" "-DCINDER_LINUX_EGL_ONLY" "-DCINDER_GL_ES_2_RPI" )
 endif()

--- a/src/cinder/app/linux/RendererGlLinuxGlfw.cpp
+++ b/src/cinder/app/linux/RendererGlLinuxGlfw.cpp
@@ -54,10 +54,13 @@ bool RendererGlLinux::initialize( void *window, RendererRef sharedRenderer )
 	gl::env()->initializeFunctionPointers();
 
 	std::shared_ptr<gl::PlatformDataLinux> platformData( new gl::PlatformDataLinux( mContext ) );
+
+#if ! defined( CINDER_GL_ES )
 	platformData->mDebug = mRenderer->getOptions().getDebug();
 	platformData->mDebugLogSeverity = mRenderer->getOptions().getDebugLogSeverity();
 	platformData->mDebugBreakSeverity = mRenderer->getOptions().getDebugBreakSeverity();
 	platformData->mObjectTracking = mRenderer->getOptions().getObjectTracking();
+#endif
 
 	mCinderContext = gl::Context::createFromExisting( platformData );
 	mCinderContext->makeCurrent();

--- a/src/cinder/app/linux/WindowImplLinuxGlfw.cpp
+++ b/src/cinder/app/linux/WindowImplLinuxGlfw.cpp
@@ -47,6 +47,7 @@ WindowImplLinux::WindowImplLinux( const Window::Format &format, WindowImplLinux 
 	const auto& options = std::dynamic_pointer_cast<RendererGl>( mRenderer )->getOptions();
 #if defined( CINDER_GL_ES )
 	::glfwDefaultWindowHints();
+	::glfwWindowHint( GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API );
 	::glfwWindowHint( GLFW_CLIENT_API, GLFW_OPENGL_ES_API );
   #if CINDER_GL_ES_VERSION >= CINDER_GL_ES_VERSION_3_2
 	::glfwWindowHint( GLFW_CONTEXT_VERSION_MAJOR, 3 );


### PR DESCRIPTION
This fixes GLES on EGL Context through GLFW on Linux.
I've removed a couple of deprecated `_GLFW_` macros and added the appropriate `glfwWindowHint` for EGL context creation.
Also `glx_context.c` was added as it is needed in both the GLX and EGL context case.