### PR TITLE
Add CI_API macro to msw gdiplus functions

### DIFF
--- a/include/cinder/msw/CinderMswGdiPlus.h
+++ b/include/cinder/msw/CinderMswGdiPlus.h
@@ -35,16 +35,16 @@
 namespace cinder { namespace msw {
 
 /** Copies the contents of a Gdiplus::Bitmap to a new Surface8u. **/
-Surface8u convertGdiplusBitmap( Gdiplus::Bitmap &bitmap );
+CI_API Surface8u convertGdiplusBitmap( Gdiplus::Bitmap &bitmap );
 
 /** Translates a cinder::SurfaceChannelOrder into a Gdiplus::PixelFormat. Supports BGR, BGRX, BGRA. Returns PixelFormatUndefined on failure **/
-Gdiplus::PixelFormat surfaceChannelOrderToGdiplusPixelFormat( const SurfaceChannelOrder &sco, bool premultiplied );
+CI_API Gdiplus::PixelFormat surfaceChannelOrderToGdiplusPixelFormat( const SurfaceChannelOrder &sco, bool premultiplied );
 
 /** Translates a Gdiplus::PixelFormat \a format to a a SurfaceChannelOrder. Sets \a resultPremultiplied based on whether \a format is premultiplied. **/
-void gdiplusPixelFormatToSurfaceChannelOrder( Gdiplus::PixelFormat format, SurfaceChannelOrder *resultChannelOrder, bool *resultPremultiplied );
+CI_API void gdiplusPixelFormatToSurfaceChannelOrder( Gdiplus::PixelFormat format, SurfaceChannelOrder *resultChannelOrder, bool *resultPremultiplied );
 
 /** Creates a Gdiplus::Bitmap which wraps a Surface8u. Requires \a surface to confrom to SurfaceConstraintsGdiPlus and throw SurfaceConstraintsExc if it does not. Caller is responsible for deleting the result.**/
-Gdiplus::Bitmap* createGdiplusBitmap( const Surface8u &surface );
+CI_API Gdiplus::Bitmap* createGdiplusBitmap( const Surface8u &surface );
 
 } } // namespace cinder::msw
 


### PR DESCRIPTION
As reported over on the [Cinder-Runtime repo](https://github.com/simongeilfus/Cinder-Runtime/issues/32) I've been trying to integrate _Runtime_ with some of Bluecadet's blocks, and the [text rendering makes use](https://github.com/bluecadet/Cinder-BluecadetText/blob/30574dcecf077f129651ca3054ab5f7eeebd6fe8/src/bluecadet/text/StyledTextLayout.cpp#L569) of `ci::msw::createGdiplusBitmap()` which was previously not exported into the resulting cinder DLL.

Only that one function was needed, but I added the macro to all the functions to be safe. Also I'm not sure if it should get added to the `SurfaceConstraintsGdiPlus` class as well?