### PR TITLE
CMake samples fixes.

### DIFF
--- a/samples/CameraPersp/proj/cmake/CMakeLists.txt
+++ b/samples/CameraPersp/proj/cmake/CMakeLists.txt
@@ -9,6 +9,7 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/CameraPerspApp.cpp
+	SOURCES		${APP_PATH}/src/CameraPerspApp.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/FrustumCulling/proj/cmake/CMakeLists.txt
+++ b/samples/FrustumCulling/proj/cmake/CMakeLists.txt
@@ -9,6 +9,7 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/FrustumCullingApp.cpp
+	SOURCES		${APP_PATH}/src/FrustumCullingApp.cpp
+			${APP_PATH}/src/CullableObject.cpp
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/Kaleidoscope/proj/cmake/CMakeLists.txt
+++ b/samples/Kaleidoscope/proj/cmake/CMakeLists.txt
@@ -9,6 +9,10 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/InstascopeApp.cpp
+	SOURCES		${APP_PATH}/src/InstascopeApp.cpp
+			${APP_PATH}/src/InstagramStream.cpp
+			${APP_PATH}/src/TextRibbon.cpp
+			${APP_PATH}/src/TrianglePiece.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/MandelbrotGLSL/proj/cmake/CMakeLists.txt
+++ b/samples/MandelbrotGLSL/proj/cmake/CMakeLists.txt
@@ -9,6 +9,7 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/MandelbrotGLSLApp.cpp
+	SOURCES		${APP_PATH}/src/MandelbrotGLSLApp.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/QuaternionAccum/proj/cmake/CMakeLists.txt
+++ b/samples/QuaternionAccum/proj/cmake/CMakeLists.txt
@@ -9,6 +9,7 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/QuaternionAccumApp.cpp
+	SOURCES		${APP_PATH}/src/QuaternionAccumApp.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/RDiffusion/proj/cmake/CMakeLists.txt
+++ b/samples/RDiffusion/proj/cmake/CMakeLists.txt
@@ -9,6 +9,7 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/RDiffusionApp.cpp
+	SOURCES		${APP_PATH}/src/RDiffusionApp.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/StereoscopicRendering/proj/cmake/CMakeLists.txt
+++ b/samples/StereoscopicRendering/proj/cmake/CMakeLists.txt
@@ -9,6 +9,8 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/StereoscopicRenderingApp.cpp
+	SOURCES		${APP_PATH}/src/StereoscopicRenderingApp.cpp
+			${APP_PATH}/src/StereoAutoFocuser.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/SurfaceBasic/proj/cmake/CMakeLists.txt
+++ b/samples/SurfaceBasic/proj/cmake/CMakeLists.txt
@@ -9,6 +9,7 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/SurfaceBasicApp.cpp
+	SOURCES		${APP_PATH}/src/SurfaceBasicApp.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/TextTest/proj/cmake/CMakeLists.txt
+++ b/samples/TextTest/proj/cmake/CMakeLists.txt
@@ -9,6 +9,7 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/TextTestApp.cpp
+	SOURCES		${APP_PATH}/src/TextTestApp.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )

--- a/samples/VoronoiGpu/proj/cmake/CMakeLists.txt
+++ b/samples/VoronoiGpu/proj/cmake/CMakeLists.txt
@@ -9,6 +9,8 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/VoronoiGpuApp.cpp
+	SOURCES		${APP_PATH}/src/VoronoiGpuApp.cpp
+			${APP_PATH}/src/VoronoiGpu.cpp
+	INCLUDES	${APP_PATH}/include
 	CINDER_PATH ${CINDER_PATH}
 )


### PR DESCRIPTION
This PR should fix compilation, through CMake, for the following samples :  

- CameraPersp
- FrustumCulling
- Kaleidoscope
- MandelbrotGLSL
- QuaternionAccum
- RDiffusion
- StereoscopicRendering
- SurfaceBasic
- TextTest
- VoronoiGpu

Partially addresses #2052 