### PR TITLE
ip additions

### DIFF
--- a/include/cinder/ip/Flip.h
+++ b/include/cinder/ip/Flip.h
@@ -31,6 +31,10 @@ namespace cinder { namespace ip {
 template<typename T>
 CI_API void flipVertical( SurfaceT<T> *surface );
 
+//! Flips the contents of \a channel vertically (bottom becomes top)
+template<typename T>
+CI_API void flipVertical( ChannelT<T> *channel );
+
 //! Copies the contents of \a srcSurface into \a destSurface, flipping them vertically
 template<typename T>
 CI_API void flipVertical( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface );
@@ -42,5 +46,17 @@ CI_API void flipVertical( const ChannelT<T> &srcChannel, ChannelT<T> *destChanne
 //! Flips the contents of \a surface horizontally (left becomes right)
 template<typename T>
 CI_API void flipHorizontal( SurfaceT<T> *surface );
+
+//! Flips the contents of \a channel horizontally (left becomes right)
+template<typename T>
+CI_API void flipHorizontal( ChannelT<T> *channel );
+
+//! Flips the contents of \a surface both vertically and horizontally (left becomes right, bottom becomes top)
+template<typename T>
+CI_API void flipDiagonal( SurfaceT<T> *surface );
+    
+//! Flips the contents of \a channel both vertically and horizontally (left becomes right, bottom becomes top)
+template<typename T>
+CI_API void flipDiagonal( ChannelT<T> *channel );
 
 } } // namespace cinder::ip

--- a/include/cinder/ip/Resize.h
+++ b/include/cinder/ip/Resize.h
@@ -41,6 +41,6 @@ template<typename T>
 CI_API SurfaceT<T> resizeCopy( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter = FilterTriangle() );
 //! Returns a new Channel which is a copy of \a srcChannel's area \a srcArea scaled to size \a dstSize using filter \a filter
 template<typename T>
-CI_API SurfaceT<T> resizeCopy( const ChannelT<T> &srcChannel, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter = FilterTriangle() );
+CI_API ChannelT<T> resizeCopy( const ChannelT<T> &srcChannel, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter = FilterTriangle() );
 
 } } // namespace cinder::ip

--- a/include/cinder/ip/Resize.h
+++ b/include/cinder/ip/Resize.h
@@ -34,10 +34,13 @@ template<typename T>
 CI_API void resize( const ChannelT<T> &srcChannel, ChannelT<T> *dstChannel, const FilterBase &filter = FilterTriangle() );
 template<typename T>
 CI_API void resize( const SurfaceT<T> &srcSurface, const Area &srcArea, SurfaceT<T> *dstSurface, const Area &dstArea, const FilterBase &filter = FilterTriangle() );
+template<typename T>
+CI_API void resize( const ChannelT<T> &srcChannel, const Area &srcArea, ChannelT<T> *dstChannel, const Area &dstArea, const FilterBase &filter = FilterTriangle() );
 //! Returns a new Surface which is a copy of \a srcSurface's area \a srcArea scaled to size \a dstSize using filter \a filter
 template<typename T>
 CI_API SurfaceT<T> resizeCopy( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter = FilterTriangle() );
+//! Returns a new Channel which is a copy of \a srcChannel's area \a srcArea scaled to size \a dstSize using filter \a filter
 template<typename T>
-CI_API void resize( const ChannelT<T> &srcChannel, const Area &srcArea, ChannelT<T> *dstChannel, const Area &dstArea, const FilterBase &filter = FilterTriangle() );
+CI_API SurfaceT<T> resizeCopy( const ChannelT<T> &srcChannel, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter = FilterTriangle() );
 
 } } // namespace cinder::ip

--- a/src/cinder/ip/Flip.cpp
+++ b/src/cinder/ip/Flip.cpp
@@ -22,6 +22,8 @@
 
 #include "cinder/ip/Flip.h"
 
+#include <boost/preprocessor/seq.hpp>
+
 using namespace std;
 
 namespace cinder { namespace ip {
@@ -41,6 +43,117 @@ void flipVertical( SurfaceT<T> *surface )
 	}	
 }
 
