### PR TITLE
[CI] Reduce test matrix on travis for xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,6 @@ matrix:
         - TOOL="xcode-osx"
         - DESCRIPTION="OS X build/test via Xcode"
     - os: osx
-      osx_image: xcode8.2
-      env: 
-        - TOOL="xcode-osx"
-        - DESCRIPTION="OS X build/test via Xcode"
-    - os: osx
-      osx_image: xcode8.1
-      env:
-        - TOOL="xcode-osx"
-        - DESCRIPTION=OS X build/test via Xcode"
-    - os: osx
       osx_image: xcode8
       env:
         - TOOL="xcode-osx"
@@ -55,16 +45,6 @@ matrix:
       env: 
         - TOOL="xcode-ios"
         - DESCRIPTION="OS X build/test via Xcode"
-    - os: osx
-      osx_image: xcode8.2
-      env: 
-        - TOOL="xcode-ios"
-        - DESCRIPTION="OS X build/test via Xcode"
-    - os: osx
-      osx_image: xcode8.1
-      env:
-        - TOOL="xcode-ios"
-        - DESCRIPTION=OS X build/test via Xcode"
     - os: osx
       osx_image: xcode8
       env:
@@ -83,16 +63,6 @@ matrix:
         - TOOL="xcode-ios-sim"
         - DESCRIPTION="OS X build/test via Xcode"
     - os: osx
-      osx_image: xcode8.2
-      env: 
-        - TOOL="xcode-ios-sim"
-        - DESCRIPTION="OS X build/test via Xcode"
-    - os: osx
-      osx_image: xcode8.1
-      env:
-        - TOOL="xcode-ios-sim"
-        - DESCRIPTION=OS X build/test via Xcode"
-    - os: osx
       osx_image: xcode8
       env:
         - TOOL="xcode-ios-sim"
@@ -106,16 +76,6 @@ matrix:
     # OS X CMake
     - os: osx
       osx_image: xcode8.3
-      env:
-        - TOOL="cmake" 
-        - DESCRIPTION="OS X build/test via CMake"
-    - os: osx
-      osx_image: xcode8.2
-      env:
-        - TOOL="cmake" 
-        - DESCRIPTION="OS X build/test via CMake"
-    - os: osx
-      osx_image: xcode8.1
       env:
         - TOOL="cmake" 
         - DESCRIPTION="OS X build/test via CMake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ matrix:
 
     # OS X Xcode
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       env: 
         - TOOL="xcode-osx"
         - DESCRIPTION="OS X build/test via Xcode"
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - TOOL="xcode-osx"
         - DESCRIPTION=OS X build/test via Xcode"
@@ -41,12 +41,12 @@ matrix:
 
     # iOS Xcode
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       env: 
         - TOOL="xcode-ios"
         - DESCRIPTION="OS X build/test via Xcode"
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - TOOL="xcode-ios"
         - DESCRIPTION=OS X build/test via Xcode"
@@ -58,12 +58,12 @@ matrix:
 
     # iOS-Sim Xcode
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       env: 
         - TOOL="xcode-ios-sim"
         - DESCRIPTION="OS X build/test via Xcode"
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - TOOL="xcode-ios-sim"
         - DESCRIPTION=OS X build/test via Xcode"
@@ -75,12 +75,12 @@ matrix:
 
     # OS X CMake
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       env:
         - TOOL="cmake" 
         - DESCRIPTION="OS X build/test via CMake"
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       env:
         - TOOL="cmake" 
         - DESCRIPTION="OS X build/test via CMake"


### PR DESCRIPTION
This PR removes xcode 8.1 and 8.2 from the test matrix with the goal of reducing travis-CI runtime. 
The remaining xcode versions are 7.3, 8 and 8.3 which should still cover most interesting cases. 

Currently, Travis seems to have some trouble anyway. Regardless of this however, I don't think testing on every version of XCode adds much value (unless you had problems in the past with a specific verion), but as travis is notoriously short on MacOS resources, it can greatly increase the ci runtime duration.

(Btw. I think we talked about this before somewhere, but I can't find the issue at the moment)  