### PR TITLE
Fixing far plane coordinates for CameraOrtho

### DIFF
--- a/include/cinder/Camera.h
+++ b/include/cinder/Camera.h
@@ -238,7 +238,6 @@ class CI_API CameraOrtho : public Camera {
 	void	setOrtho( float left, float right, float bottom, float top, float nearPlane, float farPlane );
 
 	bool	isPersp() const override { return false; }
-    //! Returns the four corners of the Camera's Far clipping plane, expressed in world-space
 	void	getFarClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const override;
   protected:
 	void	calcProjection() const override;

--- a/include/cinder/Camera.h
+++ b/include/cinder/Camera.h
@@ -238,7 +238,8 @@ class CI_API CameraOrtho : public Camera {
 	void	setOrtho( float left, float right, float bottom, float top, float nearPlane, float farPlane );
 
 	bool	isPersp() const override { return false; }
-	
+    //! Returns the four corners of the Camera's Far clipping plane, expressed in world-space
+	void	getFarClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const override;
   protected:
 	void	calcProjection() const override;
 	Ray		calcRay( float u, float v, float imagePlaneAspectRatio ) const override;

--- a/include/cinder/Camera.h
+++ b/include/cinder/Camera.h
@@ -151,6 +151,7 @@ class CI_API Camera {
 	virtual void	calcProjection() const = 0;
 
 	virtual Ray		calcRay( float u, float v, float imagePlaneAspectRatio ) const = 0;
+	void	getClipCoordinates( float clipDist, float ratio, vec3* topLeft, vec3* topRight, vec3* bottomLeft, vec3* bottomRight ) const;
 
 	vec3	mEyePoint;
 	vec3	mViewDirection;
@@ -238,6 +239,7 @@ class CI_API CameraOrtho : public Camera {
 	void	setOrtho( float left, float right, float bottom, float top, float nearPlane, float farPlane );
 
 	bool	isPersp() const override { return false; }
+	void	getNearClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const override;
 	void	getFarClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const override;
   protected:
 	void	calcProjection() const override;

--- a/src/cinder/Camera.cpp
+++ b/src/cinder/Camera.cpp
@@ -414,6 +414,18 @@ void CameraOrtho::setOrtho( float left, float right, float bottom, float top, fl
 	mProjectionCached = false;
 }
 
+void CameraOrtho::getFarClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const
+{
+	calcMatrices();
+
+	vec3 viewDirection = normalize( mViewDirection );
+
+	*topLeft		= mEyePoint + (mFarClip * viewDirection) + (mFrustumTop * mV) + (mFrustumLeft * mU);
+	*topRight		= mEyePoint + (mFarClip * viewDirection) + (mFrustumTop * mV) + (mFrustumRight * mU);
+	*bottomLeft		= mEyePoint + (mFarClip * viewDirection) + (mFrustumBottom * mV) + (mFrustumLeft * mU);
+	*bottomRight	= mEyePoint + (mFarClip * viewDirection) + (mFrustumBottom * mV) + (mFrustumRight * mU);
+}
+
 void CameraOrtho::calcProjection() const
 {
 	mat4 &p = mProjectionMatrix;

--- a/src/cinder/Camera.cpp
+++ b/src/cinder/Camera.cpp
@@ -100,29 +100,26 @@ void Camera::lookAt( const vec3 &eyePoint, const vec3 &target, const vec3 &aWorl
 	mModelViewCached = false;
 }
 
-void Camera::getNearClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const
+void Camera::getClipCoordinates(float clipDist, float ratio, vec3* topLeft, vec3* topRight, vec3* bottomLeft, vec3* bottomRight) const
 {
 	calcMatrices();
 
 	vec3 viewDirection = normalize( mViewDirection );
 
-	*topLeft		= mEyePoint + (mNearClip * viewDirection) + (mFrustumTop * mV) + (mFrustumLeft * mU);
-	*topRight		= mEyePoint + (mNearClip * viewDirection) + (mFrustumTop * mV) + (mFrustumRight * mU);
-	*bottomLeft		= mEyePoint + (mNearClip * viewDirection) + (mFrustumBottom * mV) + (mFrustumLeft * mU);
-	*bottomRight	= mEyePoint + (mNearClip * viewDirection) + (mFrustumBottom * mV) + (mFrustumRight * mU);
+	*topLeft		= mEyePoint + (clipDist * viewDirection) + ratio * ((mFrustumTop * mV) + (mFrustumLeft * mU));
+	*topRight		= mEyePoint + (clipDist * viewDirection) + ratio * ((mFrustumTop * mV) + (mFrustumRight * mU));
+	*bottomLeft		= mEyePoint + (clipDist * viewDirection) + ratio * ((mFrustumBottom * mV) + (mFrustumLeft * mU));
+	*bottomRight	= mEyePoint + (clipDist * viewDirection) + ratio * ((mFrustumBottom * mV) + (mFrustumRight * mU));
+}
+
+void Camera::getNearClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const
+{
+	getClipCoordinates(mNearClip, mFarClip/mNearClip, topLeft, topRight, bottomLeft, bottomRight);
 }
 
 void Camera::getFarClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const
 {
-	calcMatrices();
-
-	vec3 viewDirection = normalize( mViewDirection );
-	float ratio = mFarClip / mNearClip;
-
-	*topLeft		= mEyePoint + (mFarClip * viewDirection) + (ratio * mFrustumTop * mV) + (ratio * mFrustumLeft * mU);
-	*topRight		= mEyePoint + (mFarClip * viewDirection) + (ratio * mFrustumTop * mV) + (ratio * mFrustumRight * mU);
-	*bottomLeft		= mEyePoint + (mFarClip * viewDirection) + (ratio * mFrustumBottom * mV) + (ratio * mFrustumLeft * mU);
-	*bottomRight	= mEyePoint + (mFarClip * viewDirection) + (ratio * mFrustumBottom * mV) + (ratio * mFrustumRight * mU);
+	getClipCoordinates(mFarClip, mFarClip/mNearClip, topLeft, topRight, bottomLeft, bottomRight);
 }
 
 void Camera::getFrustum( float *left, float *top, float *right, float *bottom, float *near, float *far ) const
@@ -413,17 +410,14 @@ void CameraOrtho::setOrtho( float left, float right, float bottom, float top, fl
 
 	mProjectionCached = false;
 }
+void CameraOrtho::getNearClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const
+{
+	getClipCoordinates(mNearClip, 1.f , topLeft, topRight, bottomLeft, bottomRight);
+}
 
 void CameraOrtho::getFarClipCoordinates( vec3 *topLeft, vec3 *topRight, vec3 *bottomLeft, vec3 *bottomRight ) const
 {
-	calcMatrices();
-
-	vec3 viewDirection = normalize( mViewDirection );
-
-	*topLeft		= mEyePoint + (mFarClip * viewDirection) + (mFrustumTop * mV) + (mFrustumLeft * mU);
-	*topRight		= mEyePoint + (mFarClip * viewDirection) + (mFrustumTop * mV) + (mFrustumRight * mU);
-	*bottomLeft		= mEyePoint + (mFarClip * viewDirection) + (mFrustumBottom * mV) + (mFrustumLeft * mU);
-	*bottomRight	= mEyePoint + (mFarClip * viewDirection) + (mFrustumBottom * mV) + (mFrustumRight * mU);
+	getClipCoordinates(mFarClip, 1.f, topLeft, topRight, bottomLeft, bottomRight);
 }
 
 void CameraOrtho::calcProjection() const


### PR DESCRIPTION
In an ortho box, the area of the near and far sides are the same. I needed to override the getFarClipCoorinates to not use the 'ratio' factor