### PR TITLE
Add cairo block to linux

### DIFF
--- a/blocks/Cairo/cinderblock.xml
+++ b/blocks/Cairo/cinderblock.xml
@@ -4,10 +4,11 @@
 	name="Cairo"
 	id="org.libcinder.cairo"
 	author="Cinder Project"
-	summary="Cairo support for Mac OS X and Windows."
+	summary="Cairo support for Mac OS X, linux and Windows."
 	>
 	<supports os="msw" />
 	<supports os="macosx" />
+	<supports os="linux" />
 	<includePath>include</includePath>
 	<source>src/Cairo.cpp</source>
 	<header>include/cinder/cairo/Cairo.h</header>

--- a/blocks/Cairo/include/cinder/cairo/Cairo.h
+++ b/blocks/Cairo/include/cinder/cairo/Cairo.h
@@ -44,47 +44,8 @@
 #include <vector>
 #include <iomanip>
 
-// Forward declarations used by our cairo wrappers 
-struct _cairo_surface;
-typedef struct _cairo_surface cairo_surface_t;
+#include <cairo.h>
 
-struct _cairo;
-typedef struct _cairo cairo_t;
-
-struct cairo_path; 
-typedef struct cairo_path cairo_path_t;
-
-struct _cairo_pattern;
-typedef struct _cairo_pattern cairo_pattern_t;
-
-/*
-struct _cairo_rectangle;
-typedef struct _cairo_rectangle cairo_rectangle_t;
-
-struct _cairo_rectangle_list;
-typedef struct _cairo_rectangle_list cairo_rectangle_list_t;
-*/
-
-struct _cairo_font_options;
-typedef struct _cairo_font_options cairo_font_options_t;
-
-struct _cairo_matrix;
-typedef struct _cairo_matrix cairo_matrix_t;
-
-struct _cairo_font_face;
-typedef struct _cairo_font_face cairo_font_face_t;
-
-struct _cairo_scaled_font;
-typedef struct _cairo_scaled_font cairo_scaled_font_t;
-
-/*struct _cairo_glyph;
-typedef struct _cairo_glyph cairo_glyph_t;*/
-
-struct _cairo_text_extents;
-typedef struct _cairo_text_extents cairo_text_extents_t;
-
-struct _cairo_font_extents;
-typedef struct _cairo_font_extents cairo_font_extents_t;
 
 namespace cinder { namespace cairo {
 /////////////////////////////////////////////////////////////////////////////

--- a/blocks/Cairo/proj/cmake/CairoConfig.cmake
+++ b/blocks/Cairo/proj/cmake/CairoConfig.cmake
@@ -1,0 +1,24 @@
+if( NOT TARGET Cairo )
+	get_filename_component( CAIRO_SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../src" ABSOLUTE )
+	get_filename_component( CAIRO_INCLUDE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../include" ABSOLUTE )
+
+	list( APPEND CAIRO_SOURCES
+		${CAIRO_SOURCE_PATH}/Cairo.cpp
+	)
+
+	add_library( Cairo ${CAIRO_SOURCES} )
+
+	target_include_directories( Cairo PUBLIC "${CAIRO_INCLUDE_PATH}" )
+	target_link_libraries( Cairo PRIVATE cinder )
+	
+	# sudo apt-get install libcairo2-dev
+	set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}" )
+    find_package( Cairo REQUIRED )
+    target_include_directories( Cairo PUBLIC "${CAIRO_INCLUDE_DIRS}")
+    target_link_libraries( Cairo PUBLIC "${CAIRO_LIBRARIES}")
+    
+    # sudo apt-get install libfreetype6-dev
+    find_package( Freetype REQUIRED )
+    target_include_directories( Cairo PRIVATE ${FREETYPE_INCLUDE_DIRS} )
+    target_link_libraries( Cairo ${FREETYPE_LIBRARIES} )
+endif()

--- a/blocks/Cairo/proj/cmake/CairoConfig.cmake
+++ b/blocks/Cairo/proj/cmake/CairoConfig.cmake
@@ -20,5 +20,5 @@ if( NOT TARGET Cairo )
     # sudo apt-get install libfreetype6-dev
     find_package( Freetype REQUIRED )
     target_include_directories( Cairo PRIVATE ${FREETYPE_INCLUDE_DIRS} )
-    target_link_libraries( Cairo ${FREETYPE_LIBRARIES} )
+    target_link_libraries( Cairo PRIVATE ${FREETYPE_LIBRARIES} )
 endif()

--- a/blocks/Cairo/proj/cmake/FindCairo.cmake
+++ b/blocks/Cairo/proj/cmake/FindCairo.cmake
@@ -1,0 +1,75 @@
+# - Try to find Cairo
+# Once done, this will define
+#
+#  CAIRO_FOUND - system has Cairo
+#  CAIRO_INCLUDE_DIRS - the Cairo include directories
+#  CAIRO_LIBRARIES - link these to use Cairo
+#
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+pkg_check_modules(PC_CAIRO QUIET cairo)
+
+find_path(CAIRO_INCLUDE_DIRS
+    NAMES cairo.h
+    HINTS ${PC_CAIRO_INCLUDEDIR}
+          ${PC_CAIRO_INCLUDE_DIRS}
+    PATH_SUFFIXES cairo
+)
+
+find_library(CAIRO_LIBRARIES
+    NAMES cairo
+    HINTS ${PC_CAIRO_LIBDIR}
+          ${PC_CAIRO_LIBRARY_DIRS}
+)
+
+if (CAIRO_INCLUDE_DIRS)
+    if (EXISTS "${CAIRO_INCLUDE_DIRS}/cairo-version.h")
+        file(READ "${CAIRO_INCLUDE_DIRS}/cairo-version.h" CAIRO_VERSION_CONTENT)
+
+        string(REGEX MATCH "#define +CAIRO_VERSION_MAJOR +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        set(CAIRO_VERSION_MAJOR "${CMAKE_MATCH_1}")
+
+        string(REGEX MATCH "#define +CAIRO_VERSION_MINOR +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        set(CAIRO_VERSION_MINOR "${CMAKE_MATCH_1}")
+
+        string(REGEX MATCH "#define +CAIRO_VERSION_MICRO +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        set(CAIRO_VERSION_MICRO "${CMAKE_MATCH_1}")
+
+        set(CAIRO_VERSION "${CAIRO_VERSION_MAJOR}.${CAIRO_VERSION_MINOR}.${CAIRO_VERSION_MICRO}")
+    endif ()
+endif ()
+
+if ("${Cairo_FIND_VERSION}" VERSION_GREATER "${CAIRO_VERSION}")
+    message(FATAL_ERROR "Required version (" ${Cairo_FIND_VERSION} ") is higher than found version (" ${CAIRO_VERSION} ")")
+endif ()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Cairo REQUIRED_VARS CAIRO_INCLUDE_DIRS CAIRO_LIBRARIES
+                                        VERSION_VAR CAIRO_VERSION)
+
+mark_as_advanced(
+    CAIRO_INCLUDE_DIRS
+    CAIRO_LIBRARIES
+)

--- a/blocks/Cairo/src/Cairo.cpp
+++ b/blocks/Cairo/src/Cairo.cpp
@@ -41,6 +41,10 @@
 #elif defined( CINDER_MSW )
 	#include "cinder/app/App.h"
 	#include <cairo-win32.h>
+#elif defined( CINDER_LINUX )
+	#include "cinder/app/App.h"
+	#include <cairo-xlib.h>
+	#include <cairo-ft.h>
 #endif
 
 using std::vector;
@@ -344,7 +348,7 @@ SurfaceEps::SurfaceEps( const fs::path &filePath, double widthInPoints, double h
 	: SurfaceBase( (int32_t)widthInPoints, (int32_t)heightInPoints )
 {
 	mCairoSurface = cairo_ps_surface_create( filePath.string().c_str(), widthInPoints, heightInPoints ); 
-	cairo_ps_surface_set_eps( mCairoSurface, TRUE );
+	cairo_ps_surface_set_eps( mCairoSurface, true );
 	cairo_ps_surface_restrict_to_level( mCairoSurface, ( enableLevel3 ) ? CAIRO_PS_LEVEL_3 : CAIRO_PS_LEVEL_2 );
 }
 
@@ -1743,6 +1747,8 @@ void Context::setFont( const cinder::Font &font )
 	cairo_font_face_t *cairoFont = cairo_quartz_font_face_create_for_cgfont( font.getCgFontRef() );
 #elif defined( CINDER_MSW )
 	cairo_font_face_t *cairoFont = cairo_win32_font_face_create_for_logfontw( const_cast<LOGFONTW*>( (const LOGFONTW*)font.getLogfont() ) );
+#elif defined( CINDER_LINUX )
+	cairo_font_face_t *cairoFont = cairo_ft_font_face_create_for_ft_face( font.getFreetypeFace(), 0 );
 #endif
 	cairo_set_font_face( mCairo, cairoFont );
 	cairo_set_font_size( mCairo, font.getSize() );
@@ -2054,7 +2060,7 @@ class SvgRendererCairo : public svg::Renderer {
 			fontMatrix *= rotationMatrix;
 			mCtx.setFontMatrix( fontMatrix );
 			TextBox tbox = TextBox().font( *font ).text( span.getString() );
-			std::vector<std::pair<uint16_t,vec2> > glyphs = tbox.measureGlyphs();
+			std::vector<std::pair<Font::Glyph,vec2> > glyphs = tbox.measureGlyphs();
 			vec2 curPoint = mCtx.getCurrentPoint();
 			for( size_t g = 0; g < glyphs.size(); ++g ) {
 				mCtx.save();

--- a/samples/_svg/AnimatedReveal/proj/cmake/CMakeLists.txt
+++ b/samples/_svg/AnimatedReveal/proj/cmake/CMakeLists.txt
@@ -11,4 +11,5 @@ include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 ci_make_app(
 	SOURCES     ${APP_PATH}/src/AnimatedRevealApp.cpp
 	CINDER_PATH ${CINDER_PATH}
+	BLOCKS      Cairo
 )

--- a/samples/_svg/EuroMap/proj/cmake/CMakeLists.txt
+++ b/samples/_svg/EuroMap/proj/cmake/CMakeLists.txt
@@ -11,4 +11,5 @@ include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 ci_make_app(
 	SOURCES     ${APP_PATH}/src/EuroMapApp.cpp
 	CINDER_PATH ${CINDER_PATH}
+	BLOCKS      Cairo
 )

--- a/samples/_svg/GoodNightMorning/proj/cmake/CMakeLists.txt
+++ b/samples/_svg/GoodNightMorning/proj/cmake/CMakeLists.txt
@@ -8,7 +8,19 @@ get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
 
 include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 
+set( SRC_FILES
+	${APP_PATH}/src/GoodNightMorningApp.cpp
+	${APP_PATH}/src/TweetStream.cpp
+)
+
+set( INC_PATHS
+	${APP_PATH}/include
+	${APP_PATH}/src
+)
+
 ci_make_app(
-	SOURCES     ${APP_PATH}/src/GoodNightMorningApp.cpp
+	SOURCES     ${SRC_FILES}
+	INCLUDES    ${INC_FILES}
 	CINDER_PATH ${CINDER_PATH}
+	BLOCKS      Cairo
 )

--- a/samples/_svg/SimpleViewer/proj/cmake/CMakeLists.txt
+++ b/samples/_svg/SimpleViewer/proj/cmake/CMakeLists.txt
@@ -11,4 +11,5 @@ include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
 ci_make_app(
 	SOURCES     ${APP_PATH}/src/SimpleViewerApp.cpp
 	CINDER_PATH ${CINDER_PATH}
+	BLOCKS      Cairo
 )


### PR DESCRIPTION
This is a child PR from #2134.

Cairo block now builds on linux, along with all the `_svg` samples.
The code was slightly changed so it should be tested on windows and mac os.

Should close #1815 