### PR TITLE
Xml cdata write fix (addressing issue #2066)

### DIFF
--- a/include/glload/_int_glx_type.h
+++ b/include/glload/_int_glx_type.h
@@ -1,10 +1,11 @@
 #ifndef GLXWIN_GEN_TYPE_H
 #define GLXWIN_GEN_TYPE_H
-#ifdef __glxext_h_
+#if defined( __glxext_h_) || defined(__glx_glxext_h_)
 #error Attempt to include glx_exts after including glxext.h
 #endif
 
 #define __glxext_h_
+#define __glx_glxext_h_
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>

--- a/include/glload/_int_glx_type.hpp
+++ b/include/glload/_int_glx_type.hpp
@@ -1,10 +1,11 @@
 #ifndef GLXWIN_GEN_TYPE_HPP
 #define GLXWIN_GEN_TYPE_HPP
-#ifdef __glxext_h_
+#if defined( __glxext_h_) || defined(__glx_glxext_h_)
 #error Attempt to include glx_exts after including glxext.h
 #endif
 
 #define __glxext_h_
+#define __glx_glxext_h_
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>

--- a/src/cinder/Xml.cpp
+++ b/src/cinder/Xml.cpp
@@ -357,7 +357,7 @@ void XmlTree::appendRapidXmlNode( rapidxml::xml_document<char> &doc, rapidxml::x
 		default: throw ExcUnknownNodeType();
 	}
 	rapidxml::xml_node<char> *node = 0;
-	if( type == rapidxml::node_data ) {
+	if( type == rapidxml::node_data || type == rapidxml::node_cdata ) {
 		node = doc.allocate_node( type, NULL, doc.allocate_string( getValue().c_str() ) );
 	}
 	else if( type == rapidxml::node_comment ) {


### PR DESCRIPTION
Accoring to the RapidXML [node_type documentation](http://rapidxml.sourceforge.net/manual.html#namespacerapidxml_6a276b85e2da28c5f9c3dbce61c55682_16a276b85e2da28c5f9c3dbce61c55682) CDATA nodes require the data text to be the node value, so this change reflects that.

This closes issue #2066