### PR TITLE
implement gl::TextureFont::measureStringWrapped() on non-Cocoa platforms

### DIFF
--- a/include/cinder/gl/TextureFont.h
+++ b/include/cinder/gl/TextureFont.h
@@ -123,10 +123,8 @@ class CI_API TextureFont {
 
 	//! Returns the size in pixels necessary to render the string \a str with DrawOptions \a options.
 	vec2	measureString( const std::string &str, const DrawOptions &options = DrawOptions() ) const;
-#if defined( CINDER_COCOA )
 	//! Returns the size in pixels necessary to render the word-wrapped string \a str fit inside \a fitRect with DrawOptions \a options. Mac & iOS only.
 	vec2	measureStringWrapped( const std::string &str, const Rectf &fitRect, const DrawOptions &options = DrawOptions() ) const;
-#endif
     
 	//! Returns a vector of glyph/placement pairs representing \a str, suitable for use with drawGlyphs. Useful for caching placement and optimizing batching.
 	std::vector<std::pair<Font::Glyph,vec2> >		getGlyphPlacements( const std::string &str, const DrawOptions &options = DrawOptions() ) const;

--- a/src/cinder/gl/TextureFont.cpp
+++ b/src/cinder/gl/TextureFont.cpp
@@ -780,7 +780,7 @@ vec2 TextureFont::measureStringWrapped( const std::string &str, const Rectf &fit
 #endif
 	if( ! glyphMeasures.empty() ) {
 		vec2 result = vec2( 0 );
-		ivec2 glyphIndices = ivec2( 0 );
+		ivec2 glyphIndices = ivec2( glyphMeasures.front().first );
 		uint16_t glyphIndexVert = 0;
 		for( const auto &gm : glyphMeasures ) {
 			if( gm.second.x > result.x ) {


### PR DESCRIPTION
A while ago it looks like `gl::TextureFont::drawStringWrapped()` was implemented on non-Cocoa platforms via liblinebreak. This uses the same methods to implement `measureStringWrapped()`. Neither are perfect, but it allows api parity while we still figure out the next text api.