### PR TITLE
Fix explicit ComputeBasic app freezing on window resize

### DIFF
--- a/samples/_vulkan_explicit/ComputeBasic/src/ComputeBasicApp.cpp
+++ b/samples/_vulkan_explicit/ComputeBasic/src/ComputeBasicApp.cpp
@@ -49,6 +49,7 @@ class ComputeBasicApp : public App {
 public:	
 	void	setup() override;
 	void	update() override;
+	void	resize() override;
 	void	draw() override;
 	
 private:
@@ -182,6 +183,11 @@ void ComputeBasicApp::update()
 
 		vk::context()->getComputeQueue()->submit( mComputeCmdBuf, VK_NULL_HANDLE, 0, VK_NULL_HANDLE, mComputeDoneSemaphore );
 	}
+}
+
+void ComputeBasicApp::resize()
+{
+	update();
 }
 
 void ComputeBasicApp::draw()


### PR DESCRIPTION
The explicit ComputeBasic sample app will hang during window resize/maximize.

This is because the semaphore `mComputeDoneSemaphore` waited on by rendering operation submitted in `draw()` is never signaled after a resize operation, as explained in pull request #1724 .

This fix is part of the changes in the above mentioned pull request which fixes the semaphore bug, without the VkPresentModeKHR enum change for `VK_PRESENT_MODE_MAX_ENUM`, as Cinder's current vulkan.h in tools/vulkan uses `VK_PRESENT_MODE_MAX_ENUM` instead of `VK_PRESENT_MODE_MAX_ENUM_KHR`, which might be the reason #1724 didn't pass.