### PR TITLE
Fixed broken links

### DIFF
--- a/docs/htmlsrc/guides/tour/hello_cinder.html
+++ b/docs/htmlsrc/guides/tour/hello_cinder.html
@@ -67,19 +67,19 @@
                Section Two: Flocking Simulation
             </h1>
             <p><br />
-               <a class="el" href="flocking_chapter1.html">Chapter 1: Camera and Parameters</a><br />
+               <a class="el" href="../flocking/chapter1.html">Chapter 1: Camera and Parameters</a><br />
                We will learn about the Cinder Camera class and use it to create a 3D environment for the Particle engine we made in Section One. Then we will show how to setup a Params class for controlling variables during runtime.<br />
                <br />
-               <a class="el" href="flocking_chapter2.html">Chapter 2: Rule One - Separation</a><br />
+               <a class="el" href="../flocking/chapter2.html">Chapter 2: Rule One - Separation</a><br />
                The first rule of flocking is described and implemented. This rule states that all flocking objects should avoid getting too close to each other. This helps to mitigate overcrowding and collisions.<br />
                <br />
-               <a class="el" href="flocking_chapter3.html">Chapter 3: Rule Two - Cohesion</a><br />
+               <a class="el" href="../flocking/chapter3.html">Chapter 3: Rule Two - Cohesion</a><br />
                The second rule is one of attraction. Flocking objects will move towards each other in order to prevent any individual from becoming isolated and exposed.<br />
                <br />
-               <a class="el" href="flocking_chapter4.html">Chapter 4: Rule Three - Alignment</a><br />
+               <a class="el" href="../flocking/chapter4.html">Chapter 4: Rule Three - Alignment</a><br />
                The third rule is arguably the most important. Alignment, or orientation, states that flocking objects will try to move in the general direction of the nearest neighbors. This inevitably leads to characteristic group behavior that is witnessed in large groups of birds and fish.<br />
                <br />
-               <a class="el" href="flocking_chapter5.html">Chapter 5: Rule Four - Evasion</a><br />
+               <a class="el" href="../flocking/chapter5.html">Chapter 5: Rule Four - Evasion</a><br />
                In this final chapter, we will add a few predators to the simulation and show how to add personality and behavioral diversity to the flock in order to produce a more organic result. <br />
                <br />
                <br />


### PR DESCRIPTION
Fixed broken links for [Section Two : Flocking Simulation](https://libcinder.org/docs/guides/tour/hello_cinder.html).


From [Issue 1921](https://github.com/cinder/Cinder/issues/1921).

However, there is still an unsolved issue with the hyperlink to download _tour.zip_