### PR TITLE
Glfw window close

### DIFF
--- a/src/cinder/app/linux/WindowImplLinuxGlfw.cpp
+++ b/src/cinder/app/linux/WindowImplLinuxGlfw.cpp
@@ -161,6 +161,7 @@ void WindowImplLinux::setPos( const ivec2 &pos )
 
 void WindowImplLinux::close()
 {
+	::glfwSetWindowShouldClose(	mGlfwWindow, 1 );
 }
 
 void WindowImplLinux::setTitle( const std::string &title )


### PR DESCRIPTION
Filling in `Window::close()` in Linux/GLFW.