### PR TITLE
added .editorconfig file, fixes tab formatting on github file view

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# Use 4 spaces as indentation
+[*]
+indent_style = tabs
+indent_size = 4
+
+[*.py]
+indent_style = spaces


### PR DESCRIPTION
With this, github will finally show tab-aligned variables and methods correctly. Observe [with](https://github.com/richardeakin/Cinder/blob/editorconfig/include/cinder/GeomIo.h#L335-L363) and [without](https://github.com/cinder/Cinder/blob/642dbbd083efd7e15e53690c323cde6fd1444b3a/include/cinder/GeomIo.h#L335-L363).