### PR TITLE
[CMake] Use quotes for targets filepath.

### DIFF
--- a/proj/cmake/modules/cinderConfig.buildtree.cmake.in
+++ b/proj/cmake/modules/cinderConfig.buildtree.cmake.in
@@ -1,5 +1,5 @@
 if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
-    include( ${PROJECT_BINARY_DIR}/${CINDER_LIB_DIRECTORY}/cinderTargets.cmake )
+    include( "${PROJECT_BINARY_DIR}/${CINDER_LIB_DIRECTORY}/cinderTargets.cmake" )
 endif()
 
 


### PR DESCRIPTION
Solves issues with paths containing whitespaces. 

Came across this when trying out Visual Studio 2017 `Open Folder` feature where the default CMake configuration is something like `Debug (default)` and this reflects on the exported path. 

Using double quotes enforces a textual representation of the path which guards against any whitespaces.