### PR TITLE
Fix test programs

### DIFF
--- a/test/LineBreakTest/include/Resources.h
+++ b/test/LineBreakTest/include/Resources.h
@@ -1,5 +1,4 @@
 #pragma once
 #include "cinder/CinderResources.h"
-#include "Resources.h"
 
 //#define RES_MY_RES			CINDER_RESOURCE( ../resources/, image_name.png, 128, IMAGE )

--- a/test/LineBreakTest/src/LineBreakTestApp.cpp
+++ b/test/LineBreakTest/src/LineBreakTestApp.cpp
@@ -1,4 +1,5 @@
 #include "cinder/app/App.h"
+#include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
 #include "cinder/Unicode.h"
 #include "cinder/Text.h"
@@ -105,7 +106,7 @@ void LineBreakTestApp::draw()
 	box.setSize( ivec2( maxWidth, TextBox::GROW ) );
 	box.setFont( font );
 	box.setText( s );
-	gl::Texture t = box.render();
+	gl::TextureRef t = gl::Texture2d::create( box.render() );
 	gl::draw( t );
 	gl::color( Color( 0, 1, 0 ) );
 	gl::drawStrokedRect( Rectf( 0, 10, maxWidth, 800 ) );

--- a/test/ScreenSaverTest/src/ScreenSaverTestApp.cpp
+++ b/test/ScreenSaverTest/src/ScreenSaverTestApp.cpp
@@ -65,14 +65,19 @@ void prepareSettings( AppScreenSaver::Settings *settings )
 ScreenSaverTestApp::ScreenSaverTestApp()
 {
 #if LOAD_LOGO_IN_CONSTRUCTOR
-	log::manager()->enableSystemLogging();
+	//log::manager()->enableSystemLogging();
+	std::shared_ptr<log::LoggerSystem> sysLogger = log::makeLogger<log::LoggerSystem>();
+	sysLogger->setLoggingLevel(log::LEVEL_WARNING);
 	loadLogo();
 #endif
 }
 
 void ScreenSaverTestApp::setup()
 {
-	log::manager()->enableSystemLogging();
+	//log::manager()->enableSystemLogging();
+	std::shared_ptr<log::LoggerSystem> sysLogger = log::makeLogger<log::LoggerSystem>();
+	sysLogger->setLoggingLevel(log::LEVEL_WARNING);
+
 	CI_LOG_I( "called in " << getAppPath() );
 
 #if defined( CINDER_MAC )

--- a/test/XMLTest/src/XMLTestApp.cpp
+++ b/test/XMLTest/src/XMLTestApp.cpp
@@ -1,4 +1,5 @@
 #include "cinder/app/App.h"
+#include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
 #include "cinder/Xml.h"
 #include "cinder/Utilities.h"

--- a/test/_opengl/ConvenienceDrawingMethods/src/ConvenienceDrawingMethodsApp.cpp
+++ b/test/_opengl/ConvenienceDrawingMethods/src/ConvenienceDrawingMethodsApp.cpp
@@ -12,6 +12,9 @@ using namespace ci;
 using namespace ci::app;
 using namespace std;
 
+typedef PolyLineT<vec3>		PolyLine3;
+
+
 const float cCircleRadius = 40;
 const float cGridStep = cCircleRadius * 2.2f;
 
@@ -135,7 +138,7 @@ void ConvenienceDrawingMethodsApp::drawBasicOverview()
 		gl::translate( cGridStep, cGridStep * 4 );
 		gl::rotate( getElapsedSeconds(), 0, 1, 0 );
 		gl::color( Color( 1, 0, 0 ) );
-		gl::draw( mPolyline3D );
+		gl::draw( mPolyline3D.getPoints() );
 	}
 
 	// draw a 3D line back into space

--- a/test/_opengl/CubeMapLayout/src/CubeMapLayoutApp.cpp
+++ b/test/_opengl/CubeMapLayout/src/CubeMapLayoutApp.cpp
@@ -1,7 +1,7 @@
 #include "cinder/app/App.h"
 #include "cinder/app/RendererGl.h"
 #include "cinder/params/Params.h"
-#include "cinder/MayaCamUI.h"
+#include "cinder/CameraUi.h"
 #include "cinder/Camera.h"
 #include "cinder/gl/GlslProg.h"
 #include "cinder/gl/Texture.h"
@@ -14,17 +14,18 @@ using namespace std;
 
 class CubeMapLayoutApp : public App {
   public:
-	void prepareSettings ( Settings * settings );
+	static void prepareSettings ( Settings * settings );
 	void setup() override;
 	void mouseDown( MouseEvent event ) override;
 	void mouseDrag( MouseEvent event ) override;
 	void draw() override;
-	
+
 	std::vector<gl::TextureCubeMapRef> mCubeMaps;
 	int mSelectedCubeMap;
 	gl::BatchRef mCube;
 	params::InterfaceGlRef mParams;
-	MayaCamUI mMayaCam;
+	CameraUi mMayaCam;
+	CameraPersp mMayaCamPersp;
 };
 
 void CubeMapLayoutApp::prepareSettings( Settings * settings )