+template<typename T>
+void flipVertical( ChannelT<T> *channel )
+{
+    const ptrdiff_t rowBytes = channel->getRowBytes();
+    unique_ptr<uint8_t[]> buffer( new uint8_t[rowBytes] );
+    
+    const int32_t lastRow = channel->getHeight() - 1;
+    const int32_t halfHeight = channel->getHeight() / 2;
+    for( int32_t y = 0; y < halfHeight; ++y ) {
+        memcpy( buffer.get(), channel->getData( ivec2( 0, y ) ), rowBytes );
+        memcpy( channel->getData( ivec2( 0, y ) ), channel->getData( ivec2( 0, lastRow - y ) ), rowBytes );
+        memcpy( channel->getData( ivec2( 0, lastRow - y ) ), buffer.get(), rowBytes );
+    }
+}
+
+template<typename T>
+void flipHorizontal( SurfaceT<T> *surface )
+{
+    const int32_t height = surface->getHeight();
+    const int32_t width = surface->getWidth();
+    const int32_t halfWidth = width / 2;
+    
+    //uses increment to guess the right place to swap values
+    //this way we don't need to check for isPlanar() and the process will work for all conditions
+    const size_t inc = surface->getPixelInc();
+    for( int32_t y = 0; y < height; ++y ) {
+        T *rowPtr = surface->getData( ivec2( 0, y ) );
+        for( int32_t x = 0; x < halfWidth; ++x ) {
+            for( int c = 0; c < inc; ++c ) {
+                T temp = rowPtr[x*inc+c];
+                rowPtr[x*inc+c] = rowPtr[(width-x-1)*inc+c];
+                rowPtr[(width-x-1)*inc+c] = temp;
+            }
+        }
+    }
+    
+}
+    
+template<typename T>
+void flipHorizontal( ChannelT<T> *channel )
+{
+    const int32_t height = channel->getHeight();
+    const int32_t width = channel->getWidth();
+    const int32_t halfWidth = width / 2;
+    
+    //uses increment to guess the right place to swap values
+    //this way we don't need to check for isPlanar() and the process will work for all conditions
+    const size_t inc = channel->getIncrement();
+    for( int32_t y = 0; y < height; ++y ) {
+        T *rowPtr = channel->getData( ivec2( 0, y ) );
+        for( int32_t x = 0; x < halfWidth; ++x ) {
+            for( int c = 0; c < inc; ++c ) {
+                T temp = rowPtr[x*inc+c];
+                rowPtr[x*inc+c] = rowPtr[(width-x-1)*inc+c];
+                rowPtr[(width-x-1)*inc+c] = temp;
+            }
+        }
+    }
+}
+    
+template<typename T>
+void flipDiagonal( SurfaceT<T> *surface )
+{
+    const int32_t height = surface->getHeight();
+    const int32_t width = surface->getWidth();
+    const int32_t lastRow = surface->getHeight() - 1;
+    const int32_t widthStep = width / height + 1;
+    
+    //uses increment to guess the right place to swap values
+    //this way we don't need to check for isPlanar() and the process will work for all conditions
+    const size_t inc = surface->getPixelInc();
+    for( int32_t y = 0; y < height; ++y ) {
+        T* rowPtr = surface->getData( ivec2( 0, y ) );
+        T* mirrorPtr = surface->getData( ivec2(0, lastRow-y));
+        for( int32_t x = 0; x < width - widthStep * y; ++x ) {
+            for( int c = 0; c < inc; ++c ) {
+                T temp = rowPtr[x*inc+c];
+                rowPtr[x*inc+c] = mirrorPtr[(width-x)*inc+c];
+                mirrorPtr[(width-x)*inc+c] = temp;
+            }
+        }
+        
+    }
+}
+    
+template<typename T>
+void flipDiagonal( ChannelT<T> *channel )
+{
+    const int32_t height = channel->getHeight();
+    const int32_t width = channel->getWidth();
+    const int32_t lastRow = channel->getHeight() - 1;
+    const int32_t widthStep = width / height + 1;
+    
+    //uses increment to guess the right place to swap values
+    //this way we don't need to check for isPlanar() and the process will work for all conditions
+    const size_t inc = channel->getIncrement();
+    for( int32_t y = 0; y < height; ++y ) {
+        T* rowPtr = channel->getData( ivec2( 0, y ) );
+        T* mirrorPtr = channel->getData( ivec2(0, lastRow-y));
+        for( int32_t x = 0; x < width - widthStep * y; ++x ) {
+            for( int c = 0; c < inc; ++c ) {
+                T temp = rowPtr[x*inc+c];
+                rowPtr[x*inc+c] = mirrorPtr[(width-x)*inc+c];
+                mirrorPtr[(width-x)*inc+c] = temp;
+            }
+        }
+        
+    }
+    
+}
+    
 namespace { // anonymous
 template<typename T>
 void flipVerticalRawSameChannelOrder( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface, const ivec2 &size )
@@ -181,48 +294,16 @@ void flipVertical( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel )
 	}
 }
 
