### PR TITLE
Add Emscripten documentation

### DIFF
--- a/docs/htmlsrc/guides/emscripten/config.json
+++ b/docs/htmlsrc/guides/emscripten/config.json
@@ -1,0 +1,79 @@
+{
+	"data":{
+		"metadata":
+		{
+			"keywords": ["guide, emscripten"]
+		},
+		"nav":[
+			{
+				"label": "Introduction",
+				"link": "index.html",
+				"pagenav":[
+
+				]
+			},
+			{
+				"label": "Installation",
+				"link": "part1.html",
+				"pagenav":[
+
+				]
+			},
+			{
+				"label": "Getting started",
+				"link": "part2.html",
+				"pagenav":[
+
+				]
+			},
+			{
+				"label": "Possible issues",
+				"link": "part3.html",
+				"pagenav":[
+
+				]
+			},
+			{
+				"label": "Deployment",
+				"link": "part4.html",
+				"pagenav":[
+
+				]
+			},
+			{
+				"label": "Working with the Web",
+				"link": "part5.html",
+				"pagenav":[
+
+				]
+			},
+			{
+				"label": "Interesting Web technologies",
+				"link": "part6.html",
+				"pagenav":[
+				
+				]
+			},
+			{
+				"label": "Tips",
+				"link": "part7.html",
+				"pagenav":[
+
+				]
+			},
+			{
+				"label":"FAQs",
+				"link":"part8.html"
+			},
+			{
+				"label":"ci_emscripten_app",
+				"link":"part9.html"
+			}
+		],
+		"seealso":
+		{
+
+		}
+	}
+
+}

