### PR TITLE
Enable ci::Serial on Linux.

### DIFF
--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -60,12 +60,12 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/Url.cpp
 	${CINDER_SRC_DIR}/cinder/Utilities.cpp
 	${CINDER_SRC_DIR}/cinder/Xml.cpp
+	${CINDER_SRC_DIR}/cinder/Serial.cpp
 )
 
 if( ( NOT CINDER_LINUX ) AND ( NOT CINDER_ANDROID ) )
 	list( APPEND SRC_SET_CINDER
 		${CINDER_SRC_DIR}/cinder/Capture.cpp
-		${CINDER_SRC_DIR}/cinder/Serial.cpp
 	)
 endif()
 

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -60,12 +60,15 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/Url.cpp
 	${CINDER_SRC_DIR}/cinder/Utilities.cpp
 	${CINDER_SRC_DIR}/cinder/Xml.cpp
-	${CINDER_SRC_DIR}/cinder/Serial.cpp
 )
 
 if( ( NOT CINDER_LINUX ) AND ( NOT CINDER_ANDROID ) )
 	list( APPEND SRC_SET_CINDER
 		${CINDER_SRC_DIR}/cinder/Capture.cpp
+	)
+elseif( NOT CINDER_ANDROID )
+	list( APPEND SRC_SET_CINDER
+		${CINDER_SRC_DIR}/cinder/Serial.cpp
 	)
 endif()
 

--- a/src/cinder/Serial.cpp
+++ b/src/cinder/Serial.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <fcntl.h>
 
-#if defined( CINDER_MAC )
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 	#include <termios.h>
 	#include <sys/ioctl.h>
 	#include <getopt.h>
@@ -73,7 +73,7 @@ Serial::~Serial()
 
 Serial::Impl::Impl( const Serial::Device &device, int baudRate )
 {
-#if defined( CINDER_MAC )
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 	mFd = open( ( "/dev/" + device.getName() ).c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK );
 	if( mFd == -1 ) {
 		throw SerialExcOpenFailed();
@@ -89,7 +89,9 @@ Serial::Impl::Impl( const Serial::Device &device, int baudRate )
 	baudToConstant[4800] = B4800;
 	baudToConstant[9600] = B9600;			
 	baudToConstant[19200] = B19200;
+#if !defined( CINDER_LINUX )
 	baudToConstant[28800] = B28800;
+#endif
 	baudToConstant[38400] = B38400;
 	baudToConstant[57600] = B57600;
 	baudToConstant[115200] = B115200;
@@ -139,7 +141,7 @@ Serial::Impl::Impl( const Serial::Device &device, int baudRate )
 
 Serial::Impl::~Impl()
 {
-#if defined( CINDER_MAC )
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 	// restore the termios from before we opened the port
 	::tcsetattr( mFd, TCSANOW, &mSavedOptions );
 	::close( mFd );
@@ -176,7 +178,7 @@ const std::vector<Serial::Device>& Serial::getDevices( bool forceRefresh )
 
 	sDevices.clear();
 
-#if defined( CINDER_MAC )	
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 	::DIR *dir;
 	::dirent *entry;
 	dir = ::opendir( "/dev" );
@@ -248,7 +250,7 @@ void Serial::writeBytes( const void *data, size_t numBytes )
 	size_t totalBytesWritten = 0;
 	
 	while( totalBytesWritten < numBytes ) {
-#if defined( CINDER_MAC )
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 		long bytesWritten = ::write( mImpl->mFd, data, numBytes - totalBytesWritten );
 		if( ( bytesWritten == -1 ) && ( errno != EAGAIN ) )
 			throw SerialExcWriteFailure();
@@ -266,7 +268,7 @@ void Serial::readBytes( void *data, size_t numBytes )
 {
 	size_t totalBytesRead = 0;
 	while( totalBytesRead < numBytes ) {
-#if defined( CINDER_MAC )
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 		long bytesRead = ::read( mImpl->mFd, data, numBytes - totalBytesRead );
 		if( ( bytesRead == -1 ) && ( errno != EAGAIN ) )
 			throw SerialExcReadFailure();
@@ -285,7 +287,7 @@ void Serial::readBytes( void *data, size_t numBytes )
 
 size_t Serial::readAvailableBytes( void *data, size_t maximumBytes )
 {
-#if defined( CINDER_MAC )
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 	long bytesRead = ::read( mImpl->mFd, data, maximumBytes );
 #elif defined( CINDER_MSW )
 	::DWORD bytesRead = 0;
@@ -346,7 +348,7 @@ size_t Serial::getNumBytesAvailable() const
 {
 	int result;
 	
-#if defined( CINDER_MAC )
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 	::ioctl( mImpl->mFd, FIONREAD, &result );
 #elif defined( CINDER_MSW )
 	::COMSTAT status;
@@ -362,7 +364,7 @@ size_t Serial::getNumBytesAvailable() const
 	
 void Serial::flush( bool input, bool output )
 {
-#if defined( CINDER_MAC )
+#if defined( CINDER_MAC ) || defined( CINDER_LINUX )
 	int queue;
 	if( input && output )
 		queue = TCIOFLUSH;


### PR DESCRIPTION
This comes cheap since it shares the same unix implementation as macOS. `SerialCommunication` sample builds and runs also on Linux now. Relevant #2052.