### PR TITLE
gl::drawSolidTriangle with vec3 vertices

### DIFF
--- a/include/cinder/gl/draw.h
+++ b/include/cinder/gl/draw.h
@@ -134,6 +134,12 @@ CI_API void drawSolidTriangle( const vec2 &pt0, const vec2 &pt1, const vec2 &pt2
 CI_API void drawSolidTriangle( const vec2 &pt0, const vec2 &pt1, const vec2 &pt2, const vec2 &texPt0, const vec2 &texPt1, const vec2 &texPt2 );
 //! Renders a textured triangle.
 CI_API void drawSolidTriangle( const vec2 pts[3], const vec2 texCoord[3] = nullptr );
+//! Renders a solid triangle.
+CI_API void drawSolidTriangle( const vec3 &pt0, const vec3 &pt1, const vec3 &pt2 );
+//! Renders a textured triangle.
+CI_API void drawSolidTriangle( const vec3 &pt0, const vec3 &pt1, const vec3 &pt2, const vec2 &texPt0, const vec2 &texPt1, const vec2 &texPt2 );
+//! Renders a textured triangle.
+CI_API void drawSolidTriangle( const vec3 pts[3], const vec2 texCoord[3] = nullptr );
 	
 	
 CI_API void	drawArrays( GLenum mode, GLint first, GLsizei count );

--- a/src/cinder/gl/draw.cpp
+++ b/src/cinder/gl/draw.cpp
@@ -1338,6 +1338,58 @@ void drawSolidTriangle( const vec2 pts[3], const vec2 texCoord[3] )
 	ctx->popVao();
 }
 
+void drawSolidTriangle( const vec3 &pt0, const vec3 &pt1, const vec3 &pt2 )
+{
+	vec3 pts[3] = { pt0, pt1, pt2 };
+	drawSolidTriangle( pts, nullptr );
+}
+
+//! Renders a textured triangle.
+void drawSolidTriangle( const vec3 &pt0, const vec3 &pt1, const vec3 &pt2, const vec2 &texCoord0, const vec2 &texCoord1, const vec2 &texCoord2 )
+{
+	vec3 pts[3] = { pt0, pt1, pt2 };
+	vec2 texs[3] = { texCoord0, texCoord1, texCoord2 };
+	drawSolidTriangle( pts, texs );
+}
+
+void drawSolidTriangle( const vec3 pts[3], const vec2 texCoord[3] )
+{
+	auto ctx = context();
+	const GlslProg* curGlslProg = ctx->getGlslProg();
+	if( ! curGlslProg ) {
+		CI_LOG_E( "No GLSL program bound" );
+		return;
+	}
+
+	GLfloat data[3*3+3*2]; // both verts and texCoords
+	memcpy( data, pts, sizeof(float) * 3 * 3 );
+	if( texCoord )
+		memcpy( data + 3 * 2, texCoord, sizeof(float) * 3 * 2 );
+
+	ctx->pushVao();
+	ctx->getDefaultVao()->replacementBindBegin();
+	VboRef defaultVbo = ctx->getDefaultArrayVbo( sizeof(float)*15 );
+	ScopedBuffer bufferBindScp( defaultVbo );
+	defaultVbo->bufferSubData( 0, sizeof(float) * ( texCoord ? 15 : 9 ), data );
+
+	int posLoc = curGlslProg->getAttribSemanticLocation( geom::Attrib::POSITION );
+	if( posLoc >= 0 ) {
+		enableVertexAttribArray( posLoc );
+		vertexAttribPointer( posLoc, 3, GL_FLOAT, GL_FALSE, 0, (void*)0 );
+	}
+	if( texCoord ) {
+		int texLoc = curGlslProg->getAttribSemanticLocation( geom::Attrib::TEX_COORD_0 );
+		if( texLoc >= 0 ) {
+			enableVertexAttribArray( texLoc );
+			vertexAttribPointer( texLoc, 2, GL_FLOAT, GL_FALSE, 0, (void*)(sizeof(float)*6) );
+		}
+	}
+	ctx->getDefaultVao()->replacementBindEnd();
+	ctx->setDefaultShaderVars();
+	ctx->drawArrays( GL_TRIANGLES, 0, 3 );
+	ctx->popVao();
+}
+
 void drawSphere( const Sphere &sphere, int subdivisions )
 {
 	drawSphere( sphere.getCenter(), sphere.getRadius(), subdivisions );


### PR DESCRIPTION
`gl::drawSolidTriangle` vertex parameters are `vec2` and if you call it with `vec3`'s they can get converted silently cutting the z-coordinate displaying the triangle in 2d instead of 3d. This simple PR is a modification of the function for `vec3` vertices to address this.