### PR TITLE
Added missing #include to circular.h

### DIFF
--- a/include/circular/circular.h
+++ b/include/circular/circular.h
@@ -37,6 +37,7 @@
 #ifndef CIRCULAR_BUFFER_H
 #define CIRCULAR_BUFFER_H
 
+#include <algorithm>
 #include <exception>
 #include <iterator>
 #include <memory>


### PR DESCRIPTION
Simple fix to be able to use `ConcurrentCircularBuffer`.

Otherwise I get the following errors in macOS 10.12.6 with clang 9.0
```
in file included from cinder/include/cinder/ConcurrentCircularBuffer.h:28:
cinder/include/circular/circular.h:490:41: error: no member named 'equal' in namespace 'std'
    return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
                                   ~~~~~^
cinder/include/circular/circular.h:499:42: error: no member named 'equal' in namespace 'std'
    return a.size() != b.size() || !std::equal(a.begin(), a.end(), b.begin());
                                    ~~~~~^
cinder/include/circular/circular.h:508:17: error: no member named 'lexicographical_compare' in namespace 'std'
    return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end());
           ~~~~~^
3 errors generated.
```