-template<typename T>
-void flipHorizontal( SurfaceT<T> *surface )
-{
-	const int32_t height = surface->getHeight();
-	const int32_t width = surface->getWidth();
-	const int32_t halfWidth = width / 2;
-	
-	if( surface->getPixelInc() == 4 ) {
-		for( int32_t y = 0; y < height; ++y ) {
-			T *rowPtr = surface->getData( ivec2( 0, y ) );
-			for( int32_t x = 0; x < halfWidth; ++x ) {
-				for( int c = 0; c < 4; ++c ) {
-					T temp = rowPtr[x*4+c];
-					rowPtr[x*4+c] = rowPtr[(width-x-1)*4+c];
-					rowPtr[(width-x-1)*4+c] = temp;
-				}
-			}
-		}
-	}
-	else { // pixel inc of 3
-		for( int32_t y = 0; y < height; ++y ) {
-			T *rowPtr = surface->getData( ivec2( 0, y ) );
-			for( int32_t x = 0; x < halfWidth; ++x ) {
-				for( int c = 0; c < 3; ++c ) {
-					T temp = rowPtr[x*3+c];
-					rowPtr[x*3+c] = rowPtr[(width-x-1)*3+c];
-					rowPtr[(width-x-1)*3+c] = temp;
-				}
-			}
-		}
-	}
-}
-
-#define flip_PROTOTYPES(T)\
+#define flip_PROTOTYPES(r,data,T)\
 	template CI_API void flipVertical<T>( SurfaceT<T> *surface );\
+    template CI_API void flipVertical<T>( ChannelT<T> *channel );\
 	template CI_API void flipVertical<T>( const SurfaceT<T> &srcSurface, SurfaceT<T> *destSurface );\
 	template CI_API void flipVertical<T>( const ChannelT<T> &srcChannel, ChannelT<T> *destChannel );\
-	template CI_API void flipHorizontal<T>( SurfaceT<T> *surface );
+	template CI_API void flipHorizontal<T>( SurfaceT<T> *surface );\
+    template CI_API void flipHorizontal<T>( ChannelT<T> *surface );\
+    template CI_API void flipDiagonal<T>( SurfaceT<T> *surface );\
+    template CI_API void flipDiagonal<T>( ChannelT<T> *surface );
 	
-	
-flip_PROTOTYPES(uint8_t)
-flip_PROTOTYPES(uint16_t)
-flip_PROTOTYPES(float)
+BOOST_PP_SEQ_FOR_EACH( flip_PROTOTYPES, ~, (uint8_t)(uint16_t)(float) )
 
 } } // namespace cinder::ip

--- a/src/cinder/ip/Resize.cpp
+++ b/src/cinder/ip/Resize.cpp
@@ -344,6 +344,12 @@ void resize( const SurfaceT<T> &srcSurface, SurfaceT<T> *dstSurface, const Filte
 {
 	resize( srcSurface, srcSurface.getBounds(), dstSurface, dstSurface->getBounds(), filter );
 }
+	
+template<typename T>
+void resize( const ChannelT<T> &srcChannel, ChannelT<T> *dstChannel, const FilterBase &filter )
+{
+	resize( srcChannel, srcChannel.getBounds(), dstChannel, dstChannel->getBounds(), filter );
+}
 
 template<typename T>
 SurfaceT<T> resizeCopy( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter )
@@ -354,17 +360,20 @@ SurfaceT<T> resizeCopy( const SurfaceT<T> &srcSurface, const Area &srcArea, cons
 }
 
 template<typename T>
-void resize( const ChannelT<T> &srcChannel, ChannelT<T> *dstChannel, const FilterBase &filter )
+ChannelT<T> resizeCopy( const ChannelT<T> &srcChannel, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter )
 {
-	resize( srcChannel, srcChannel.getBounds(), dstChannel, dstChannel->getBounds(), filter );
+	ChannelT<T> result( dstSize.x, dstSize.y );
+	resize( srcChannel, srcArea, &result, result.getBounds(), filter );
+	return result;
 }
 
 #define resize_PROTOTYPES(T)\
 	template CI_API void resize( const SurfaceT<T> &srcSurface, SurfaceT<T> *dstSurface, const FilterBase &filter ); \
 	template CI_API void resize( const SurfaceT<T> &srcSurface, const Area &srcArea, SurfaceT<T> *dstSurface, const Area &dstArea, const FilterBase &filter ); \
 	template CI_API void resize( const ChannelT<T> &srcChannel, ChannelT<T> *dstChannel, const FilterBase &filter ); \
+	template CI_API void resize( const ChannelT<T> &srcChannel, const Area &srcArea, ChannelT<T> *dstChannel, const Area &dstArea, const FilterBase &filter );\
 	template CI_API SurfaceT<T> resizeCopy( const SurfaceT<T> &srcSurface, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter ); \
-	template CI_API void resize( const ChannelT<T> &srcChannel, const Area &srcArea, ChannelT<T> *dstChannel, const Area &dstArea, const FilterBase &filter );
+	template CI_API ChannelT<T> resizeCopy( const ChannelT<T> &srcChannel, const Area &srcArea, const ivec2 &dstSize, const FilterBase &filter );
 
 // These should match CHANNEL_TYPES
 resize_PROTOTYPES(uint8_t)


### PR DESCRIPTION
Added a resizeCopy version for Channels. 
concerning Flip: Added flipHorizontal for channels and also added code for flipping
surfaces and channels diagonally (both horizontally and vertically),
it’s simply called flipDiagonal() but could change to flip() if
Cinder’s maintainers think it sounds better