### PR TITLE
Fixed centering issue on Mac

### DIFF
--- a/samples/_timeline/TextInputTween/src/TextInputTweenApp.cpp
+++ b/samples/_timeline/TextInputTween/src/TextInputTweenApp.cpp
@@ -25,7 +25,7 @@ using namespace std;
 
 class TextInputTweenApp : public App {
   public:
-	void prepareSettings( Settings *settings );
+	static void prepareSettings( Settings *settings );
 	void setup();
 	void keyDown( KeyEvent event );
 	void update();
@@ -49,6 +49,9 @@ class TextInputTweenApp : public App {
 
 void TextInputTweenApp::prepareSettings( Settings *settings )
 {
+#if defined( CINDER_MAC )
+    	settings->setHighDensityDisplayEnabled(true);
+#endif
 	settings->setWindowSize( 700, 700 );
 	settings->setFrameRate( 60 );
 }
@@ -161,4 +164,4 @@ void TextInputTweenApp::draw()
 		mDyingCharacters.pop_front();
 }
 
-CINDER_APP( TextInputTweenApp, RendererGl )
+CINDER_APP( TextInputTweenApp, RendererGl, &TextInputTweenApp::prepareSettings )


### PR DESCRIPTION
The content was in the upper right hand corner on recent Mac builds so I updated this sample to handle high density screens

Added setHighDensityDisplayEnabled() and passed prepareSettings into CINDER_APP