### PR TITLE
[Linux Dep Install] Update apt package lists on linux

### DIFF
--- a/tools/linux/scripts/trusty-install-deps.sh
+++ b/tools/linux/scripts/trusty-install-deps.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Packages
+sudo apt-get update
 sudo apt-get -y install \
   libxcursor-dev \
   libxrandr-dev \


### PR DESCRIPTION
As mentioned in https://github.com/cinder/Cinder/issues/1964, apt might not find all the packages on a fresh ubuntu image (as e.g. on CI machine)