### PR TITLE
Workaround for VC++ 14 bug with URLs with 260+ chars

### DIFF
--- a/src/cinder/DataSource.cpp
+++ b/src/cinder/DataSource.cpp
@@ -148,7 +148,19 @@ DataSourceUrlRef DataSourceUrl::create( const Url &url, const UrlOptions &option
 DataSourceUrl::DataSourceUrl( const Url &url, const UrlOptions &options )
 	: DataSource( "", url ), mOptions( options )
 {
+#if _MSC_VER >= 1900 && _MSC_VER <= 1912
+	std::string urlString = url.str();
+
+	if ( urlString.size() >= 260 )	{
+		// Workaround for MSVC++ 14.0/17.0 exceptions once fs::path length hits 260
+		const size_t start = urlString.rfind( '/' );
+		urlString = urlString.substr( start == std::string::npos ? 0 : start, 259 );
+	}
+
+	setFilePathHint( urlString );
+#else
 	setFilePathHint( url.str() );
+#endif
 }
 
 void DataSourceUrl::createBuffer()

--- a/src/cinder/Url.cpp
+++ b/src/cinder/Url.cpp
@@ -142,8 +142,17 @@ IStreamUrlRef IStreamUrl::create( const Url &url, const std::string &user, const
 IStreamUrl::IStreamUrl( const std::string &url, const std::string &user, const std::string &password, const UrlOptions &options )
 	: IStreamCinder()
 {
-	setFileName( url );
 	mImpl = std::shared_ptr<IStreamUrlImpl>( new IStreamUrlPlatformImpl( url, user, password, options ) );
+#if _MSC_VER >= 1900 && _MSC_VER <= 1912
+	if (url.size() >= 260)
+	{
+		// Workaround for MSVC++ 14.0/17.0 exceptions once fs::path length hits 260
+		const size_t start = url.rfind( '/' );
+		setFileName( url.substr( start == std::string::npos ? 0 : start, 259 ) );
+		return;
+	}
+#endif
+	setFileName( url );
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -167,3 +176,4 @@ UrlLoadExc::UrlLoadExc( int code, const std::string &message )
 }
 
 } // namespace cinder
+


### PR DESCRIPTION
First pass at addressing #1979. This patch resolves the original issue we had at our studio with loading URLs with  long query strings (e.g. [this graphql query](https://www.graphqlhub.com/graphql?query=%7B%09%09%09graphQLHub%09%09%09giphy%7B%09%09%09%09random(tag:%22javascript%22)%20%7B%09%09%09%09%09id%09%09%09%09%09url%09%09%09%09%09images%7B%09%09%09%09%09%09original%7B%09%09%09%09%09%09%09url%09%09%09%09%09%09%7D%09%09%09%09%09%7D%09%09%09%09%7D%09%09%09%7D%09%09%7D)).

A couple of notes:

* Since yesterday (03/01/2018) the bug is reported as [resolved on the MS dev forums](https://developercommunity.visualstudio.com/content/problem/167666/maximum-filesystempath-length.html) and will be included in the next VS compiler release. Because of that I limited the patch scope to [`_MSC_VER`](https://blogs.msdn.microsoft.com/vcblog/2017/11/15/msvc-conformance-improvements-in-visual-studio-2017-version-15-5/) and not globally to `CINDER_MSW`. Thoughts?
* The same issue of converting the URL string to `fs::path` in order to conveniently get the filename popped up in two places: `DataSourceUrl` and `IStreamUrl`. Currently I have nearly the same snippet in both locations, but am happy to consolidate if there are any suggestions for where that could/should live.
* I followed @andrewfb's suggestion to attempt a simple filename retrieval using an `rfind('/')` . This works for our use-cases but I don't have a ton of insight into what other situations the `DataSourceUrl::getFilePathHint()` and `StreamBase::getFileName()`. Below the line it's better than the exception though. Any other suggestions are welcome, but I felt like a simple fix now is better than a beefier workaround later.

Happy to iterate over this.