### PR TITLE
Linux unicode input

### DIFF
--- a/include/cinder/app/KeyEvent.h
+++ b/include/cinder/app/KeyEvent.h
@@ -43,6 +43,8 @@ class CI_API KeyEvent : public Event {
 	uint32_t	getCharUtf32() const { return mChar32; } 
 	//! Returns the key code associated with the event, which maps into the enum listed below
 	int			getCode() const { return mCode; }
+	//! Returns the modifiers associated with the event. Can also use the convenience methods below to check for a specific modifiered,
+	unsigned int	getModifiers() const	{ return mModifiers; }
 	//! Returns whether the Shift key was pressed during the event.
 	bool		isShiftDown() const { return (mModifiers & SHIFT_DOWN) ? true : false; }
 	//! Returns whether the Alt (or Option) key was pressed during the event.

--- a/include/cinder/app/KeyEvent.h
+++ b/include/cinder/app/KeyEvent.h
@@ -31,10 +31,11 @@ namespace cinder{ namespace app{
 //! Represents a keyboard event
 class CI_API KeyEvent : public Event {
   public:
-	KeyEvent() : Event()
+	KeyEvent()
+		: Event(), mCode( 0 ), mChar32( 0 ), mChar( 0 ), mModifiers( 0 ), mNativeKeyCode( 0 )
 	{}
-	KeyEvent( WindowRef win, int aCode, uint32_t aChar32, char aChar, unsigned int aModifiers, unsigned int aNativeKeyCode )
-		: Event( win ), mCode( aCode ), mChar32( aChar32 ), mChar( aChar ), mModifiers( aModifiers ), mNativeKeyCode( aNativeKeyCode )
+	KeyEvent( WindowRef win, int code, uint32_t c32, char c, unsigned int modifiers, unsigned int nativeKeyCode )
+		: Event( win ), mCode( code ), mChar32( c32 ), mChar( c ), mModifiers( modifiers ), mNativeKeyCode( nativeKeyCode )
 	{}
 
 	//! Returns the ASCII character associated with the event.

--- a/samples/TextBox/src/TextBoxApp.cpp
+++ b/samples/TextBox/src/TextBoxApp.cpp
@@ -2,7 +2,9 @@
 #include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
 #include "cinder/gl/Texture.h"
+#include "cinder/Log.h"
 #include "cinder/Text.h"
+#include "cinder/Unicode.h"
 
 using namespace ci;
 using namespace ci::app;
@@ -10,14 +12,17 @@ using namespace std;
 
 class TextBoxApp : public App {
   public:
-	void prepareSettings( Settings *settings ) { settings->setMultiTouchEnabled( false ); }
-	void setup();
-	void mouseDrag( MouseEvent event );	
-	void update();
-	void draw();
+	static void prepareSettings( Settings *settings ) { settings->setMultiTouchEnabled( false ); }
+	void setup() override;
+	void keyDown( KeyEvent event ) override;
+	void keyUp( KeyEvent event ) override;
+	void mouseDrag( MouseEvent event ) override;
+	void update() override;
+	void draw() override;
 
 	void render();
 	
+	string				mText;
 	gl::TextureRef		mTextTexture;
 	vec2				mSize;
 	Font				mFont;
@@ -25,13 +30,36 @@ class TextBoxApp : public App {
 
 void TextBoxApp::setup()
 {
+	mText = "Here is some text that is larger than can fit naturally inside of 100 pixels.\nHere are some unicode code points: \303\251\303\241\303\250\303\240\303\247";
+
 #if defined( CINDER_COCOA )
 	mFont = Font( "Cochin-Italic", 32 );
 #else
-	mFont = Font( "Times New Roman", 32 );
+	mFont = Font( "Times New Roman", 24 );
 #endif
 	mSize = vec2( 100, 100 );
 	render();
+}
+
+void TextBoxApp::keyDown( KeyEvent event )
+{
+	if( event.getCharUtf32() ) {
+		std::u32string strUtf32( 1, event.getCharUtf32() );
+		std::string str = ci::toUtf8( strUtf32 );
+		
+		CI_LOG_I( "char " << event.getChar() << ", Utf32: " << str );
+
+		mText += str;
+		render();
+	}
+}
+
+void TextBoxApp::keyUp( KeyEvent event )
+{
+	std::u32string strUtf32( 1, event.getCharUtf32() );
+	std::string str = ci::toUtf8( strUtf32 );
+	
+	CI_LOG_I( "char " << event.getChar() << ", Utf32: " << str );
 }
 
 void TextBoxApp::mouseDrag( MouseEvent event )
@@ -42,12 +70,11 @@ void TextBoxApp::mouseDrag( MouseEvent event )
 
 void TextBoxApp::render()
 {
-	string txt = "Here is some text that is larger than can fit naturally inside of 100 pixels.\nAnd here is another line after a hard break.";
-	TextBox tbox = TextBox().alignment( TextBox::RIGHT ).font( mFont ).size( ivec2( mSize.x, TextBox::GROW ) ).text( txt );
+	TextBox tbox = TextBox().alignment( TextBox::LEFT ).font( mFont ).size( ivec2( mSize.x, TextBox::GROW ) ).text( mText );
 	tbox.setColor( Color( 1.0f, 0.65f, 0.35f ) );
 	tbox.setBackgroundColor( ColorA( 0.5, 0, 0, 1 ) );
 	ivec2 sz = tbox.measure();
-	console() << "Height: " << sz.y << endl;
+	CI_LOG_I( "Height: " << sz.y );
 	mTextTexture = gl::Texture2d::create( tbox.render() );
 }
 

--- a/samples/TextBox/src/TextBoxApp.cpp
+++ b/samples/TextBox/src/TextBoxApp.cpp
@@ -15,7 +15,6 @@ class TextBoxApp : public App {
 	static void prepareSettings( Settings *settings ) { settings->setMultiTouchEnabled( false ); }
 	void setup() override;
 	void keyDown( KeyEvent event ) override;
-	void keyUp( KeyEvent event ) override;
 	void mouseDrag( MouseEvent event ) override;
 	void update() override;
 	void draw() override;
@@ -47,19 +46,9 @@ void TextBoxApp::keyDown( KeyEvent event )
 		std::u32string strUtf32( 1, event.getCharUtf32() );
 		std::string str = ci::toUtf8( strUtf32 );
 		
-		CI_LOG_I( "char " << event.getChar() << ", Utf32: " << str );
-
 		mText += str;
 		render();
 	}
-}
-
-void TextBoxApp::keyUp( KeyEvent event )
-{
-	std::u32string strUtf32( 1, event.getCharUtf32() );
-	std::string str = ci::toUtf8( strUtf32 );
-	
-	CI_LOG_I( "char " << event.getChar() << ", Utf32: " << str );
 }
 
 void TextBoxApp::mouseDrag( MouseEvent event )
@@ -74,7 +63,7 @@ void TextBoxApp::render()
 	tbox.setColor( Color( 1.0f, 0.65f, 0.35f ) );
 	tbox.setBackgroundColor( ColorA( 0.5, 0, 0, 1 ) );
 	ivec2 sz = tbox.measure();
-	CI_LOG_I( "Height: " << sz.y );
+	CI_LOG_I( "text size: " << sz );
 	mTextTexture = gl::Texture2d::create( tbox.render() );
 }
 

--- a/src/cinder/app/linux/AppImplLinuxGlfw.cpp
+++ b/src/cinder/app/linux/AppImplLinuxGlfw.cpp
@@ -199,20 +199,15 @@ public:
 			auto modifiers = extractKeyModifiers( mods );
 			auto convertedChar = modifyChar( key, modifiers, sCapsLockDown );
 
-			CI_LOG_I( "converterdChar: " << convertedChar << ", native keycode: " << nativeKeyCode << ", modifiers: " << modifiers << ", action: " << action );
-
 			if( GLFW_PRESS == action ) {
 				sKeyEvent = KeyEvent( cinderWindow, nativeKeyCode, 0, 0, modifiers, scancode );
 				// if convertedChar != 0, we'll get the unicode char value and wait until onCharInput is called.
 				// if convertedChar == 0, that means it is a non-unicode key (ex ctrl), so we'll emit the keydown here.
 				if( convertedChar == 0 ) {
-					CI_LOG_I( "\t- emitting key down" );
 					cinderWindow->emitKeyDown( &sKeyEvent );
-
 				}
 			}
 			else if( GLFW_RELEASE == action ) {
-				CI_LOG_I( "\t- emitting key up" );
 				KeyEvent event( cinderWindow, sKeyEvent.getCode(), sKeyEvent.getCharUtf32(), sKeyEvent.getChar(), modifiers, scancode );
 				sKeyEvent = {};
 				cinderWindow->emitKeyUp( &event );
@@ -230,7 +225,6 @@ public:
 
 			// create new sKeyEvent that includes same info as previous but also the utf32 char. emit key down signal with that
 			char asciiChar = codepoint < 256 ? (char)codepoint : 0;
-			CI_LOG_I( "codepoint: " << codepoint << ", ascii: " << asciiChar );
 			sKeyEvent = KeyEvent( cinderWindow, sKeyEvent.getCode(), codepoint, asciiChar, sKeyEvent.getModifiers(), sKeyEvent.getNativeKeyCode() );
 			cinderWindow->emitKeyDown( &sKeyEvent );
 		}

--- a/src/cinder/app/linux/AppImplLinuxGlfw.cpp
+++ b/src/cinder/app/linux/AppImplLinuxGlfw.cpp
@@ -35,6 +35,7 @@ class GlfwCallbacks {
 public:
 	
 	static std::map<GLFWwindow*, std::pair<AppImplLinux*,WindowRef>> sWindowMapping;
+	static KeyEvent sKeyEvent;
 	static bool sCapsLockDown, sNumLockDown, sScrollLockDown;
 		
 	static void registerWindowEvents( GLFWwindow *glfwWindow, AppImplLinux* cinderAppImpl, const WindowRef& cinderWindow ) {
@@ -42,6 +43,7 @@ public:
 
 		::glfwSetWindowSizeCallback( glfwWindow, GlfwCallbacks::onWindowSize );
 		::glfwSetKeyCallback( glfwWindow, GlfwCallbacks::onKeyboard );
+		::glfwSetCharCallback( glfwWindow, GlfwCallbacks::onCharInput );
 		::glfwSetCursorPosCallback( glfwWindow, GlfwCallbacks::onMousePos );
 		::glfwSetMouseButtonCallback( glfwWindow, GlfwCallbacks::onMouseButton );
 		::glfwSetScrollCallback( glfwWindow, GlfwCallbacks::onMouseWheel );
@@ -186,7 +188,6 @@ public:
 			cinderAppImpl->setWindow( cinderWindow );
 
 			int32_t nativeKeyCode = KeyEvent::translateNativeKeyCode( key );
-			uint32_t char32 = 0;
 			
 			if( glfwGetKey( glfwWindow, GLFW_KEY_CAPS_LOCK ) )
 				sCapsLockDown = ! sCapsLockDown;
@@ -198,13 +199,40 @@ public:
 			auto modifiers = extractKeyModifiers( mods );
 			auto convertedChar = modifyChar( key, modifiers, sCapsLockDown );
 
-			KeyEvent event( cinderWindow, nativeKeyCode, char32, convertedChar, modifiers, scancode );
+			CI_LOG_I( "converterdChar: " << convertedChar << ", native keycode: " << nativeKeyCode << ", modifiers: " << modifiers << ", action: " << action );
+
 			if( GLFW_PRESS == action ) {
-				cinderWindow->emitKeyDown( &event );
+				sKeyEvent = KeyEvent( cinderWindow, nativeKeyCode, 0, 0, modifiers, scancode );
+				// if convertedChar != 0, we'll get the unicode char value and wait until onCharInput is called.
+				// if convertedChar == 0, that means it is a non-unicode key (ex ctrl), so we'll emit the keydown here.
+				if( convertedChar == 0 ) {
+					CI_LOG_I( "\t- emitting key down" );
+					cinderWindow->emitKeyDown( &sKeyEvent );
+
+				}
 			}
 			else if( GLFW_RELEASE == action ) {
+				CI_LOG_I( "\t- emitting key up" );
+				KeyEvent event( cinderWindow, sKeyEvent.getCode(), sKeyEvent.getCharUtf32(), sKeyEvent.getChar(), modifiers, scancode );
+				sKeyEvent = {};
 				cinderWindow->emitKeyUp( &event );
-			}		
+			}
+		}
+	}
+
+	static void onCharInput( GLFWwindow *glfwWindow, unsigned int codepoint )
+	{
+		auto iter = sWindowMapping.find( glfwWindow );
+		if( sWindowMapping.end() != iter ) {
+			auto& cinderAppImpl = iter->second.first;
+			auto& cinderWindow = iter->second.second;
+			cinderAppImpl->setWindow( cinderWindow );
+
+			// create new sKeyEvent that includes same info as previous but also the utf32 char. emit key down signal with that
+			char asciiChar = codepoint < 256 ? (char)codepoint : 0;
+			CI_LOG_I( "codepoint: " << codepoint << ", ascii: " << asciiChar );
+			sKeyEvent = KeyEvent( cinderWindow, sKeyEvent.getCode(), codepoint, asciiChar, sKeyEvent.getModifiers(), sKeyEvent.getNativeKeyCode() );
+			cinderWindow->emitKeyDown( &sKeyEvent );
 		}
 	}
 
@@ -289,6 +317,7 @@ public:
 };
 
 std::map<GLFWwindow*, std::pair<AppImplLinux*,WindowRef>> GlfwCallbacks::sWindowMapping;
+KeyEvent GlfwCallbacks::sKeyEvent;
 bool GlfwCallbacks::sCapsLockDown = false;
 bool GlfwCallbacks::sNumLockDown = false;
 bool GlfwCallbacks::sScrollLockDown = false;


### PR DESCRIPTION
This is an initial implementation of unicode text input on linux / GLFW platforms. It requires storing an extra `ci::app::KeyEvent` to combine GLFW's `glfwSetKeyCallback` with the `glfwSetCharCallback`, but we discussed and thought this was the most flexible approach. Please let me know what you think, and if you write in a language that requires unicode support then testing is very welcome. :)

I've added a little code to the TextBox sample, and some logging that shows what's going on, which I'll remove before merging.

Fixes #1661