@@ -36,27 +37,27 @@ void CubeMapLayoutApp::setup()
 {
 	gl::enableDepthRead();
 	gl::enableDepthWrite();
-					
+
 	mParams = params::InterfaceGl::create( "Settings", ivec2(200, 200) );
 	mParams->addParam( "Cubemap", { "Horizontal Cross", "Vertical Cross", "Vertical Cross Layout", "Horizontal", "Vertical" }, &mSelectedCubeMap );
-	
+
 	gl::GlslProgRef shader = gl::GlslProg::create( loadAsset( "sky_box.vert" ), loadAsset( "sky_box.frag" ) );
 	shader->uniform( "uCubeMapTex", 0 );
-	
+
 	mCube = gl::Batch::create( geom::Cube().size( vec3( 100.0f ) ), shader );
-	
+
 	mSelectedCubeMap = 0;
 	mCubeMaps.push_back( gl::TextureCubeMap::create( loadImage( loadAsset( "horizontal_cross.jpg" ) ) ) );
 	mCubeMaps.push_back( gl::TextureCubeMap::create( loadImage( loadAsset( "vertical_cross.png" ) ) ) );
 	mCubeMaps.push_back( gl::TextureCubeMap::create( loadImage( loadAsset( "vertical_cross_layout.png" ) ) ) );
 	mCubeMaps.push_back( gl::TextureCubeMap::create( loadImage( loadAsset( "horizontal.png" ) ) ) );
 	mCubeMaps.push_back( gl::TextureCubeMap::create( loadImage( loadAsset( "vertical.hdr" ) ) ) );
-	
-	CameraPersp cam( getWindowWidth(), getWindowHeight(), 60.0, 0.1f, 1000.0f );
-	cam.setEyePoint( vec3( 0, 0, 10 ) );
-	cam.setCenterOfInterestPoint( vec3(0) );
-	
-	mMayaCam.setCurrentCam( cam );
+
+	mMayaCamPersp = CameraPersp( getWindowWidth(), getWindowHeight(), 60.0, 0.1f, 1000.0f );
+	mMayaCamPersp.setEyePoint( vec3( 0, 0, 10 ) );
+	mMayaCamPersp.lookAt( vec3(0) );
+
+	mMayaCam.setCamera( &mMayaCamPersp );
 }
 
 void CubeMapLayoutApp::mouseDown( MouseEvent event )
@@ -72,14 +73,14 @@ void CubeMapLayoutApp::mouseDrag( MouseEvent event )
 void CubeMapLayoutApp::draw()
 {
 	gl::clear( Color( 0, 0, 0 ) );
-	
+
 	{
 		gl::setMatrices( mMayaCam.getCamera() );
 		gl::ScopedTextureBind texture( mCubeMaps[mSelectedCubeMap] );
 		mCube->draw();
 	}
-	
+
 	mParams->draw();
 }
 
-CINDER_APP( CubeMapLayoutApp, RendererGl )
+CINDER_APP( CubeMapLayoutApp, RendererGl, &CubeMapLayoutApp::prepareSettings )

--- a/test/_opengl/QueryTest/src/QueryTestApp.cpp
+++ b/test/_opengl/QueryTest/src/QueryTestApp.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 class QueryTestApp : public App {
 public:
-	void prepareSettings( Settings * settings ) override;
+	static void prepareSettings( Settings * settings );
 	void setup() override;
 	void update() override;
 	void draw() override;
@@ -80,4 +80,4 @@ void QueryTestApp::draw()
 	
 }
 
-CINDER_APP( QueryTestApp, RendererGl )
+CINDER_APP( QueryTestApp, RendererGl, &QueryTestApp::prepareSettings )

--- a/test/assetTest/src/assetTestApp.cpp
+++ b/test/assetTest/src/assetTestApp.cpp
@@ -1,4 +1,5 @@
 #include "cinder/app/App.h"
+#include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
 #include "cinder/ImageIo.h"
 #include "cinder/gl/Texture.h"
@@ -12,13 +13,13 @@ class assetTestApp : public App {
 	void setup();
 	void draw();
 
-	gl::Texture img;
+	gl::TextureRef img;
 };
 
 void assetTestApp::setup()
 {
 	app::console() << "The full path to asset1 is " << getAssetPath( "asset1.png" ) << std::endl;
-	img = loadImage( loadAsset( "asset1.png" ) );
+	img = gl::Texture::create( loadImage( loadAsset( "asset1.png" ) ) );
 }
 
 void assetTestApp::draw()

