### PR TITLE
add Capture implementation for Linux

### DIFF
--- a/include/cinder/Capture.h
+++ b/include/cinder/Capture.h
@@ -50,6 +50,10 @@
 	namespace cinder {
 		class CaptureImplJni;
 	}	
+#elif defined( CINDER_LINUX )
+	namespace cinder {
+		class CaptureImplLinux;
+	}
 #endif
 
 #include <map>
@@ -106,7 +110,7 @@ class CI_API Capture {
 	//! Finds the first device whose name contains the string \a nameFragment
 	static DeviceRef findDeviceByNameContains( const std::string &nameFragment );
 
-#if defined( CINDER_COCOA ) || defined( CINDER_ANDROID )
+#if defined( CINDER_COCOA ) || defined( CINDER_ANDROID ) || defined( CINDER_LINUX )
 	typedef std::string DeviceIdentifier;
 #else
 	typedef int DeviceIdentifier;
@@ -148,6 +152,8 @@ class CI_API Capture {
 	CaptureImplDirectShow			*mImpl;
 #elif defined( CINDER_ANDROID )
 	CaptureImplJni					*mImpl;		
+#elif defined( CINDER_LINUX )
+	CaptureImplLinux 				*mImpl;
 #endif
 };
 

--- a/include/cinder/CaptureImplLinux.h
+++ b/include/cinder/CaptureImplLinux.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "cinder/Cinder.h"
+#include "cinder/Capture.h"
+
+#include <thread>
+#include <condition_variable>
+
+namespace cinder {
+
+class CaptureImplLinux {
+public:
+	class Device : public Capture::Device {
+	public:
+		Device( const std::string &deviceFile );
+
+		Capture::DeviceIdentifier getUniqueId() const override { return mDeviceFile; }
+
+		bool checkAvailable() const override;
+		bool isConnected() const override { return mIsConnected; }
+
+		void setConnected( bool c=true ) { mIsConnected = c; }
+
+	protected:
+		Capture::DeviceIdentifier mDeviceFile;
+		bool mIsConnected;
+	};
+
+public:
+	CaptureImplLinux( int32_t width, int32_t height, const Capture::DeviceRef device );
+	~CaptureImplLinux();
+
+	void start();
+	void stop();
+
+	bool isCapturing();
+	bool checkNewFrame() const;
+
+	Surface8uRef getSurface() const;
+
+	int32_t getWidth() const { return mWidth; }
+	int32_t getHeight() const { return mHeight; }
+
+	const Capture::DeviceRef getDevice() const { return mDevice; }
+
+	static const std::vector<Capture::DeviceRef>& getDevices( bool forceRefresh = false );
+
+protected:
+	Capture::DeviceRef mDevice;
+	int32_t mWidth, mHeight;
+
+	int mDeviceFileDescriptor;
+
+	std::thread mThread;
+	std::atomic<bool> mRunning;
+	std::condition_variable mStopCondition;
+	mutable std::atomic<bool> mNewFrameAvailable;
+
+	void update();
+
+protected:
+	struct RawFrame {
+		void *data;
+		size_t length;
+	} mRawBuffer[2];
+
+	SurfaceRef mSurfaces[2];
+	std::atomic<size_t> mSurfaceReadIndex;
+
+};
+
+}

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -62,13 +62,10 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/Xml.cpp
 )
 
-if( ( NOT CINDER_LINUX ) AND ( NOT CINDER_ANDROID ) )
-	list( APPEND SRC_SET_CINDER
-		${CINDER_SRC_DIR}/cinder/Capture.cpp
-	)
-elseif( NOT CINDER_ANDROID )
+if( NOT CINDER_ANDROID )
 	list( APPEND SRC_SET_CINDER
 		${CINDER_SRC_DIR}/cinder/Serial.cpp
+		${CINDER_SRC_DIR}/cinder/Capture.cpp
 	)
 endif()
 

--- a/proj/cmake/platform_linux.cmake
+++ b/proj/cmake/platform_linux.cmake
@@ -50,6 +50,13 @@ if( NOT CINDER_DISABLE_VIDEO )
 	)
 endif()
 
