### PR TITLE
fix compile for Mesa 18.2.6 on some Linux

### DIFF
--- a/include/glload/_int_glx_type.h
+++ b/include/glload/_int_glx_type.h
@@ -1,10 +1,11 @@
 #ifndef GLXWIN_GEN_TYPE_H
 #define GLXWIN_GEN_TYPE_H
-#ifdef __glxext_h_
+#if defined( __glxext_h_) || defined(__glx_glxext_h_)
 #error Attempt to include glx_exts after including glxext.h
 #endif
 
 #define __glxext_h_
+#define __glx_glxext_h_
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>

--- a/include/glload/_int_glx_type.hpp
+++ b/include/glload/_int_glx_type.hpp
@@ -1,10 +1,11 @@
 #ifndef GLXWIN_GEN_TYPE_HPP
 #define GLXWIN_GEN_TYPE_HPP
-#ifdef __glxext_h_
+#if defined( __glxext_h_) || defined(__glx_glxext_h_)
 #error Attempt to include glx_exts after including glxext.h
 #endif
 
 #define __glxext_h_
+#define __glx_glxext_h_
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>


### PR DESCRIPTION
As discussed in #2064, this add compatibility for `glload` with newer version of Mesa.