### PR TITLE
Add CINDER_MSVC_MT

### DIFF
--- a/docs/htmlsrc/guides/cmake/cmake.html
+++ b/docs/htmlsrc/guides/cmake/cmake.html
@@ -147,3 +147,4 @@ ci_make_app(
 <h1 id="platform-specific-notes">Platform Specific Notes</h1>
 <h3 id="microsoft-windows">Microsoft Windows</h3>
 <p>As of this writing, we do not support building from CMake-generated Makefiles on Windows, simply because the GCC toolchain is too difficult to set up there with a compiler that supports the features we need (C++11). The best approach there is to use the provided Visual Studio project files, as <a href="https://libcinder.org/docs/guides/windows-setup/index.html">explained here</a>. You can however generate new Visual Studio project files from CMake, if that suits your needs.</p>
+<p>By default, runtime library is set to Multi-threaded Dll (<code>"/MD"</code>), set <code>CINDER_MSVC_MT</code> to <code>ON</code> to use <code>"/MT"</code></p>

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -110,17 +110,19 @@ function( ci_make_app )
 		endif()
 	elseif( CINDER_MSW )
 		if( MSVC )
-			# Override the default /MD with /MT
-			foreach(
-				flag_var
-				CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
-				CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
-			)
-				if( ${flag_var} MATCHES "/MD" )
-					string( REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}" )
-					set( "${flag_var}" "${${flag_var}}" PARENT_SCOPE )
-				endif()
-			endforeach()
+			if( CINDER_MSVC_MT )
+				# Override the default /MD with /MT
+				foreach(
+					flag_var
+					CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+					CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
+				)
+					if( ${flag_var} MATCHES "/MD" )
+						string( REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}" )
+						set( "${flag_var}" "${${flag_var}}" PARENT_SCOPE )
+					endif()
+				endforeach()
+			endif()
 			# Force synchronous PDB writes
 			add_compile_options( /FS )
 			# Force multiprocess compilation

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -108,16 +108,18 @@ list( APPEND CINDER_INCLUDE_SYSTEM_PRIVATE
 list( APPEND CINDER_DEFINES "_LIB;UNICODE;_UNICODE;NOMINMAX;_WIN32_WINNT=0x0601;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS" )
 
 if( MSVC )
-	# Override the default /MD with /MT
-	foreach( 
-		flag_var
-		CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO 
-		CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO 
-	)
-		if( ${flag_var} MATCHES "/MD" )
-			string( REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}" )
-		endif()
-	endforeach()
+	if( CINDER_MSVC_MT )
+		# Override the default /MD with /MT
+		foreach( 
+			flag_var
+			CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO 
+			CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO 
+		)
+			if( ${flag_var} MATCHES "/MD" )
+				string( REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}" )
+			endif()
+		endforeach()
+	endif()
 	# Force synchronous PDB writes
 	add_compile_options( /FS )
 	# Force multiprocess compilation


### PR DESCRIPTION
Cinder's current cmake system actually works well on Windows, but the runtime library is fixed to MT which is not the default setting of other cmake projects. When cinder is used together with other cmake based MSW projects, the setting should have a switch to change between MT and MD.