### PR TITLE
Fixing “qualified reference to 'Format' is a constructor name rather …

### DIFF
--- a/include/cinder/qtime/AvfWriter.h
+++ b/include/cinder/qtime/AvfWriter.h
@@ -116,7 +116,7 @@ class MovieWriter {
 
 	~MovieWriter();
 
-	static MovieWriterRef	create( const fs::path &path, int32_t width, int32_t height, const Format &format = Format::Format() )
+	static MovieWriterRef	create( const fs::path &path, int32_t width, int32_t height, const Format &format = Format() )
 		{ return std::shared_ptr<MovieWriter>( new MovieWriter( path, width, height, format ) ); }
 
 	//! Returns the Movie's default frame duration measured in seconds. You can also think of this as the Movie's frameRate.


### PR DESCRIPTION
…than a type in this context” error.

Build Error with Latest Version 9.3 (9E145) of Xcode.