--- a/docs/htmlsrc/guides/emscripten/index.html
+++ b/docs/htmlsrc/guides/emscripten/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+        <section id="intro">
+
+
+            <h1><a id="Cinder_Emscripten_Guide_1"></a>Cinder Emscripten Guide</h1>
+            <p>Cinder now supports building for Emscripten as of version (todo : add version number ). This allows users to open up their Cinder applications to the world wide web!</p>
+		   
+			<h1><a id="But_what_is_Emscripten_exactly_5"></a>But what is Emscripten exactly?</h1>
+            <p>Emscripten is a toolchain for compiling to asm.js and WebAssembly, built using LLVM, that lets you run C and C++ on the web at near-native speed without plugins.</p>
+            <p>In essence, it's simply a tool that lets you treat the web as another compilation target. A large chunk of the work was already done thanks to the efforts of <a href="https://github.com/chaoticbob/Cinder-Emscripten">Hai Nguyen</a> (<a href="https://github.com/chaoticbob">@chaoticbob</a>), this latest version builds on top of that by adding some additional features such as video support.</p>
+			
+			<h1><a id="How_it_works_10"></a>How it works</h1>
+            <p>You can treat your Emscripten project pretty much like any other CMake based Cinder project, you just need to run a slightly different command than what you might be used to.</p>
+			
+			<h1><a id="Whats_known_to_notwork_13"></a>Whats known to (not)work</h1>
+            <p>A large chunk of what you know about Cinder should mostly be transferable directly when building with Emscripten in mind, so with that said, it is perhaps easier to instead list all currently known un-supported features</p>
+            <ul>
+                <li>Threads (there is some experimentation with adatpting pthread but due to the Spectre vulnerability, support of this does depend a little on browser builders)</li>
+                <li>PBOs</li>
+                <li>Multi-window support (with some trickery you could perhaps simulate multi-screen support but given the strictness with how things are sandboxed on the web the possibility remains very low.)</li>
+				<li>Compute shaders are currently not useable in WebGL</li>
+				<li>SSBOs</li>
+				<li>It is also currently not possible to bind buffers for use in shaders for uses other than Transform Feedback or UBOs.</li>
+			</ul>
+            <h1><a id="Demos_22"></a>Demos</h1>
+            <p>You can find some of the original demos <a href="http://chaoticbob.github.io/Cinder-Emscripten/">here</a></p>
+            <p>To get started continue on to <a href="/part1.html">installation instructions.</a></p>
+        </section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part1.html
+++ b/docs/htmlsrc/guides/emscripten/part1.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+        <section id="install">
+            <h1><a id="Getting_things_set_up_0"></a>Getting things set up</h1>
+            <p>There are number of things you'll need to do in order to get things set up to build with Emscripten. If you're already familiar with CMake projects and how those work, then this will likely not be new for you as the process for running an Emscripten project is nearly identical.</p>
+            <h1><a id="System_requirements_3"></a>System requirements</h1>
+            <p>In terms of hardware requirements, this should work on any system that supports Cinder and Emscripten.</p>
+
+            <h1><a id="Browser_support_43"></a>Browser support</h1>
+            <p>Browser support can be a little tricker. You technically just need a browser that can support WebGL 2 but even if there is support, sometimes different browser developers enable/disable different things. That being said the recommended browsers are Firefox or Chrome.</p>
+            <p>
+                <strong>When running your application</strong><br>
+                To run your Cinder applications, while not strictly necessary, it's recommended to host on a server that can serve files with the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types">mime type</a> <code>application/wasm</code>
+            </p>
+            <p>If your server does not support that mime type, you will still be able to run your app, but may suffer from a performance decrease as the 
+                asm.js binary will load in place of the WebAssembly. Asm.js is known to not be quite as optimized as WebAssembly.</p>
+
+            
+            <h1><a id="Downloading_the_essentials_6"></a>Downloading the essentials</h1>
+            <ul>
+                <li>Install <a target="_blank" href="https://cmake.org/">Cmake</a> (at least version 3.10 but may work on older versions as well)</li>
+                <li>
+                    You'll also need a *nix style terminal window as well as <code>make</code> or something similar if you happen to be on Windows
+                    <ul>
+                        <li>For *nix systems, bash will do just fine. If you're on Windows, the easiest shell to get would be the one that comes with a standard <code>git</code> installation. If you'd like an alternative, the Windows Subsystem for Linux will work as well.</li>
+                        <li>If you're using a *nix based computer, you should have the command <code>make</code> available to you. If you're on Windows, this was tested on MingGW 64. If you're using the Windows Linux subsystem, you will have the <code>make</code> command available.</li>
+                    </ul>
+                </li>
+                <li>Of course, you'll need to install Emscripten. <a target="_blank" href="http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html">Make sure to follow the directions found on the official site</a> as the method of installation has changed since Emscripten was originally conceived.</li>
+            </ul>
+
+            <p>Once you have all that...</p>
+            
+            <h1><a id="Building_Cinder_16"></a>Building Cinder</h1>
+            <ul>
+                <li>First, run <code>emsdk activate latest</code>, then run <code>source emsdk_env.sh</code></li>
+                <li>Navigate into  <code>Cinder/emscripten</code> directory and run <code>./cibuild</code></li>
+            </ul>
+            <h1><a id="If_you_gotta_build_Boost_this_is_optional_21"></a>If you gotta build Boost (this is optional)</h1>
+            <p>Emscripten support relies on Boost system and filesystem libraries which should be included. If for some reason you need to rebuild. Note that you will definitely need a Unix-y terminal for this, Git Bash won't work.</p>
+            <ul>
+                <li>Download Boost. Note that it appears that the set of headers used needs to match the version of the library built. The current version of Boost being used is 1.60. When it's downloaded cd into the Boost directory.</li>
+                <li>run <a target="_blank" href="http://bootstrap.sh">bootstrap.sh</a>. It should produce 2 executables but we're only interested in one called b2.</li>
+                <li>Next you can run b2 --with-system --with-filesystem toolset=emscripten link=static. If for some reason you get an error, you can try replacing emscripten with clang-emscripten</li>
+                <li>In your Cinder folder, drop the output in lib/emscripten</li>
+            </ul>
+            <h1><a id="Updating_your_systems_PATH_variable_28"></a>Updating your systems <code>PATH</code> variable</h1>
+            <p>This isn't entirely necessary it will be useful to add the path to your <code>emsdk</code> folder to your system's <code>PATH</code> variable to make it easier to run commands.</p>
+            <p><a href="/part2.html">Now we can start on to building an actual projecct.</a></p>
+            
+           
+        </section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part10.html
+++ b/docs/htmlsrc/guides/emscripten/part10.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+        <!-- CONTENT STARTS HERE -->
+        <!-- TODO - add to docs after testing api -->
+        <section id="Cinder-Audio">
+            <h1>Cinder Audio on the web</h1>
+
+            <p>For Emscripten, the audio api is simplified a bit in an effort to make use of the native WebAudio api as much as possible due to the complexity in 
+                trying to integrate C++ with the WebAudio api in addition to some parts of the WebAudio api that would have been needed being marked for deprecation.
+                There are other fringe benefits such as the audio processing happening on a separate thread. 
+                <br/>
+                An effort was made to keep the general use of the audio api as similar as possible, but overall you probably won't be able to directly port 
+                your audio code to the web without some re-writing. 
+            </p>
+            
+            <p>Overall the pattern is similar and perhaps is best explained through a code snippit</p>
+            <br/>
+            <code>
+                auto ctx = AudioContext::Instance();
+
+                oscilator = ctx->makeNode(new NativeNode(WebAudioApiNode::OscillatorNode));
+                oscilator->setAudioParam("frequency",255);
+            
+                gain = ctx->makeNode(new CustomNode());
+            
+                oscilator >> gain >> ctx;
+            
+                ctx->enable();
+            </code>
+            <br/>
+            <p>In essance, the audio api is slimmed down to just 2 types of nodes - a <code>NativeNode</code> and a <code>CustomNode</code></p>
+
+            <h2>Native Nodes</h2>
+            <p>Native notes represent native WebAudio nodes that are already built into the browser. Beyond simple settings, these nodes are essentially self-contained 
+                black boxes that prevent you from directly touching their internal buffer. That is until you connect a ....
+            </p>
+
+            <h2>CustomNode</h2>
+            <p>This node is, as it's name suggests, a node that you can customize. The core of this class is the <code>process</code> function. It will get passed 
+            a set of data arrays </p>
+            <ul>
+                <li>
+                    <b>inputs</b> - This array corresponds to the input data that's coming in from the previous node in the chain. 
+                </li> 
+                <li>
+                    <b>outputs</b> - This array corresponds to any output information you want to send to the next node in the chain or the output destination.  
+                </li>
+                <li>
+                    <b>channelCount</b> - This is just an int corresponding to the number of channels that are being used. 
+                </li>
+            </ul>
+
+            <p>Note that this information is passed in from a singular <code>emscripten::val</code> object.</p>
+        </section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part2.html
+++ b/docs/htmlsrc/guides/emscripten/part2.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+		<section id="started">
+      <h1><a id="Building_an_Emscripten_project_0"></a>Building an Emscripten project.</h1>
+      <p>Building a project that targets Emscripten is a lot like building a project that builds with CMake. That being said, there are some very subtle differences.</p>
+	 
+	  <h1><a id="Creating_a_project_structure_4"></a>Creating a project structure.</h1>
+      <p>You can start off by generating your project with Tinderbox, like you might already be doing. Now if you haven't worked with Cmake before, you'll also have to make some kind of "build" folder, basically a place where your compiled files will get output to; the common practice is to just have a folder called build at the root of your project(note you can name it something other than build if you want)</p>
+	  <p>Next, you'll need a CMakeLists.txt file that will describe how to build your project. If you've never worked with CMake before, you can check out any of the samples in <code>samples/_emscripten</code> which will have CMake files available. If you're familiar
+		with CMake and want to write everything by hand, grabbing the CMakeLists file that builds Cinder is a good starting point to see what flags and settings need to applied to build for Emscripten. </p>
+     <p>Now we can move onto actually building a project. </p>
+	 
+	  <h1><a id="Building_a_project_16"></a>Building a project</h1>
+      <p>To build your project, from within your build folder(note I'm assuming it's within the root of your project)</p>
+      <ul>
+	  <li>run <code>emcmake cmake ..</code></li>
+	  <li>run <code>make</code> (or <code>mingw32-make</code> etc if on Windows)</li>
+      <li>When the build is done, everything you need to upload will end up in your build folder. </li>
+
+		
+		<li>
+			Note that resource and asset bundling/copying is not automatically done because builds will fail if the compiler can't find the 
+			resources directory. To add your asseet folders :
+			<br/>
+			<p><b>For Resources</b></p>
+			<p>If you're not using ci_emscripten_app(which will be talked about later on) you can add the flag</p>
+			<p><code>--preload-file ../(path to your resources folder)@</code></p>
+			
+			<p><b>For Assets</b></p>
+			<p>If you're not using ci_emscripten_app, unless your CMake file is already set up to copy it over, you will have to manually copy your assets folder into your output directory.</p>
+		
+			
+		</li>
+	</ul>
+
+      <h1><a id="Running_your_project_24"></a>Running your project</h1>
+	  <p>Running your project is fairly straightforward. You'll need to serve your project from a server somehow, one that can support the mime type <code>application/wasm</code>(though note this kind of server is not strictly necessary but it may provide better performance)</p>
+	  <p>There are a multitude of ways to do so, but perhaps the simplist solution is to borrow the built-in server on good ol' Python</p>
+		
+	  <ul>
+		<li>if on Python 2, from within your build directory, run <code>python -m SimpleHTTPServer</code></li>
+		<li>if on Python 3, your command is <code>python -m http.server</code></li>
+		<li>Note that for both commands you can specify a port after typing in the command, otherwise things will default to port 8000</li>
+		<li>Currently, while your project should still run, it won't technically be running in it's WebAssembly form since the python server does not support WebAssembly at the moment.
+			There is a provided alternative server you can use called <a href="https://www.npmjs.com/package/wasm-server" target="_blanke">wasm-server</a>. You can of course choose to roll your own as well if you wish. 
+		</li>
+	 </ul>
+	
+	<h1><a id="Building_the_samples_24"></a>Building the samples</h1>
+      <p> If you'd like to generate Cmake project folder for the the samples, there is a helper python script in
+		   <code>Cinder/emscripten/sample_generation</code> called <code>gensamples.py</code>. 
+		   It will also generate a sample CMakeLists.txt file for each sample as well. 
+		   Note that while the script attempts to avoid generating things in projects where there is known incompatibility with Emscripten, 
+		   there is no guarantee that all the samples will run against Emscripten.</p>
+  
+	  <h1><a id="ci_emscripten_app"></a>ci_emscripten_app</h1>
+      <p>If you're not comfortable writing your own CMakeLists.txt file, there is helper function to make things a 
+		  little bit easier. If you run <code>gensamples.py</code> and then check the samples, 
+		  you can see how to use the function. Also see the <a href="/part9.html">ci_emscripten_app section</a> for a more in-depth look as to the options and other functionality
+		it can provide. </p>
+	  <p>If you've been using <code>ci_make_app</code>, the functionality and usage is very similar. 
+		Check out <code>/proj/cmake/cinderEmscriptenApp.cmake</code> to see what the function looks like. All options have comments describing what they are for. </p>
+	
+	</section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part3.html
+++ b/docs/htmlsrc/guides/emscripten/part3.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+		<section id="possible-issues">
+      <h1>Potential issues</h1>
+      <p> While things do basically appear to be working, there are some things that could potentially break things depending on what you're doing</p>
+
+      <ol>
+        <li>
+          <p>Including Freetype's ftlcdfil.c file will cause a link error when building Cinder which states `ERROR: Linking globals named 'ft_lcd_padding': symbol multiply defined!`</p>
+        </li>
+        <li>
+          <p>
+            Shaders are currently not detached after creation due to a possible bug Emscripten that essentially sets the shader handle to null.
+          </p>
+        </li>
+      
+        <li>
+          <p>While the audio api is technically available, it is still largely un-tested and may still have kinks that need to be worked out. </p>
+        </li>
+      </ol>
+    </section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part4.html
+++ b/docs/htmlsrc/guides/emscripten/part4.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+		<section id="deployment">
+      <h1>Javascript</h1>
+
+      <p>If you&#39;re including any Javascript support files for your project, keep in mind that when building in release, the currently shipped version of Uglifyjs that comes with Emscripten appears to not like some ES6 semantics like the arrow function (<code>()=&gt;{}</code>)</p>
+
+      <p>In addition to that, if you add supplementary Javascript to your project and compile a release build, you&#39;ll likely need to add an externs file. In your <code>CMakeLists.txt</code> file you can add</p>
+
+      <p><code>
+      list(APPEND EMCC_CLOSURE_ARGS &quot;&lt;path to your externs file&rsaquo;&quot;)
+      </code>
+    </p>
+    <p>
+      If you&#39;ve never used an externs file, the idea is pretty straightforward. For every function and variable and object in your project you just need to add the basic definition. You could think of it as Javascript&#39;s forward declaration mechanism.</p>
+
+      <p>Cinder for example, includes a <code>helpers.js</code> file when dealing with video. In it there is a variable called <code>window.CINDER_VIDEO</code> which looks like</p>
+
+      <p>
+        <code>
+        createVideo:function(){
+          ... more code </code>
+
+        </p>
+      <p>In the externs file, all I would need to declare is <code>window.CINDER_VIDEO = {}</code> since <code>window.CINDER_VIDEO</code> is a Javascript object. If it were a function it would look like <code>window.CINDER_VIDEO = function(){}</code></p>
+
+      <h1>WebGL 1 / glsl 120 support</h1>
+
+      <p>Note that Cinder only supports WebGL 2 / GLSL 300 es as there really isn&#39;t a reason to support WebGL 1 at this point.</p>
+      <p>That being said, there really isn't any reason you couldn't set up the webgl portion of the Emscripten flags yourself, change the values, then copy over
+        what you need from Cinder.cmake</p>
+
+      <h1>Autoplaying media in Chrome</h1>
+
+      <p>In Chrome - auto-playing of media was disabled in May / 2018.
+      See
+       <a target="_blank" href="https://arstechnica.com/gaming/2018/05/chromes-autoplay-video-blocker-is-accidentally-killing-web-based-games/">this article from ArsTechnica</a>
+      <a target="_blank" href="https://twitter.com/Cabbibo/status/992854400061227008"> as well as this tweet from Twitter user Cabibbo</a></p>
+
+      <p>You&#39;ll have to do some sort of interaction before things will start playing.</p>
+    </section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part5.html
+++ b/docs/htmlsrc/guides/emscripten/part5.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+		<section id="web-notes">
+      <h1>Things to remember when deploying to the web</h1>
+      <p>The web is ultimately a different world altogether compared to the world of desktop and mobile development. There are some special things to take care to remember when dealing with Cinder Emscripten.</p>
+
+      <h2>Output file size and how to serve smaller files over the web.</h2>
+
+      <p>The output of WebAssembly files is generally quite large. It&#39;s probably not going to be a big deal if you&#39;re just doing an installation but if you intend to distribute your project to the world, it could be worth thinking about.</p>
+
+	  <p>The most common way of reducing the file size of your output is to ensure that you build your WebAssembly bundle with optimizations, which can be included by adding <code>-s WASM=1 -Os -g0</code> flags to your project&#39;s CMake file.
+		(if you're using ci_emscripten_app, this will happen automatically when building in Release mode) </p>
+
+      <p><a target="_blank" href="https://hacks.mozilla.org/2018/01/shrinking-webassembly-and-javascript-code-sizes-in-emscripten/">See here for more information</a></p>
+
+      <h2>Re: External media that&#39;s not on the URL / server you&#39;re deploying on</h2>
+
+      <p>Note that due to how browsers work, with the exception of some built-in elements like the image tag,  by default, you cannot grab assets directly from another server different from the one you&#39;re deploying on. This is known as a <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS">Cross Origin Resource Sharing</a> and it is normally not allowed.</p>
+
+      <p>If for some reason you must absolutely store your content on another server, you&#39;ll need to ensure that that server is set up to accept CORS requests, only then will you be able to pull content from elsewhere. It should not be difficult to do and most common place server 
+		  software packages usually include a simple way of enabling this feature.</p>
+
+      <h2>Dealing With video</h2>
+
+	  <p>There is a special object called <code>EmscriptenVideo</code> that is availble whose sole purpose 
+		is to playback video. While there are other techniques to stream video data, 
+		using EmscriptenVideo is the easiset way as it just takes advantage of the browser's built-in 
+		video tag. It even provides a texture you can use!</p>
+
+      <h2>Multi-window projects</h2>
+
+      <p>Note that you likely won&#39;t be able to port over any multi-window projects. On the web, each <code>&lt;canvas&gt;</code> element&#39;s WebGL context, and all of the content that it creates, is only available to that context&#39;s canvas element. </p>
+
+			<h2> Dealing with audio</h2>
+			<p>Note that as of Chrome 69 - you may experience issues in doing anything with audio, specifically, the tab may in fact crash before anything is loaded. Oddly enough there isn't any issue as long as
+				you have the dev tools open. Firefox is known to be fine for audio so it may be worthwhile to just stick to that. </p>
+
+		</section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part6.html
+++ b/docs/htmlsrc/guides/emscripten/part6.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+	
+		<section id="web-workers">
+
+      <h1>Web Workers</h1>
+
+      <p>Web workers can essentially be thought of as the threads of the web. That being said though there are some limitations to what you can do in a Web Worker.</p>
+
+      <ul><li>You cannot pass complex types to a thread, only standard Javascript types. When it comes to C++, you can only pass a <code>char*</code> and a <code>void*</code></li><li>You will not have access to the DOM.</li></ul>
+
+      <p>That being said ,  there are 2 ways of writing web workers.</p>
+
+      <h2>As a Cpp program</h2>
+
+	  <p>You can write Web Workers as a C++ program. Unfortuantely you will have to treat it essentially as a separate project as in order to build a worker, 
+		  you will need to add the flag <code>-s BUILD_AS_WORKER=1</code>
+		 Note that you will also have to add another flag separately called <code>EXPORTED_FUNCTIONS</code> in which you make it equal to an array like object with all the method names in your worker file that you want to expose prefixed with underscores, IE : <code>[&#39;_onmessage&#39;]</code></p>
+
+      <p>It currently appears you can add as many functions as you&#39;d like and use your libraries the same way you might a regular project.</p>
+			<p>You could conceptually write the setup for this in the same CMake file as your main application but it is advised to seperate your worker into a new project for clarity.</p>
+
+      <h2>As Javascript</h2>
+
+	  <p>The potentially easier alternative might be to write your worker directly as JS. The CINDER_HELPERS namespace contains a function called <code>sourceToBlob</code>
+		which will convert any string source into a format suitable for instantiating a WebWorker in Javascript. 
+
+		Note that going this route and trying to use C++ to talk to the worker is a bit of a pain as you'll have to use the rather verbose emscripten::val api or proxy a global Javascript function 
+		but it is possible to go this route if you'd like. 
+		</p>
+	 
+	  <h2>Offscreen canvas</h2>
+	  <p>Something interesting that Emscripten supports is the ability to use OffscreenCanvas.
+	  Currently - only Firefox has good support for OffscreenCanvas but it has been rumored that Chrome is set to get better support in the next version</p>
+	  <a href="https://developers.google.com/web/updates/2018/08/offscreen-canvas" target="_blank">See this article for more information.</a>
+
+	</section>
+
+	
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part7.html
+++ b/docs/htmlsrc/guides/emscripten/part7.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+		<h1>Additional potentially helpful information</h1>
+
+		
+
+		<section id="tips">
+
+      <ol>
+        <li>
+          It may be beneficial to run emcc <code>--clear-cache</code> now and then to ensure you get a clean build.
+        </li>
+        <li>
+          <p>Run <code>export EMCC_DEBUG=1</code> before building to tell Emscripten to spit out it's own debugging information.
+            You can optionally pass in <code>-v</code> as an Emscripten flag
+          </p>
+        </li>
+        <li>
+          <p>You can of course, use your own HTML shell for building your app.
+          <a href="https://kripken.github.io/emscripten-site/docs/tools_reference/emcc.html#emcc-shell-file" target="_blank">See here for details</a>
+        </p>
+        </li>
+        <li>
+
+          <a href="https://kripken.github.io/emscripten-site/docs/tools_reference/emcc.htm" target="_blank">
+ 							If you're curious about what other flags you can add when building your Emscripten project
+          </a>
+        </li>
+        <li>
+          <p>From time to time, you may notice that Emscripten has stopped compiling new changes, which can be a pain. You'll have to remember to 
+            make a small tweak in one of your main specified source files to get things to re-compile. 
+          </p>
+        </li>
+
+        <li>
+          <p>
+            For faster load times, assuming you don't need to examine the output, it may be a good idea to just do release builds.
+          </p>
+        </li>
+      </ol>
+		</section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part8.html
+++ b/docs/htmlsrc/guides/emscripten/part8.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+        <section id="FAQs">
+			<h1><a id="Faq_0"></a>Faq</h1>
+			<p>While building projects targeting WebAssembly, you can potentially run into some issues.
+			</p>
+			<ul>
+				<li>
+					<b>My application works in one browser but not in another.</b>
+					<br/>
+						Despite the fact that there is technically a standard for how everything works, 
+						browser builders have thus far decided to implement things differently or roll things out
+						on different timelines. For example, Apple's Safari STILL does not support WebGL 2.
+						Chrome and Firefox are the recommended browsers though you may have luck with other ones.
+					
+				</li>
+
+				<br/>
+				<li>
+					<b>I can't load files hosted on my server.</b>
+					<br/>
+						Browsers operate on the principle that all content loaded must be on the same server as the page you're 
+						requesting. The process of making a request for content on another server is called a <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">Cross-Origin Request Sharing</a>, 
+						or CORS for short.
+
+						<br/>
+						<br/>
+						If you must load content from another server, it is possible to get around this restriction by enabling CORS handling on your server which is 
+						a pretty basic option these days on common open-source server software. If you don't have access to the server, then you'll have to contact someone that does. 
+					
+				</li>
+
+				<br/>
+				<li>
+					<b>How do I deploy my project?</b>
+					<br/>
+						Assuming you're using <code>ci_emscripten_app</code>, Cinder Emscripten is set up so that when you build, depending on your build type (the default is "Debug"), you'll have either a 
+						"Debug" or "Release" folder inside of your build directory. You should be able to just copy and drop the contents of this folder 
+						onto your server.
+
+						<br/>
+						<br/>
+						If you're writing your own CMakeLists file - well then, that's up to you to figure out but in general, your output should come out in the build area that you specify. 
+					
+				</li>
+
+				<br/>
+				<li>
+
+					<b>Can I build for mobile?</b>
+					<br/>
+				
+							Since there is an alternate asm.js build whenever you compile applications, it should be possible to build for mobile as well in theory though this has not
+							been throughly tested yet. Note that IOS does not support WebGL 2 and that when using an asm.js build, performance may suffer somewhat.
+				</li>
+
+				<br/>
+				<li>
+					<b>I still want to build for IOS or Safari </b>
+					<br/>
+						You will have to then make alterations to the script at root/tools/emscripten/cibuilder or take the CMakeLists.txt file found in root/emscripten to 
+						concoct your own build script. By default since WebGL 2 has fairly good support that was what we chose to go with. Note that on the web, with WebGL 1, 
+						things are much more limited and a lot of things are hidden behind extensions which Emscripten may or may not enable. There will also be 
+						things you'll need to keep in mind like being restricted to power of 2 textures. 
+					
+
+				</li>
+			
+			</ul>
+        </section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part9.5.html
+++ b/docs/htmlsrc/guides/emscripten/part9.5.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+        <section id="FAQs">
+			<h1>emscripten::val</h1>
+                <p>It's probbaly worth talking about how <code>emscripten::val</code> works since </p>
+
+            </ul>
+        </section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/emscripten/part9.html
+++ b/docs/htmlsrc/guides/emscripten/part9.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<!-- Update title -->
+		<title>Cinder with Emscripten</title>
+
+		<!-- keywords used for searching -->
+		<meta name="keywords" content="guide, emscripten, cinder">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- reference to Cinder classes -->
+   		<!-- <ci seealso dox="[CLASS NAME GOES HERE]" label="[NAME OF LINK]"></ci> -->
+
+   		<!-- master stylesheet - these links will be replaced when compiled -->
+		<link rel="stylesheet" href="../../_assets/css/foundation.css">
+		<link rel="stylesheet" href="../../_assets/css/prism.css">
+		<link rel="stylesheet" href="../../_assets/css/style.css">
+		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet' type='text/css'>
+
+		<!-- Place additional stylsheet links here, which will be copied over when compiled (optional) -->
+
+	</head>
+
+	<body id="guide-contents" class="language-c++">
+
+		<!-- CONTENT STARTS HERE -->
+
+        <section id="FAQs">
+			<h1>ci_emscripten_app</h1>
+            <p><code>ci_emscripten_app</code> is a helper function to make your <code>CMakeLists.txt</code> files easier to write. </p>
+            <p>It is designed to more or less mimic <code>ci_make_app</code> for desktop apps but with some Emscripten specific parameters</p>
+            <p>While you can still hand-write your CMakeLists.txt file, it is recommended to use <code>ci_emscripten_app</code> instead.</p>
+
+
+            <p><code>ci_emscripten_app</code> takes a number of options. At the very least, you'll need to specify the options: 
+                <br/>
+                * <code>CINDER_PATH</code>
+                <br/>
+                * <code>SOURCES</code>(and the path to your main app file)
+            </p>
+            <p>
+                There are a number of other options you can pass in as well. 
+            </p>
+            <ul>
+                <li><code>CINDER_PATH</code> - the path to where you downloaded Cinder. This is important
+                    as otherwise your code will not compile correctly. In general a relative path from where your CMakeLists.txt file is 
+                    is expected, but it should work with an absolute path as well. 
+                </li>
+
+                <br/>
+                <li>
+                    <code>SOURCES</code> - specify a path to all of your .cpp files. Your main app file should be the first item in the list. 
+                    Multiple paths should be seperated by spaces and un-quoted. 
+                </li>
+
+
+                <br/>
+                <li>
+
+                    <code>INCLUDES</code> - specify a path to all of your .h files here. Formatting should be same as source files. 
+                </li>
+
+                <br/>
+                <li>
+                    <code>LIBRARIES</code> - specify a path to all of your library files here. Formatting for different paths is the same as your source code. Note that Emscripten only supports .a or .bc library files.
+                </li>
+
+                <br/>
+                <li>
+                    <code>FLAGS</code> - by default, some common flags will get used to build your application; that being said,
+                     Emscripten has a number of other flags in addition to the ones you can manipulate with ci_emscripten_app that can be used to build 
+                    your project. Specify any other flags you want to use as a single string with this parameter. <a href="https://kripken.github.io/emscripten-site/docs/tools_reference/emcc.html" target="_blank">See here for more details.</a>
+                </li>
+
+                <br/>
+                <li>
+                    <code>ASSETS</code> - the path to your assets directory if you have one. When your code is built, this 
+                    directory will get copied to your build directory. Note that if the NO_ASYNC parameter is specified you will have to rely on the loadAssetAsync function 
+                    or write your own function in order to access items in the assets folder. 
+                </li>
+
+                <br/>
+                <li>
+                    <code>RESOURCES</code> - the path to your resources directory if you have one. When your application is built, 
+                    all of the files in the resources folder will get bundled into a binary file called "index.binary". Note that
+                    if specified, you need to make sure that the folder really does exist or your build will fail. ci_emscripten_app guards against
+                    this by only adding the necessary flags if the parameter is set. Also note that if NO_ASYNC is set - you will loose access to the bundle. 
+                </li>
+
+                <br/>
+                <li>
+                    <code>THREADS</code> - enables threading support (via pthread) for your application. Note that due to the Spectre vulnerability, your browser will likely have disabled the <code>SharedArrayBuffer</code> object 
+                    which is necessary for this to function correctly. If you're using Chrome, you do have the option of re-enabling support for SharedArrayBuffers which can be done from <a href="chrome://flags" target="_blank">chrome://flags</a>.
+                    It's currently unknkown if other browser's will allow support down the line. 
+                    If you're interested in learning more about threads with Emscripten, <a href="https://youtu.be/zgOGZgAPUjQ?t=892" target="_blank">Google recently put out a good introduction on the topic.</a>
+                    <br/>
+                    <br/>
+                    As far as deployment when building a threaded application, Chrome appears to be the only browser offering support.<a href="https://youtu.be/zgOGZgAPUjQ?t=1153" target="_blank">The presenter in the video above talks a little bit about it here.</a>
+                </li>
+                
+                <br/>
+                <li>
+                    <code>THREAD_POOL_SIZE</code> - this tells the compiler how many threads you definetly plan on using in your application. It's better to specify 
+                    this value ahead of time so things can be pre-alocated ahead of time, though it is possible to dynamically generate new threads as well.
+                </li>
+                
+                <br/>
+                <li>
+                    <code>HTML_TEMPLATE</code> - by default, a there is a default template has a lot of branding already associated with it. 
+                    You do have the option to use your own template though by specifiying a path to your template with this paramter. 
+                    <a href="https://kripken.github.io/emscripten-site/docs/tools_reference/emcc.html#emcc-shell-file" target="_blank">See here for how to specify your own template.</a>
+                </li>
+
+                <br/>
+                <li>
+                    <code>BUILD_TYPE</code> - specify the type of build you would like to do, either "Debug" (which is the default) or "Release".
+                    The difference between the two is that in "Release", optimizations are done to help things run better. If you pass in another value, your build will default to "Debug"
+                </li>
+
+                <br/>
+                <li>
+                    <code>BUILD_AS_WORKER</code> - this will build your code as a Web Worker, which is slightly different than a regular application bundle. 
+                </li>
+
+                <br/>
+                <li>
+                    <code>EXPORT_FROM_WORKER</code> - This tells Emscripten what functions you want to expose to your main application within your worker. 
+                     The parameter should be a single quoted string with all functions separated by a comma ie  '_onmessage,_postmessage'
+                </li>
+                <br/>
+                <li>
+                    <code>NO_ASYNC</code> - by default, some Emscripten libraries are included that deal with http requests among other things. 
+                    This is necessary because of the lack of a filesystem api on the web(well, technically it does exist but will be/has been deprecated) and because
+                    Cinder Emscripten attempts to emulate <code>ci::app::loadAsset</code> as closely as possible. 
+                    
+                    In addition, another reason for including Emscripten's async libraries is to 
+                    make it possible to load larger files like videos, audio, etc; currently, while you can bundle them into the emulated filesystem(which can be accessed using <code>ci::app::loadResource</code>), 
+                    it seems that at the moment, there is an issue with Emscripten and how it will read those larger files. Also, including those larger files will add to your page load time. 
+               
+                    <br/>
+                    <br/>
+                    The tradeoff for including these libraries though is that it will roughly double your compile time(based on early estimates on an i7 7700) and increase your final wasm size(which could be important depending on your project).
+                    <br/>
+                    <br/>
+                        If you feel comfortable with asynchronous functions, you can disable inclusion of these libraries by 
+                        passing <code>TRUE</code> to the <code>NO_ASYNC</code> parameter. Note that this of course will disable <code>ci::app::loadAsset</code>.
+                        In <code>CinderEmscripten.h</code>, there is the function <code>ci::app::loadAssetAsync</code>. It works just like the normal <code>loadAsset</code> function with 
+                        2 exceptions. 
+
+                        <ul>
+                            <li>There is no return value so you don't pass it into another function(ie loadImage, etc)</li>
+                            <li>You need to pass it a lamda as a second parameter that has a ci::DataSourceRef as the parameter for the function.</li>
+                        </ul>
+
+                        If you know a little Javascript, you can write your own async request handler as well. 
+               
+
+                </li>
+
+                <br/>
+                <li>
+                    <code>OUTPUT_NAME</code> - By default, the name "index" is used as the output name as it makes it simpler when deploying projects. 
+                    If you'd like to specify something specific, this parameter will allow you to do so. 
+                </li>
+                
+                <li>
+                    <code>OUTPUT_DIRECTORY</code> - By default, all output should go into your build folder, but if there is another 
+                    folder you wish to deploy to, you can specify that path here. 
+                </li>
+
+                <li>
+                    <code>PRE_JS</code> - Pass in paths to any javascript files you want to include in your build. The JS will get included before your 
+                    your main compiled code. 
+                </li>
+
+                <li>
+                    <code>POST_JS</code> - Pass in paths to any javascript files you want to include in your build. The JS will get included after your 
+                    your main compiled code. 
+                </li>
+
+
+            </ul>
+        </section>
+
+		<!-- END CONTENT -->
+
+		<!-- Scripts -->
+		<script src="../../_assets/js/prism.js" type="text/javascript"></script>
+		<!-- Place additional scripts here (optional) -->
+		<!-- <script type="text/javascript"></script> -->
+
+	</body>
+</html>

--- a/docs/htmlsrc/guides/index.html
+++ b/docs/htmlsrc/guides/index.html
@@ -26,7 +26,8 @@
 	            <li><a href="linux-notes/index.html">Linux Platform Notes</a></li>
 	            <li><a href="ios-notes/index.html">iOS Platform Notes</a></li>
 	            <li><a href="android-notes/index.html">Android Platform Notes</a></li>
-	            <li><a href="winrt-notes/index.html">UWP Platform Notes</a></li>
+				<li><a href="winrt-notes/index.html">UWP Platform Notes</a></li>
+				<li><a href="emscripten/index.html">Emscripten Notes</a></li>
 	        </ul>
 
 			<ul>


### PR DESCRIPTION
Add docs/guide for Emscripten usage . 

Could probably use a once-over from someone who's actually a copywriter but should be pretty complete. 

Note that there two additional documents over a potential path for a new Emscripten specific audio API as well as a starting point for how to use `emscripten::val` object but not linking to those for now. 