### PR TITLE
Fix DLL export

### DIFF
--- a/include/cinder/Stream.h
+++ b/include/cinder/Stream.h
@@ -355,16 +355,16 @@ class CI_API IStreamStateRestore {
 };
 
 //! Opens the file lcoated at \a path for read access as a stream.
-IStreamFileRef	loadFileStream( const fs::path &path );
+CI_API IStreamFileRef	loadFileStream( const fs::path &path );
 //! Opens the file located at \a path for write access as a stream, and creates it if it does not exist. Optionally creates any intermediate directories when \a createParents is true.
-OStreamFileRef	writeFileStream( const fs::path &path, bool createParents = true );
+CI_API OStreamFileRef	writeFileStream( const fs::path &path, bool createParents = true );
 //! Opens a path for read-write access as a stream.
-IoStreamFileRef readWriteFileStream( const fs::path &path );
+CI_API IoStreamFileRef readWriteFileStream( const fs::path &path );
 
 //! Loads the contents of a stream into a contiguous block of memory, pointed to by \a resultData. The size of this block is stored in \a resultDataSize.
-void loadStreamMemory( IStreamRef is, std::shared_ptr<uint8_t> *resultData, size_t *resultDataSize );
+CI_API void loadStreamMemory( IStreamRef is, std::shared_ptr<uint8_t> *resultData, size_t *resultDataSize );
 //! Loads the contents of a stream into a ref counted Buffer
-BufferRef loadStreamBuffer( IStreamRef is );
+CI_API BufferRef loadStreamBuffer( IStreamRef is );
 
 
 #if defined( CINDER_ANDROID )

--- a/include/freetype/config/ftoption.h
+++ b/include/freetype/config/ftoption.h
@@ -289,6 +289,49 @@ FT_BEGIN_HEADER
 
   /*************************************************************************/
   /*                                                                       */
+  /* DLL export compilation                                                */
+  /*                                                                       */
+  /*   When compiling FreeType as a DLL, some systems/compilers need a     */
+  /*   special keyword in front OR after the return type of function       */
+  /*   declarations.                                                       */
+  /*                                                                       */
+  /*   Two macros are used within the FreeType source code to define       */
+  /*   exported library functions: FT_EXPORT and FT_EXPORT_DEF.            */
+  /*                                                                       */
+  /*     FT_EXPORT( return_type )                                          */
+  /*                                                                       */
+  /*       is used in a function declaration, as in                        */
+  /*                                                                       */
+  /*         FT_EXPORT( FT_Error )                                         */
+  /*         FT_Init_FreeType( FT_Library*  alibrary );                    */
+  /*                                                                       */
+  /*                                                                       */
+  /*     FT_EXPORT_DEF( return_type )                                      */
+  /*                                                                       */
+  /*       is used in a function definition, as in                         */
+  /*                                                                       */
+  /*         FT_EXPORT_DEF( FT_Error )                                     */
+  /*         FT_Init_FreeType( FT_Library*  alibrary )                     */
+  /*         {                                                             */
+  /*           ... some code ...                                           */
+  /*           return FT_Err_Ok;                                           */
+  /*         }                                                             */
+  /*                                                                       */
+  /*   You can provide your own implementation of FT_EXPORT and            */
+  /*   FT_EXPORT_DEF here if you want.  If you leave them undefined, they  */
+  /*   will be later automatically defined as `extern return_type' to      */
+  /*   allow normal compilation.                                           */
+  /*                                                                       */
+  /*   Do not #undef these macros here since the build system might define */
+  /*   them for certain configurations only.                               */
+  /*                                                                       */
+#if defined( CINDER_SHARED_BUILD )
+#define FT_EXPORT(x)      __declspec(dllexport) x
+#define FT_EXPORT_DEF(x)  __declspec(dllexport) x
+#endif
+
+  /*************************************************************************/
+  /*                                                                       */
   /* Glyph Postscript Names handling                                       */
   /*                                                                       */
   /*   By default, FreeType 2 is compiled with the `psnames' module.  This */


### PR DESCRIPTION
This PR fixes a few missing function from CI_API, needed when compiling Cinder as a shared library. It also exposes the FreeType functions.