### PR TITLE
Update Renderer.cpp

### DIFF
--- a/src/cinder/app/Renderer.cpp
+++ b/src/cinder/app/Renderer.cpp
@@ -169,7 +169,7 @@ HWND Renderer2d::getHwnd() const
 
 HDC	Renderer2d::getDc() const
 {
-	return mWindowImpl->getDc();
+	return mImpl->getDc();
 }
 
 void Renderer2d::kill()


### PR DESCRIPTION
Most of the Cairo samples and Render2dBasic were affected by a problem with rendering to the window's dc instead of the backbuffer (mDoubleBufferDc ).
This change makes the geDC() in Renderer.cpp call the right method.
The mImpl->getDc() method is declared in cinder::app::msw::RendererImpl2dGdi.h as:
virtual HDC getDc() const { return ( mDoubleBuffer ) ? mDoubleBufferDc : mPaintDc; }