### PR TITLE
Added noexcept to signals move constructors and assignment operators.

### DIFF
--- a/include/cinder/Signals.h
+++ b/include/cinder/Signals.h
@@ -123,9 +123,9 @@ class CI_API Connection {
 	Connection();
 	Connection( const std::shared_ptr<detail::Disconnector> &disconnector, detail::SignalLinkBase *link, int priority );
 	Connection( const Connection &other );
-	Connection( Connection &&other );
+	Connection( Connection &&other ) noexcept;
 	Connection& operator=( const Connection &rhs );
-	Connection& operator=( Connection &&rhs );
+	Connection& operator=( Connection &&rhs ) noexcept;
 
 	//! Disconnects this Connection from the callback chain. \a return true if a disconnection was made, false otherwise.
 	bool disconnect();
@@ -150,9 +150,9 @@ class CI_API ScopedConnection : public Connection, private Noncopyable {
   public:
 	ScopedConnection();
 	~ScopedConnection();
-	ScopedConnection( ScopedConnection &&other );
-	ScopedConnection( Connection &&other );
-	ScopedConnection& operator=( ScopedConnection &&rhs );
+	ScopedConnection( ScopedConnection &&other ) noexcept;
+	ScopedConnection( Connection &&other ) noexcept;
+	ScopedConnection& operator=( ScopedConnection &&rhs ) noexcept;
 };
 
 // ----------------------------------------------------------------------------------------------------

--- a/src/cinder/Signals.cpp
+++ b/src/cinder/Signals.cpp
@@ -42,7 +42,7 @@ Connection::Connection( const Connection &other )
 {
 }
 
-Connection::Connection( Connection &&other )
+Connection::Connection( Connection &&other ) noexcept
 	: mDisconnector( move( other.mDisconnector ) ), mLink( move( other.mLink ) ), mPriority( move( other.mPriority ) )
 {
 }
@@ -56,7 +56,7 @@ Connection& Connection::operator=( const Connection &rhs )
 	return *this;
 }
 
-Connection& Connection::operator=( Connection &&rhs )
+Connection& Connection::operator=( Connection &&rhs ) noexcept
 {	
 	mDisconnector = move( rhs.mDisconnector );
 	mLink = move( rhs.mLink );
@@ -117,17 +117,17 @@ ScopedConnection::~ScopedConnection()
 	disconnect();
 }
 
-ScopedConnection::ScopedConnection( ScopedConnection &&other )
+ScopedConnection::ScopedConnection( ScopedConnection &&other ) noexcept
 	: Connection( std::move( other ) )
 {
 }
 
-ScopedConnection::ScopedConnection( Connection &&other )
+ScopedConnection::ScopedConnection( Connection &&other ) noexcept
 	: Connection( std::move( other ) )
 {
 }
 
-ScopedConnection& ScopedConnection::operator=( ScopedConnection &&rhs )
+ScopedConnection& ScopedConnection::operator=( ScopedConnection &&rhs ) noexcept
 {
 	disconnect(); // first disconnect from existing
 	Connection::operator=( std::move( rhs ) );


### PR DESCRIPTION
This will allow `std::vector<Connection>` and `std::vector<ScopedConnection>` to resize a little more efficiently. Was only waiting until our minimum compiler on MSW was v140 which is now the case.

Fixes #1681. That issue is marked for 0.9.2 milestone, although this is a pretty minor modification so it can be merged before or after that lands.