### PR TITLE
Added shader type member to GlslProg compile exception

### DIFF
--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -579,6 +579,12 @@ class CI_API GlslProgExc : public cinder::gl::Exception {
 class CI_API GlslProgCompileExc : public GlslProgExc {
   public:
 	GlslProgCompileExc( const std::string &log, GLint shaderType );
+	
+	//! Returns the glsl shader type: GL_VERTEX_SHADER, GL_FRAGMENT_SHADER, ...
+	GLint getShaderType() const { return mShaderType; }
+	
+  protected:
+	GLint mShaderType;
 };
 
 class CI_API GlslProgLinkExc : public GlslProgExc {

--- a/include/cinder/gl/GlslProg.h
+++ b/include/cinder/gl/GlslProg.h
@@ -181,7 +181,7 @@ class CI_API GlslProg {
 		//! Supplies the GLSL source for the fragment shader
 		Format&		fragment( const DataSourceRef &dataSource );
 		//! Supplies the GLSL source for the fragment shader
-		Format&		fragment( const std::string &vertexShader );
+		Format&		fragment( const std::string &fragmentShader );
 		//! Returns the GLSL source for the vertex shader. Returns an empty string if it isn't present.
 		const std::string&	getVertex() const { return mVertexShader; }
 		//! Returns the GLSL source for the fragment shader. Returns an empty string if it isn't present.

--- a/src/cinder/gl/GlslProg.cpp
+++ b/src/cinder/gl/GlslProg.cpp
@@ -2028,7 +2028,7 @@ std::ostream& operator<<( std::ostream &os, const GlslProg &rhs )
 
 //////////////////////////////////////////////////////////////////////////
 // GlslProgCompileExc
-GlslProgCompileExc::GlslProgCompileExc( const std::string &log, GLint shaderType )
+GlslProgCompileExc::GlslProgCompileExc( const std::string &log, GLint shaderType ) : mShaderType( shaderType )
 {
 	string typeString;
 


### PR DESCRIPTION
Useful in live coding setups when a shader in the GlslProg fails to compile: query getShaderType() and select the appropriate fallback.

Shouldn't have side effects, 1 member and 1 getter added.