### PR TITLE
Fixed Plane ostream <<

### DIFF
--- a/include/cinder/Plane.h
+++ b/include/cinder/Plane.h
@@ -75,7 +75,7 @@ typedef PlaneT<double>	Planed;
 template<typename T>
 std::ostream& operator<<( std::ostream &o, const PlaneT<T> &p )
 {
-	return o << "(" << p.mNormal << ", " << p.mDistance << ")";
+	return o << "(" << p.getNormal() << ", " << p.getDistance() << ")";
 }
 
 //! Exception type thrown when bad values are encountered.


### PR DESCRIPTION
Without this fix `operator<<` cannot access the variables to be printed.
```
cinder/include/cinder/Plane.h:78:23: error: ‘cinder::PlaneT<float>::Vec3T cinder::PlaneT<float>::mNormal’ is private within this context
  return o << "(" << p.mNormal << ", " << p.mDistance << ")";
```