### PR TITLE
Making getNetworkAdapters() work on Linux

### DIFF
--- a/src/cinder/System.cpp
+++ b/src/cinder/System.cpp
@@ -59,6 +59,9 @@
 	using namespace Windows::Networking;
 	using namespace Windows::Networking::Connectivity;
 	using namespace cinder::winrt;
+#elif defined( CINDER_LINUX )
+	#include <ifaddrs.h>
+	#include <netdb.h>
 #endif
 
 #if defined( __clang__ ) || defined( __GNUC__ )
@@ -624,7 +627,8 @@ vector<System::NetworkAdapter> System::getNetworkAdapters()
 {
 	vector<System::NetworkAdapter> adapters;
 
-#if defined( CINDER_COCOA )
+#if defined( CINDER_COCOA ) || defined( CINDER_LINUX )
+
 	struct ifaddrs *interfaces = nullptr;
 
 	if( getifaddrs( &interfaces ) == 0 ) {


### PR DESCRIPTION
The same code works in macOS and Linux. Only the required header files were needed to make it work.