### PR TITLE
Added videoInput.cpp to msw platform cmake file and fixed header path

### DIFF
--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -86,12 +86,15 @@ if( NOT CINDER_DISABLE_VIDEO )
 			message( WARNING "Requested GStreamer video playback support for MSW but no suitable GStreamer installation found. Make sure that GStreamer is installed properly and GSTREAMER_1_0_ROOT_X86_64 is defined in your env variables. " )
 		endif()
 	endif()
+
+	list( APPEND SRC_SET_VIDEO_MSW ${CINDER_SRC_DIR}/videoInput/videoInput.cpp )
 endif()
 
 list( APPEND CINDER_SRC_FILES
 	${SRC_SET_MSW}
 	${SRC_SET_APP_MSW}
 	${SRC_SET_AUDIO_MSW}
+	${SRC_SET_VIDEO_MSW}
 	${SRC_SET_CINDER_AUDIO_DSP}
 )
 
@@ -99,6 +102,7 @@ source_group( "cinder\\msw"			FILES ${SRC_SET_MSW} )
 source_group( "cinder\\app\\msw"	FILES ${SRC_SET_APP_MSW} )
 source_group( "cinder\\audio\\msw"	FILES ${SRC_SET_AUDIO_MSW} )
 source_group( "cinder\\audio\\dsp"	FILES ${SRC_SET_CINDER_AUDIO_DSP} )
+source_group( "cinder\\video\\msw"	FILES ${SRC_SET_VIDEO_MSW} )
 
 list( APPEND CINDER_INCLUDE_SYSTEM_PRIVATE
 	${CINDER_INC_DIR}/msw/zlib

--- a/src/videoInput/videoInput.cpp
+++ b/src/videoInput/videoInput.cpp
@@ -7,7 +7,7 @@
 //THE SOFTWARE.
 #include  <iostream>
 
-#include "videoInput/videoInput.h"
+#include "msw/videoInput/videoInput.h"
 #include "cinder/msw/CinderMsw.h"
 #include <tchar.h>
 


### PR DESCRIPTION
When compiling cinder using CMake on Windows, videoInput.cpp was missing from platform_msw.cmake, leading to unresolved external symbol errors. This commit adds videoInput.cpp back into the project and adds a cinder/video/msw source group to bring it in line with the cinder/audio/msw source group.

Tested using CMake 3.13.0, MSVC 15.8.8, Windows 10 build 1803.