### PR TITLE
Terminate handler instead of global try-catch

### DIFF
--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -450,6 +450,7 @@ class CI_API AppBase {
 	//! \endcond
 
   private:
+	static void		onTerminate();
 
 	Timer					mTimer;
 	uint32_t				mFrameCount;

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -184,19 +184,29 @@ void AppBase::initialize( Settings *settings, const RendererRef &defaultRenderer
 	sSettingsFromMain = settings;
 }
 
+void AppBase::onTerminate()
+{
+	if( auto excptr = std::current_exception() ) {
+		try {
+			std::rethrow_exception( excptr );
+		}
+		catch( const std::exception & exc ) {
+			CI_LOG_F( "Uncaught exception, type: " << System::demangleTypeName( typeid( exc ).name() ) << ", what: " << exc.what() );
+		}
+	}
+	std::exit( EXIT_FAILURE );
+}
+
 void AppBase::executeLaunch()
 {
-	try {
-		// a quit() was called from the app constructor; don't launch
-		if( mQuitRequested )
-			return;
-		mLaunchCalled = true;
-		launch();
-	}
-	catch( std::exception &exc ) {
-		CI_LOG_F( "Uncaught exception, type: " << System::demangleTypeName( typeid( exc ).name() ) << ", what: " << exc.what() );
-		throw;
-	}
+	std::set_terminate( onTerminate );
+
+	// a quit() was called from the app constructor; don't launch
+	if( mQuitRequested )
+		return;
+
+	mLaunchCalled = true;
+	launch();
 }
 
 // static

--- a/src/cinder/app/AppBase.cpp
+++ b/src/cinder/app/AppBase.cpp
@@ -191,7 +191,10 @@ void AppBase::onTerminate()
 			std::rethrow_exception( excptr );
 		}
 		catch( const std::exception & exc ) {
-			CI_LOG_F( "Uncaught exception, type: " << System::demangleTypeName( typeid( exc ).name() ) << ", what: " << exc.what() );
+			CI_LOG_F( "Terminating due to uncaught exception, type: " << System::demangleTypeName( typeid( exc ).name() ) << ", what: " << exc.what() );
+		}
+		catch( ... ) {
+			CI_LOG_F( "Terminating due to unknown uncaught exception" );
 		}
 	}
 	std::exit( EXIT_FAILURE );


### PR DESCRIPTION
Consider this more as a suggestion -- needs more testing.

This is an alternative to the global app try-catch. Debuggers and crash dumps can often point to catch re-throw and hide the exact source of an exception. This would be prevented with this approach, while preserving the error logging.

Thoughts?