### PR TITLE
Fixed issue that prevents Texture1d/3d to use glTexStorage

### DIFF
--- a/src/cinder/gl/Texture.cpp
+++ b/src/cinder/gl/Texture.cpp
@@ -816,7 +816,7 @@ Texture1d::Texture1d( GLint width, Format format )
 	TextureBase::initParams( format, GL_RGB, GL_UNSIGNED_BYTE );
 
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	env()->allocateTexStorage1d( mTarget, format.mMaxMipmapLevel + 1, mInternalFormat, mWidth, format.isImmutableStorage(), format.getDataType() );
+	env()->allocateTexStorage1d( mTarget, mMaxMipmapLevel + 1, mInternalFormat, mWidth, format.isImmutableStorage(), format.getDataType() );
 }
 
 Texture1d::Texture1d( const Surface8u &surface, Format format )
@@ -1739,7 +1739,7 @@ Texture3d::Texture3d( GLint width, GLint height, GLint depth, Format format )
 	TextureBase::initParams( format, GL_RGB, GL_UNSIGNED_BYTE );
 
 	ScopedTextureBind tbs( mTarget, mTextureId );
-	env()->allocateTexStorage3d( mTarget, format.mMaxMipmapLevel + 1, mInternalFormat, mWidth, mHeight, mDepth, format.isImmutableStorage() );
+	env()->allocateTexStorage3d( mTarget, mMaxMipmapLevel + 1, mInternalFormat, mWidth, mHeight, mDepth, format.isImmutableStorage() );
 }
 
 Texture3d::Texture3d( const void *data, GLenum dataFormat, int width, int height, int depth, Format format )


### PR DESCRIPTION
Which prevents 1d and 3d textures to be immutable / to use any recent GL functions that require the use of texture storage.

As can be seen in [`TextureBase::initParams`](https://github.com/cinder/Cinder/blob/master/src/cinder/gl/Texture.cpp#L254-L266) the `format.mMaxMipmapLevel` never get updated when [reaching this line](https://github.com/cinder/Cinder/blob/master/src/cinder/gl/Texture.cpp#L1742) if mipmapping is disabled. This results in passing a max level of zero to [this call](https://github.com/cinder/Cinder/blob/master/src/cinder/gl/EnvironmentCore.cpp#L182) to `glTexStorage3d`, which is [illegal (`GL_INVALID_VALUE is generated if width, height, depth or levels are less than 1. `)](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexStorage3D.xhtml).

The [`Texture2d` constructor](https://github.com/cinder/Cinder/blob/master/src/cinder/gl/Texture.cpp#L993) uses the local `mMaxMipMapLevel` instead, which is probably the reason this managed to slipped through.

Do you guys see any reason the `Texture1d` and `Texture3d` would use a different path?