### PR TITLE
implement GlslProg::Format::getDefines()

### DIFF
--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -267,7 +267,7 @@ class CI_API GlslProg {
 		//! Adds a define directive to the ShaderPreprocessor, which will be prepended to the shader sources
 		Format&		define( const std::string &define, const std::string &value );
 		//! Returns the define directives that the ShaderPreprocessor will prepend to shader sources.
-		std::vector<std::string> getDefineDirectives() const;
+		const std::vector<std::pair<std::string,std::string>>& getDefines() const;
 		//! Specifies the #version directive that the ShaderPreprocessor will add to shader sources, if they don't contain an explicit `#version` string.
 		Format&		version( int version );
 		//! Returns the #version directive that the ShaderPreprocessor will add to shader sources, if they don't contain an explicit `#version` string.

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -377,6 +377,16 @@ GlslProg::Format& GlslProg::Format::define( const std::string &define, const std
 	return *this;
 }
 
+const std::vector<std::pair<std::string,std::string>>& GlslProg::Format::getDefines() const
+{
+	if( mPreprocessor ) {
+		return mPreprocessor->getDefines();
+	}
+
+	static std::vector<std::pair<std::string,std::string>> sEmpty;
+	return sEmpty;
+}
+
 GlslProg::Format& GlslProg::Format::attribLocation( const std::string &attribName, GLint location )
 {
 	for( auto& attrib : mAttributes ) {


### PR DESCRIPTION
Previous declaration was unimplemented. Removed 'Directives' suffix from the previous (unimplemented) method for consistency.