--- a/test/base64Test/src/base64TestApp.cpp
+++ b/test/base64Test/src/base64TestApp.cpp
@@ -1,5 +1,6 @@
 #include "cinder/app/App.h"
 #include "cinder/app/RendererGl.h"
+#include "cinder/gl/gl.h"
 #include "cinder/Base64.h"
 
 using namespace ci;
@@ -16,11 +17,11 @@ class base64TestApp : public App {
 
 std::string toString( Buffer b )
 {
-	if( b.getDataSize() == 0 )
+	if( b.getSize() == 0 )
 		return std::string();
-	char *temp = new char[b.getDataSize()+1];
-	memcpy( temp, b.getData(), b.getDataSize() );
-	temp[b.getDataSize()] = 0;
+	char *temp = new char[b.getSize()+1];
+	memcpy( temp, b.getData(), b.getSize() );
+	temp[b.getSize()] = 0;
 	return string( temp );	
 }
 

--- a/test/cmdLineArgs/include/Resources.h
+++ b/test/cmdLineArgs/include/Resources.h
@@ -1,5 +1,4 @@
 #pragma once
 #include "cinder/CinderResources.h"
-#include "Resources.h"
 
 //#define RES_MY_RES			CINDER_RESOURCE( ../resources/, image_name.png, 128, IMAGE )

--- a/test/cmdLineArgs/src/cmdLineArgsApp.cpp
+++ b/test/cmdLineArgs/src/cmdLineArgsApp.cpp
@@ -1,4 +1,6 @@
 #include "cinder/app/App.h"
+#include "cinder/app/RendererGl.h"
+#include "cinder/gl/gl.h"
 #include "cinder/Utilities.h"
 
 using namespace ci;
@@ -10,6 +12,9 @@ class cmdLineArgsApp : public App {
  public:
 	void setup();
 	void draw();
+
+	static void prepareSettings( App::Settings *settings ) { getArgs() = settings->getCommandLineArgs(); }
+	static vector<string>& getArgs() { static vector<string> args; return args; }
 };
 
 void cmdLineArgsApp::setup()
@@ -28,4 +33,4 @@ void cmdLineArgsApp::draw()
 }
 
 // This line tells Cinder to actually create the application
-CINDER_APP( cmdLineArgsApp, RendererGl )
+CINDER_APP( cmdLineArgsApp, RendererGl, &cmdLineArgsApp::prepareSettings )

--- a/test/resizeTest/Resources.h
+++ b/test/resizeTest/Resources.h
@@ -1,4 +1,4 @@
 #pragma once
 #include "cinder/CinderResources.h"
 
-#define RES_IMAGE		CINDER_RESOURCE( ../../data/, cinder_logo.png, 128, JPG )
+#define RES_IMAGE		CINDER_RESOURCE( ../../samples/data/, cinder_logo.png, 128, PNG )

--- a/test/resizeTest/resizeTest.cpp
+++ b/test/resizeTest/resizeTest.cpp
@@ -18,7 +18,7 @@ using namespace ci::app;
 class ResizeTestApp : public App {
  public:	
 	
-	void prepareSettings( Settings *settings );
+	static void prepareSettings( Settings *settings );
 	void setup();
 	void draw();
 
@@ -55,4 +55,4 @@ void ResizeTestApp::draw()
 }
 
 
-CINDER_APP( ResizeTestApp, RendererGl )
+CINDER_APP( ResizeTestApp, RendererGl, &ResizeTestApp::prepareSettings )

--- a/test/streamFileTest/src/streamFileTestApp.cpp
+++ b/test/streamFileTest/src/streamFileTestApp.cpp
@@ -22,7 +22,12 @@ class streamFileTestApp : public App {
 
 fs::path streamFileTestApp::createReadTestFile()
 {
-	fs::path resultPath = fs::unique_path( getAppPath() / "cinder_streamFileTest-%%%%-%%%%-%%%%-%%%%" );
+    // unique_path() is not in std::filesystem. 
+	//fs::path resultPath = fs::unique_path( getAppPath() / "cinder_streamFileTest-%%%%-%%%%-%%%%-%%%%" );
+	char buff[256] = { 0 };
+	snprintf(buff, 255, "cinder_streamFileTest-%llu", (unsigned long long)time(NULL));
+	fs::path resultPath = getAppPath() / buff;
+
 	FILE *f = fopen( resultPath.string().c_str(), "wb" );
 	for( size_t d = 0; d < DATA_SIZE; ++d ) {
 		uint8_t b = d % 256;


### PR DESCRIPTION
Some of the test programs built with vc 2015 were fixed as it was the old Cinder specification.

   assetTest   base64Test   CameraLensShiftTest
   cmdLineArgs   LineBreakTest   TestScreensaver
   streamFileTest  XMLTest
   _opengl/
       ConvenienceDrawingMethods   CubeMapLayout   QueryTest

Things that were difficult to fix and gave up:
  cairoTest   mathTest   SignalsTest