+if( NOT CINDER_DISABLE_CAPTURE )
+	list( APPEND SRC_SET_CINDER_VIDEO_LINUX
+		${CINDER_SRC_DIR}/cinder/CaptureImplLinux.cpp
+	)
+	list( APPEND CINDER_LIBS_DEPENDS libv4l2.so )
+endif()
+
 # Curl
 list( APPEND SRC_SET_CINDER_LINUX ${CINDER_SRC_DIR}/cinder/UrlImplCurl.cpp )
 

--- a/src/cinder/Capture.cpp
+++ b/src/cinder/Capture.cpp
@@ -34,6 +34,9 @@
 #elif defined( CINDER_ANDROID )
 	#include "cinder/CaptureImplJni.h"
 	typedef cinder::CaptureImplJni CapturePlatformImpl;	
+#elif defined( CINDER_LINUX )
+	#include "cinder/CaptureImplLinux.h"
+	typedef cinder::CaptureImplLinux CapturePlatformImpl;
 #endif
 
 #include <set>

--- a/src/cinder/CaptureImplLinux.cpp
+++ b/src/cinder/CaptureImplLinux.cpp
@@ -1,0 +1,193 @@
+#include "cinder/CaptureImplLinux.h"
+
+#include <linux/videodev2.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <libv4l2.h>
+
+#include <mutex>
+
+namespace cinder {
+
+CaptureImplLinux::Device::Device( const std::string &deviceFile ):
+mDeviceFile( deviceFile ), mIsConnected( false )
+{
+	int mDeviceFileDescriptor = v4l2_open( deviceFile.c_str(), O_RDWR );
+	if ( mDeviceFileDescriptor >= 0 ) {
+		struct v4l2_capability deviceInfo;
+		int error = v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_QUERYCAP, &deviceInfo );
+		v4l2_close( mDeviceFileDescriptor );
+
+		if ( ! error ) {
+			mName = std::string( reinterpret_cast<const char*>( &deviceInfo.card[0] ) );
+		}
+	}
+}
+
+
+bool CaptureImplLinux::Device::checkAvailable() const
+{
+	return ! mName.empty();
+}
+
+CaptureImplLinux::CaptureImplLinux( int32_t width, int32_t height, const Capture::DeviceRef device ):
+mDeviceFileDescriptor( -1 ),
+mRunning( false ), mNewFrameAvailable( false ),
+mDevice( device )
+{
+	// choose first
+	if ( !mDevice ) {
+		auto &devices = getDevices();
+		if ( devices.empty() ) {
+			throw CaptureExcInitFail();
+		} else {
+			mDevice = getDevices()[0];
+		}
+	}
+
+	const char *name = mDevice->getUniqueId().c_str();
+
+	// implicty set to blocking io
+	mDeviceFileDescriptor = v4l2_open( name , O_RDWR );
+	if ( mDeviceFileDescriptor < 0 ) {
+		throw CaptureExcInitFail();
+	}
+
+	struct v4l2_format format{};
+	std::memset( &format, 0, sizeof( v4l2_format ) );
+
+	format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	format.fmt.pix.width = static_cast<uint32_t>( width );
+	format.fmt.pix.height = static_cast<uint32_t>( height );
+	format.fmt.pix.pixelformat = V4L2_PIX_FMT_RGB24;
+	format.fmt.pix.field = V4L2_FIELD_NONE;
+
+	v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_S_FMT, &format );
+
+	if ( format.fmt.pix.pixelformat != V4L2_PIX_FMT_RGB24 ) {
+		throw CaptureExcInvalidChannelOrder();
+	}
+
+	mWidth = format.fmt.pix.width;
+	mHeight = format.fmt.pix.height;
+
+	struct v4l2_requestbuffers requestBuffers{};
+	requestBuffers.count = 2;
+	requestBuffers.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	requestBuffers.memory = V4L2_MEMORY_MMAP;
+
+	v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_REQBUFS, &requestBuffers );
+
+	struct v4l2_buffer buffer{};
+	buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	buffer.memory = V4L2_MEMORY_MMAP;
+	buffer.index = 0;
+
+	for ( uint32_t i = 0; i < 2; i++ ) {
+		buffer.index = i;
+
+		v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_QUERYBUF, &buffer );
+		mRawBuffer[i].length = buffer.length;
+		mRawBuffer[i].data = v4l2_mmap( NULL, buffer.length,
+				PROT_READ | PROT_WRITE, MAP_SHARED, mDeviceFileDescriptor, buffer.m.offset );
+
+		if ( mRawBuffer[i].data == MAP_FAILED ) {
+			throw CaptureExcInitFail();
+
+		} else {
+			mSurfaces[i] = Surface::create( reinterpret_cast<unsigned  char*>( mRawBuffer[i].data ),
+											mWidth, mHeight, mWidth * 3,
+											SurfaceChannelOrder( SurfaceChannelOrder::RGB ) );
+		}
+
+		v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_QBUF, &buffer );
+	}
+
+	dynamic_cast<CaptureImplLinux::Device*>( mDevice.get() )->setConnected();
+}
+
+CaptureImplLinux::~CaptureImplLinux()
+{
+	if ( mDeviceFileDescriptor >= 0 ) {
+		for ( size_t i = 0; i < 2; i++ ) {
+			v4l2_munmap( mRawBuffer[i].data, mRawBuffer[i].length );
+		}
+		v4l2_close( mDeviceFileDescriptor );
+	}
+
+	dynamic_cast<CaptureImplLinux::Device*>( mDevice.get() )->setConnected( false );
+}
+
+void CaptureImplLinux::start()
+{
+	enum v4l2_buf_type bufferType = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_STREAMON, &bufferType );
+
+	mRunning.store( true );
+	mThread = std::thread( &CaptureImplLinux::update, this );
+}
+
+void CaptureImplLinux::stop()
+{
+	mRunning.store( false );
+
+	std::unique_lock<std::mutex> locker;
+	mStopCondition.wait( locker );
+
+	enum v4l2_buf_type bufferType = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_STREAMOFF, &bufferType );
+}
+
+void CaptureImplLinux::update()
+{
+	struct v4l2_buffer buffer{};
+	buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	buffer.memory = V4L2_MEMORY_MMAP;
+
+	while ( mRunning ) {
+		v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_DQBUF, &buffer );
+		mSurfaceReadIndex.store( buffer.index );
+		mNewFrameAvailable.store( true );
+		v4l2_ioctl( mDeviceFileDescriptor, VIDIOC_QBUF, &buffer );
+	}
+
+	mStopCondition.notify_one();
+}
+
+bool CaptureImplLinux::isCapturing()
+{
+	return mRunning;
+}
+
+bool CaptureImplLinux::checkNewFrame() const
+{
+	return mNewFrameAvailable;
+}
+
+Surface8uRef CaptureImplLinux::getSurface() const
+{
+	mNewFrameAvailable.store( false );
+	return Surface::create( *mSurfaces[mSurfaceReadIndex] );
+}
+
+const std::vector<Capture::DeviceRef>& CaptureImplLinux::getDevices( bool forceRefresh  )
+{
+	static std::vector<Capture::DeviceRef>	devices;
+
+	if ( forceRefresh || devices.empty() ) {
+		devices.clear();
+
+		for ( fs::directory_iterator it( "/dev" ); it != fs::directory_iterator(); ++it ) {
+			auto deviceFile = it->path().string();
+			if ( deviceFile.find( "video" ) != std::string::npos ) {
+				devices.emplace_back( std::make_shared<CaptureImplLinux::Device>( deviceFile ) );
+			}
+		}
+
+	}
+
+	return devices;
+}
+
+}


### PR DESCRIPTION
Given `v4l2` is part of the Linux kernel, I thought it would be a good idea to use it to implement video capture on Linux. I didn't need it, but on some distributions you may need to download the `libv4l-dev` package for this to compile.

With view of issue #2052, `CaptureBasic` and `CaptureCube` now build and work on my machine.

Here are a few notes:

* I setup `v4l2` to double buffer the incoming capture frames.
* When `getSurface()` is called a copy of the last written buffer is made. As far as I can see, this is necessary.
* A new `shared_ptr` is created each time `getSurface()` is called. I noticed that the Windows implementation has a pool of `SurfaceRef`s to eliminate this overhead. I chose the simplest solution!
