### PR TITLE
Remove boost from cinder json

### DIFF
--- a/include/cinder/Json.h
+++ b/include/cinder/Json.h
@@ -1,7 +1,7 @@
 /*
  Copyright (c) 2012, The Cinder Project
  All rights reserved.
- 
+
  This code is designed for use with the Cinder C++ library, http://libcinder.org
 
  Redistribution and use in source and binary forms, with or without modification, are permitted provided that
@@ -68,7 +68,7 @@ class CI_API JsonTree {
 	  private:
 		bool	mIgnoreErrors, mAllowComments;
 	};
-	
+
 	//! Options for JSON writing. Passed to the \c write method.
 	class CI_API WriteOptions {
 	public:
@@ -82,17 +82,17 @@ class CI_API JsonTree {
 		bool	getCreateDocument() const;
 		//! Returns whether JSON string is indented.
 		bool	getIndented() const;
-		
+
 	private:
 		//! \cond
 		bool	mCreateDocument;
 		bool	mIndented;
 		//! \endcond
-		
+
 	};
-	
+
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////////
-	
+
 	//! Creates a null JsonTree.
 	explicit JsonTree();
 	//! Parses the JSON contained in the string \a xmlString
@@ -120,12 +120,12 @@ class CI_API JsonTree {
 	explicit JsonTree( const std::string &key, int64_t value );
 	//! Creates a JsonTree with key \a key and uint64_t \a value .
 	explicit JsonTree( const std::string &key, uint64_t value );
-	
+
 	/**! Creates a JsonTree with key \a key and an empty array. **/
 	static JsonTree					makeArray( const std::string &key = "" );
 	/**! Creates a JsonTree with key \a key as an empty object. **/
 	static JsonTree					makeObject( const std::string &key = "" );
