### PR TITLE
Fixed typo in header include

### DIFF
--- a/samples/QuaternionAccum/src/QuaternionAccumApp.cpp
+++ b/samples/QuaternionAccum/src/QuaternionAccumApp.cpp
@@ -3,7 +3,7 @@
 #include "cinder/app/App.h"
 #include "cinder/app/RendererGl.h"
 #include "cinder/gl/gl.h"
-#include "cinder/Bspline.h"
+#include "cinder/BSpline.h"
 #include "cinder/Rand.h"
 #include "cinder/Camera.h"
 #include "cinder/ImageIo.h"


### PR DESCRIPTION
Simple fix (typo in include statement)  that prevented the compilation of the QuaternionAccumApp sample.