### PR TITLE
Audio shutdown fixes

### DIFF
--- a/src/cinder/audio/Context.cpp
+++ b/src/cinder/audio/Context.cpp
@@ -113,8 +113,6 @@ DeviceManager* Context::deviceManager()
 #elif defined( CINDER_MSW )
 	#if( _WIN32_WINNT > 0x0600 ) // requires Windows Vista+
 		sDeviceManager.reset( new msw::DeviceManagerWasapi() );
-	//#else
-	//	CI_ASSERT( 0 && "TODO: simple DeviceManagerXp" );
 	#endif
 #elif defined( CINDER_ANDROID )
 		sDeviceManager.reset( new android::DeviceManagerOpenSl() );

--- a/src/cinder/audio/Context.cpp
+++ b/src/cinder/audio/Context.cpp
@@ -97,9 +97,8 @@ Context* Context::master()
 #elif defined( CINDER_LINUX )
 		sMasterContext.reset( new linux::ContextPulseAudio() );
 #endif
-		if( ! sIsRegisteredForCleanup )
-			registerClearStatics();
 	}
+
 	return sMasterContext.get();
 }
 
@@ -122,10 +121,8 @@ DeviceManager* Context::deviceManager()
 #elif defined( CINDER_LINUX )
 		sDeviceManager.reset( new linux::DeviceManagerPulseAudio() );
 #endif
-
-		if( ! sIsRegisteredForCleanup )
-			registerClearStatics();
 	}
+
 	return sDeviceManager.get();
 }
 
@@ -139,6 +136,8 @@ void Context::setMaster( Context *masterContext, DeviceManager *deviceManager )
 Context::Context()
 	: mEnabled( false ), mAutoPullRequired( false ), mAutoPullCacheDirty( false ), mNumProcessedFrames( 0 ), mTimeDuringLastProcessLoop( -1.0 )
 {
+	if( ! sIsRegisteredForCleanup )
+		registerClearStatics();
 }
 
 Context::~Context()

--- a/src/cinder/audio/Node.cpp
+++ b/src/cinder/audio/Node.cpp
@@ -179,8 +179,11 @@ void Node::enable()
 		initializeImpl();
 
 	// Need to cancel events regardless if node is already enabled as one might be disabling us
-	if( mEventScheduled && ! getContext()->isAudioThread() ) {
-		getContext()->cancelScheduledEvents( shared_from_this() );
+	if( mEventScheduled ) {
+		auto context = getContext();
+		if( context && ! context->isAudioThread() ) {
+			context->cancelScheduledEvents( shared_from_this() );
+		}
 	}
 
 	if( mEnabled )
@@ -193,8 +196,11 @@ void Node::enable()
 void Node::disable()
 {
 	// Need to cancel events regardless if node is already disabled as one might be enabling us
-	if( mEventScheduled && ! getContext()->isAudioThread() ) {
-		getContext()->cancelScheduledEvents( shared_from_this() );
+	if( mEventScheduled ) {
+		auto context = getContext();
+		if( context && ! context->isAudioThread() ) {
+			context->cancelScheduledEvents( shared_from_this() );
+		}
 	}
 
 	if( ! mEnabled )


### PR DESCRIPTION
Fixing a couple shutdown bugs I ran into while working on `audio::ContextPortAudio`, which is different because it is a non-default audio context.