-	
+
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	//! Returns the JsonTree as a string with standard formatting.
@@ -140,13 +140,13 @@ class CI_API JsonTree {
 	//! Returns a ConstIter which marks the end of the children of this node.
 	ConstIter						end() const;
 
-	//! Assigns the JsonTree a new value, and creates it if it doesn't exist. 
+	//! Assigns the JsonTree a new value, and creates it if it doesn't exist.
 	JsonTree&						operator=( const JsonTree &jsonTree );
-	
-	/**! Returns the child at \a relativePath. Throws ExcChildNotFound if none matches. 
+
+	/**! Returns the child at \a relativePath. Throws ExcChildNotFound if none matches.
 		<br><tt>JsonTree node = myNode[ "path.to.child" ];</tt> **/
 	JsonTree&						operator[]( const std::string &relativePath );
-	/**! Returns the child at \a relativePath. Throws ExcChildNotFound if none matches. 
+	/**! Returns the child at \a relativePath. Throws ExcChildNotFound if none matches.
 		<br><tt>JsonTree node = myNode[ "path.to.child" ];</tt> **/
 	const JsonTree&					operator[]( const std::string &relativePath ) const;
 	//! Returns the child at \a index. Throws ExcChildNotFound if none matches.
@@ -155,11 +155,11 @@ class CI_API JsonTree {
 	const JsonTree&					operator[]( size_t index ) const;
 	//! Streams the JsonTree \a json to std::ostream \a out with standard formatting.
 	friend CI_API std::ostream&		operator<<( std::ostream &out, const JsonTree &json );
-	
-	/**! Returns the child at \a relativePath. Throws ExcChildNotFound if none matches. 
+
+	/**! Returns the child at \a relativePath. Throws ExcChildNotFound if none matches.
 		<br><tt>JsonTree node = myNode.getChild( "path.to.child" );</tt> **/
 	JsonTree&						getChild( const std::string &relativePath, bool caseSensitive = false, char separator = '.' );
-	/**! Returns the child at \a relativePath. Throws ExcChildNotFound if none matches. 
+	/**! Returns the child at \a relativePath. Throws ExcChildNotFound if none matches.
 		<br><tt>JsonTree node = myNode.getChild( "path.to.child" );</tt> **/
 	const JsonTree&					getChild( const std::string &relativePath, bool caseSensitive = false, char separator = '.' ) const;
 	//! Returns the child at \a index. Throws ExcChildNotFound if none matches.
@@ -171,7 +171,7 @@ class CI_API JsonTree {
 	//! Returns the number of child nodes.
 	size_t							getNumChildren() const	{ return getChildren().size(); }
 
-	/**! Returns whether the child at \a relativePath exists. 
+	/**! Returns whether the child at \a relativePath exists.
 		<br><tt>bool nodeExists = myNode.hasChild( "path.to.child" );</tt> **/
 	bool							hasChild( const std::string &relativePath, bool caseSensitive = false, char separator = '.' ) const;
 	//! Returns whether this node has a parent node.
@@ -186,9 +186,9 @@ class CI_API JsonTree {
 
 	//! Removes all child nodes
 	void							clear();
-	/**! Appends a copy of the node \a newChild to the children of this node.  
-		If \a this is a value node, it will change to an object or an array. 
-		If \a newChild has a key, \a this becomes an object node. 
+	/**! Appends a copy of the node \a newChild to the children of this node.
+		If \a this is a value node, it will change to an object or an array.
+		If \a newChild has a key, \a this becomes an object node.
 		If not, \a this becomes an array node. Returns reference to itself. **/
 	JsonTree&						addChild( const JsonTree &newChild );
 	/**! Appends a copy of the node \a newChild to the children of this node.
@@ -205,24 +205,24 @@ class CI_API JsonTree {
 	//! Replaces the child at \a pos with JsonTree \a newChild. Throws ExcChildNotFound if none matches.
 	void							replaceChild( Iter pos, const JsonTree &newChild );
 
-	/**! Writes this JsonTree to \a path with standard formatting. 
+	/**! Writes this JsonTree to \a path with standard formatting.
 	 If \a writeOptions creates a document then an implicit parent object node is created when necessary and \a this is treated as the root element.
 	 If \a writeOptions indents then the JSON string will be indented.**/
 	void							write( const fs::path &path, WriteOptions writeOptions = WriteOptions() );
-	/**! Writes this JsonTree to \a target. 
+	/**! Writes this JsonTree to \a target.
 		If \a writeOptions creates a document then an implicit parent object node is created when necessary and \a this is treated as the root element.
-	    If \a writeOptions indents then the JSON string will be indented.**/
+		If \a writeOptions indents then the JSON string will be indented.**/
 	void							write( DataTargetRef target, WriteOptions writeOptions = WriteOptions() );
 
 	//! Returns the node's key as a string. Returns index if node does not have a key.
 	const std::string&				getKey() const;
-	
+
 	/**! Returns a path to this node, separated by the character \a separator. **/
 	std::string						getPath( char separator = '.' ) const;
-	
+
 	/**! \brief Returns the value of the node cast to T using ci::fromString().
 		<br><tt>float value = myNode.getValue<float>();</tt> **/
-	template <typename T> 
+	template <typename T>
 	inline T						getValue() const
 	{
 		try {
@@ -259,13 +259,13 @@ private:
 	Json::Value						createNativeDoc( WriteOptions writeOptions = WriteOptions() ) const;
 	static Json::Value				deserializeNative( const std::string &jsonString, ParseOptions parseOptions );
 	static std::string				serializeNative( const Json::Value &value );
-   
-	void							init( const std::string &key, const Json::Value &value, bool setType = false, 
+
+	void							init( const std::string &key, const Json::Value &value, bool setType = false,
 		NodeType nodeType = NODE_VALUE, ValueType valueType = VALUE_STRING );
-	
+
 	JsonTree*						getNodePtr( const std::string &relativePath, bool caseSensitive, char separator ) const;
 	static bool						isIndex( const std::string &key );
-	
+
 	Container						mChildren;
 	std::string						mKey;
 	JsonTree						*mParent;
@@ -279,7 +279,7 @@ private:
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 	//! Base class for JsonTree exceptions.
-	class CI_API Exception : public cinder::Exception 
+	class CI_API Exception : public cinder::Exception
 	{
 	};
 
@@ -287,9 +287,9 @@ private:
 	class CI_API ExcChildNotFound : public JsonTree::Exception {
 	  public:
 		ExcChildNotFound( const JsonTree &node, const std::string &key ) throw();
-		virtual const char* what() const throw() 
-		{ 
-			return mMessage; 
+		virtual const char* what() const throw()
+		{
+			return mMessage;
 		}
 
 	  private:
@@ -300,9 +300,9 @@ private:
 	class CI_API ExcNonConvertible : public JsonTree::Exception {
 	  public:
 		ExcNonConvertible( const JsonTree &node ) throw();
-		virtual const char* what() const throw() 
-		{ 
-			return mMessage; 
+		virtual const char* what() const throw()
+		{
+			return mMessage;
 		}
 
 	  private:
@@ -313,11 +313,11 @@ private:
 	class CI_API ExcJsonParserError : public JsonTree::Exception {
 	public:
 		ExcJsonParserError( const std::string &errorMessage ) throw();
-		virtual const char* what() const throw() 
-		{ 
-			return mMessage; 
+		virtual const char* what() const throw()
+		{
+			return mMessage;
 		}
-		
+
 	private:
 		char mMessage[ 2048 ];
 	};

--- a/include/cinder/Json.h
+++ b/include/cinder/Json.h
@@ -30,7 +30,7 @@
 #include "cinder/Utilities.h"
 
 #include <string>
-#include <boost/container/list.hpp>
+#include <list>
 
 namespace Json {
 	class Value;
@@ -40,9 +40,9 @@ namespace cinder {
 
 class CI_API JsonTree {
   public:
-	
+
 	//! \cond
-	typedef boost::container::list<JsonTree> Container;
+	typedef std::list<JsonTree> Container;
 
 	typedef Container::const_iterator ConstIter;
 	typedef Container::iterator Iter;

--- a/src/cinder/Json.cpp
+++ b/src/cinder/Json.cpp
@@ -1,7 +1,7 @@
 /*
  Copyright (c) 2012, The Cinder Project
  All rights reserved.
- 
+
  Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 
  This code is designed for use with the Cinder C++ library, http://libcinder.org
@@ -9,9 +9,9 @@
  Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  the following conditions are met:
 
-    * Redistributions of source code must retain the above copyright notice, this list of conditions and
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
 	the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
 	the following disclaimer in the documentation and/or other materials provided with the distribution.
 
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
@@ -38,21 +38,21 @@
 using namespace std;
 
 namespace cinder {
-	
-JsonTree::ParseOptions::ParseOptions() 
+
+JsonTree::ParseOptions::ParseOptions()
 	: mIgnoreErrors( false ), mAllowComments( true )
 {
 }
-	
-JsonTree::ParseOptions& JsonTree::ParseOptions::ignoreErrors( bool ignore ) 
-{ 
-	mIgnoreErrors = ignore; 
-	return *this; 
+
+JsonTree::ParseOptions& JsonTree::ParseOptions::ignoreErrors( bool ignore )
+{
+	mIgnoreErrors = ignore;
+	return *this;
 }
-	
-bool JsonTree::ParseOptions::getIgnoreErrors() const 
-{ 
-	return mIgnoreErrors; 
+
+bool JsonTree::ParseOptions::getIgnoreErrors() const
+{
+	return mIgnoreErrors;
 }
 
 JsonTree::ParseOptions& JsonTree::ParseOptions::allowComments( bool allow )
@@ -90,14 +90,14 @@ bool JsonTree::WriteOptions::getCreateDocument() const
 
 bool JsonTree::WriteOptions::getIndented() const
 {
-	return mIndented;	
+	return mIndented;
 }
-		
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 JsonTree::JsonTree()
 {
-    init( "", Json::Value( Json::nullValue ), true, NODE_NULL );
+	init( "", Json::Value( Json::nullValue ), true, NODE_NULL );
 }
 
 JsonTree::JsonTree( const JsonTree &jsonTree )
@@ -110,7 +110,7 @@ JsonTree::JsonTree( const JsonTree &jsonTree )
 
 	for( ConstIter childIt = jsonTree.begin(); childIt != jsonTree.end(); ++childIt ) {
 		pushBack( *childIt );
-    }
+	}
 }
 
 JsonTree& JsonTree::operator=( const JsonTree &jsonTree )
@@ -125,13 +125,13 @@ JsonTree& JsonTree::operator=( const JsonTree &jsonTree )
 
 	for( ConstIter childIt = jsonTree.begin(); childIt != jsonTree.end(); ++childIt ) {
 		pushBack( *childIt );
-    }
+	}
 
 	return *this;
 }
 
 JsonTree::JsonTree( DataSourceRef dataSource, ParseOptions parseOptions )
-{    
+{
 	string jsonString = loadString( dataSource );
 	Json::Value value = deserializeNative( jsonString, parseOptions );
 	init( "", value, true, NODE_OBJECT );
@@ -153,47 +153,47 @@ JsonTree::JsonTree( const std::string &key, const Json::Value &value )
 {
 	init( key, value, true, NODE_VALUE );
 }
-    
+
 JsonTree::JsonTree( const string &key, bool value )
 {
-    init( key, Json::Value( value ), false, NODE_VALUE, VALUE_BOOL );
+	init( key, Json::Value( value ), false, NODE_VALUE, VALUE_BOOL );
 }
-    
+
 JsonTree::JsonTree( const string &key, double value )
 {
-    init( key, Json::Value( value ), false, NODE_VALUE, VALUE_DOUBLE );
+	init( key, Json::Value( value ), false, NODE_VALUE, VALUE_DOUBLE );
 }
-    
+
 JsonTree::JsonTree( const string &key, float value )
 {
-    init( key, Json::Value( (double)value ), false, NODE_VALUE, VALUE_DOUBLE );
+	init( key, Json::Value( (double)value ), false, NODE_VALUE, VALUE_DOUBLE );
 }
 
 JsonTree::JsonTree( const string &key, int value )
 {
-    init( key, Json::Value( value ), false, NODE_VALUE, VALUE_INT );
+	init( key, Json::Value( value ), false, NODE_VALUE, VALUE_INT );
 }
 
 JsonTree::JsonTree( const string &key, const std::string &value )
 {
-    init( key, Json::Value( value ), false, NODE_VALUE, VALUE_STRING );
+	init( key, Json::Value( value ), false, NODE_VALUE, VALUE_STRING );
 }
 
 JsonTree::JsonTree( const std::string &key, const char *value )
 {
-    init( key, Json::Value( value ), false, NODE_VALUE, VALUE_STRING );
+	init( key, Json::Value( value ), false, NODE_VALUE, VALUE_STRING );
 }
 
 JsonTree::JsonTree( const string &key, uint32_t value )
 {
-    init( key, Json::Value( value ), false, NODE_VALUE, VALUE_UINT );
+	init( key, Json::Value( value ), false, NODE_VALUE, VALUE_UINT );
 }
 
 JsonTree::JsonTree( const string &key, int64_t value )
 {
 	init( key, Json::Value( static_cast<Json::Value::Int64>( value ) ), true, NODE_VALUE, VALUE_INT );
 }
-	
+
 JsonTree::JsonTree( const string &key, uint64_t value )
 {
 	init( key, Json::Value( static_cast<Json::Value::UInt64>( value ) ), true, NODE_VALUE, VALUE_UINT );
@@ -211,7 +211,7 @@ JsonTree JsonTree::makeObject( const std::string &key )
 {
 	JsonTree result;
 	result.mNodeType = NODE_OBJECT;
-	result.mKey = key;	
+	result.mKey = key;
 	return result;
 }
 
@@ -219,28 +219,28 @@ JsonTree JsonTree::makeObject( const std::string &key )
 
 void JsonTree::init( const string &key, const Json::Value &value, bool setType, NodeType nodeType, ValueType valueType )
 {
-    mKey = key;
+	mKey = key;
 	mNodeType = nodeType;
 	mParent = 0;
 	mValue = "";
 	mValueType = valueType;
 
 	if( ! value.isNull() && ( value.isArray() || value.isObject() ) ) {
-        if( value.isArray() ) {
-            mNodeType = NODE_ARRAY;
-            for ( uint32_t i = 0; i < value.size(); i++ ) {
-                pushBack( JsonTree( "", value[ i ] ) );
-            }
-        }
+		if( value.isArray() ) {
+			mNodeType = NODE_ARRAY;
+			for ( uint32_t i = 0; i < value.size(); i++ ) {
+				pushBack( JsonTree( "", value[ i ] ) );
+			}
+		}
 		else if( value.isObject() ) {
-            mNodeType = NODE_OBJECT;
-            Json::Value::Members members = value.getMemberNames();
-            for( Json::Value::Members::const_iterator memberIt = members.begin(); memberIt != members.end(); ++memberIt ) {
+			mNodeType = NODE_OBJECT;
+			Json::Value::Members members = value.getMemberNames();
+			for( Json::Value::Members::const_iterator memberIt = members.begin(); memberIt != members.end(); ++memberIt ) {
 				string key = *memberIt;
-                pushBack( JsonTree( key, value[ key ] ) );
-            }
-        }
-    }
+				pushBack( JsonTree( key, value[ key ] ) );
+			}
+		}
+	}
 	else {
 		if( value.isBool() ) {
 			mValue = toString( value.asBool() );
@@ -248,25 +248,25 @@ void JsonTree::init( const string &key, const Json::Value &value, bool setType, 
 				mValueType = VALUE_BOOL;
 			}
 		}
-		else if ( value.isInt() ) { 
+		else if ( value.isInt() ) {
 			mValue = toString( value.asLargestInt() );
 			if ( setType ) {
 				mValueType = VALUE_INT;
 			}
 		}
-		else if ( value.isString() ) { 
+		else if ( value.isString() ) {
 			mValue = toString( value.asString() );
 			if ( setType ) {
 				mValueType = VALUE_STRING;
 			}
 		}
-		else if ( value.isUInt() ) { 
+		else if ( value.isUInt() ) {
 			mValue = toString( value.asLargestUInt() );
 			if ( setType ) {
 				mValueType = VALUE_UINT;
 			}
 		}
-		else if ( value.isDouble() ) { // jsoncpp defines isDouble() to include integral types, so this must follow isInt() && isUint() 
+		else if ( value.isDouble() ) { // jsoncpp defines isDouble() to include integral types, so this must follow isInt() && isUint()
 			mValue = toString( value.asDouble() );
 			if ( setType ) {
 				mValueType = VALUE_DOUBLE;
@@ -283,12 +283,12 @@ Json::Value JsonTree::deserializeNative( const string &jsonString, ParseOptions 
 	features.strictRoot_ = ! parseOptions.getIgnoreErrors();
 	Json::Reader reader( features );
 	Json::Value value;
-    try {
-        reader.parse( jsonString, value, false );
-    }
+	try {
+		reader.parse( jsonString, value, false );
+	}
 	catch ( ... ) {
 		throw ExcJsonParserError( "Unknown error." );
-    }
+	}
 	if( ! parseOptions.getIgnoreErrors() ) {
 		string errorMessage = reader.getFormattedErrorMessages();
 		if( errorMessage.length() > 0 ) {
@@ -297,7 +297,7 @@ Json::Value JsonTree::deserializeNative( const string &jsonString, ParseOptions 
 	}
 	return value;
 }
-	
+
 void JsonTree::clear()
 {
 	mChildren.clear();
@@ -319,7 +319,7 @@ void JsonTree::pushBack( const JsonTree &newChild )
 
 	mChildren.push_back( newChild );
 	mChildren.back().mParent = this;
-    mValue = "";
+	mValue = "";
 }
 
 void JsonTree::removeChild( size_t index )
@@ -333,7 +333,7 @@ void JsonTree::removeChild( size_t index )
 		throw ExcChildNotFound( *this, toString( index ) );
 	}
 }
-	
+
 JsonTree::Iter JsonTree::removeChild( JsonTree::Iter pos )
 {
 	try {
@@ -355,7 +355,7 @@ void JsonTree::replaceChild( size_t index, const JsonTree &newChild )
 		throw ExcChildNotFound( *this, toString( index ) );
 	}
 }
-	
+
 void JsonTree::replaceChild( JsonTree::Iter pos, const JsonTree &newChild )
 {
 	try {
@@ -388,27 +388,27 @@ const JsonTree&	JsonTree::operator[]( size_t index ) const
 	return getChild( index );
 }
 
-JsonTree::Iter JsonTree::begin() 
-{ 
-	return mChildren.begin(); 
-}
-
-JsonTree::ConstIter JsonTree::begin() const 
-{ 
+JsonTree::Iter JsonTree::begin()
+{
 	return mChildren.begin();
 }
 
-JsonTree::Iter JsonTree::end() 
-{ 
+JsonTree::ConstIter JsonTree::begin() const
+{
+	return mChildren.begin();
+}
+
+JsonTree::Iter JsonTree::end()
+{
 	return mChildren.end();
 }
 
-JsonTree::ConstIter JsonTree::end() const 
-{ 
-	return mChildren.end(); 
+JsonTree::ConstIter JsonTree::end() const
+{
+	return mChildren.end();
 }
 
-JsonTree& JsonTree::getChild( const std::string &relativePath, bool caseSensitive, char separator ) 
+JsonTree& JsonTree::getChild( const std::string &relativePath, bool caseSensitive, char separator )
 {
 	JsonTree *child = getNodePtr( relativePath, caseSensitive, separator );
 	if ( child ) {
@@ -418,7 +418,7 @@ JsonTree& JsonTree::getChild( const std::string &relativePath, bool caseSensitiv
 	}
 }
 
-const JsonTree& JsonTree::getChild( const std::string &relativePath, bool caseSensitive, char separator ) const 
+const JsonTree& JsonTree::getChild( const std::string &relativePath, bool caseSensitive, char separator ) const
 {
 	JsonTree *child = getNodePtr( relativePath, caseSensitive, separator );
 	if ( child ) {
@@ -428,7 +428,7 @@ const JsonTree& JsonTree::getChild( const std::string &relativePath, bool caseSe
 	}
 }
 
-JsonTree& JsonTree::getChild( size_t index ) 
+JsonTree& JsonTree::getChild( size_t index )
 {
 	JsonTree *child = getNodePtr( toString( index ), false, '.' );
 	if ( child ) {
@@ -438,7 +438,7 @@ JsonTree& JsonTree::getChild( size_t index )
 	}
 }
 
-const JsonTree& JsonTree::getChild( size_t index ) const 
+const JsonTree& JsonTree::getChild( size_t index ) const
 {
 	JsonTree *child = getNodePtr( toString( index ), false, '.' );
 	if ( child ) {
@@ -449,8 +449,8 @@ const JsonTree& JsonTree::getChild( size_t index ) const
 }
 
 const JsonTree::Container& JsonTree::getChildren() const
-{ 
-	return mChildren; 
+{
+	return mChildren;
 }
 
 bool JsonTree::hasChild( const string &relativePath, bool caseSensitive, char separator ) const
@@ -463,33 +463,33 @@ bool JsonTree::hasChildren() const
 	return mChildren.size() > 0;
 }
 
-JsonTree& JsonTree::getParent() 
-{ 
-	return *mParent; 
-}
-const JsonTree& JsonTree::getParent() const 
-{ 
+JsonTree& JsonTree::getParent()
+{
 	return *mParent;
 }
-bool JsonTree::hasParent() const 
-{ 
-	return mParent != 0; 
+const JsonTree& JsonTree::getParent() const
+{
+	return *mParent;
 }
-    
-const string& JsonTree::getKey() const 
-{ 
-    return mKey;
+bool JsonTree::hasParent() const
+{
+	return mParent != 0;
+}
+
+const string& JsonTree::getKey() const
+{
+	return mKey;
 }
 
 string JsonTree::getPath( char separator ) const
 {
-    string result;
-    
-    const JsonTree *node = this;
+	string result;
+
+	const JsonTree *node = this;
 	bool prevWasArrayIndex = false;
-    while( node != 0 ) {
+	while( node != 0 ) {
 		bool isArrayIndex = false;
-        string nodeName = node->mKey;
+		string nodeName = node->mKey;
 		if( nodeName.empty() && node->mParent ) { // should be an array index; find out which by searching our parent's children for ourselves
 			size_t index = 0;
 			for( ConstIter parentChildIt = node->mParent->mChildren.begin(); parentChildIt != node->mParent->mChildren.end(); ++parentChildIt, ++index ) {
@@ -506,11 +506,11 @@ string JsonTree::getPath( char separator ) const
 			result = nodeName + separator + result;
 		} else if( ! nodeName.empty() ) {
 			result = nodeName + result;
-        }
-        node = node->mParent;
+		}
+		node = node->mParent;
 		prevWasArrayIndex = isArrayIndex;
-    }
-    return result;
+	}
+	return result;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -572,16 +572,16 @@ JsonTree* JsonTree::getNodePtr( const string &relativePath, bool caseSensitive, 
 			}
 		}
 
-        // Return null pointer if we're out of nodes to search,
-        // otherwise assign node and continue to search its children
+		// Return null pointer if we're out of nodes to search,
+		// otherwise assign node and continue to search its children
 		if( node == curNode->getChildren().end() ) {
-            return 0;
-        } else {
+			return nullptr;
+		} else {
 			curNode = const_cast<JsonTree*>( &( *node ) );
-        }
+		}
 	}
 
-    // Return child
+	// Return child
 	return curNode;
 
 }
@@ -593,9 +593,9 @@ bool JsonTree::isIndex( const string &key )
 	char* p = to_convert;
 	errno = 0;
 	unsigned long val = strtoul( to_convert, &p, 10 );
-    if( val > 0L ) {
-        // Prevents "unused variable" warning 
-    }
+	if( val > 0L ) {
+		// Prevents "unused variable" warning
+	}
 	return !( errno != 0 || to_convert == p || *p != 0 );
 }
 
@@ -607,10 +607,10 @@ Json::Value JsonTree::createNativeDoc( WriteOptions writeOptions ) const
 	Json::Value value( Json::nullValue );
 
 	// Key on node type
-    switch( mNodeType ) {
+	switch( mNodeType ) {
 		case NODE_ARRAY: {
 			uint32_t i = 0;
-			
+
 			// Add children to array as objects
 			for ( ConstIter childIt = mChildren.begin(); childIt != mChildren.end(); ++childIt, i++ ) {
 				value[ i ] = childIt->createNativeDoc();
@@ -644,28 +644,28 @@ Json::Value JsonTree::createNativeDoc( WriteOptions writeOptions ) const
 			}
 		break;
 		default:
-        break;
-    }
-    
+		break;
+	}
+
 	// Return JsonCpp object
-    if ( writeOptions.getCreateDocument() && !value.isNull() ) { 
-        Json::Value doc( Json::objectValue );
-        doc[ mKey ] = value;
-        return doc;
-    } else {
-        return value;
-    }
+	if ( writeOptions.getCreateDocument() && !value.isNull() ) {
+		Json::Value doc( Json::objectValue );
+		doc[ mKey ] = value;
+		return doc;
+	} else {
+		return value;
+	}
 }
 
 string JsonTree::serialize() const
-{	
-    stringstream ss;
-    ss << *this;
-    return ss.str();
+{
+	stringstream ss;
+	ss << *this;
+	return ss.str();
 }
 
 string JsonTree::serializeNative( const Json::Value & value )
-{	
+{
 	try {
 		Json::StyledWriter writer;
 		return writer.write( value );
@@ -685,7 +685,7 @@ void JsonTree::write( DataTargetRef target, JsonTree::WriteOptions writeOptions 
 	string jsonString = "";
 
 	try {
-		
+
 		// Create JsonCpp data to send to parser
 		Json::Value value = createNativeDoc( writeOptions );
 
@@ -717,7 +717,7 @@ void JsonTree::write( DataTargetRef target, JsonTree::WriteOptions writeOptions 
 	// Save data to file
 	OStreamRef os = target->getStream();
 	os->writeData( jsonString.c_str(), jsonString.length() );
-	
+
 }
 
 
@@ -758,7 +758,7 @@ ostream& operator<<( ostream &out, const JsonTree &json )
 	JsonTree::WriteOptions writeOptions;
 	bool createDocument = json.mNodeType == JsonTree::NODE_VALUE;
 	writeOptions.createDocument( createDocument );
-    Json::Value value = json.createNativeDoc( writeOptions );
+	Json::Value value = json.createNativeDoc( writeOptions );
 	string doc = JsonTree::serializeNative( value );
 	out << doc;
 	return out;


### PR DESCRIPTION
This removes the boost dependencies from Json.cpp and Json.h.

The second commit only contains some small modifications I made while I was messing with the function anyway, but it came with a lot of whitespace changes, so this PR is probably easier to review commit by commit.