### PR TITLE
Remove boost artifacts from macOS cmake configuration.

### DIFF
--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -86,11 +86,6 @@ list( APPEND CINDER_SRC_FILES
 	${SRC_SET_AUDIO_COCOA}
 )
 
-list( APPEND CINDER_LIBS_DEPENDS
-    ${CINDER_PATH}/lib/${CINDER_TARGET_SUBFOLDER}/libboost_system.a
-    ${CINDER_PATH}/lib/${CINDER_TARGET_SUBFOLDER}/libboost_filesystem.a
-)
-
 # link in system frameworks
 find_library( COCOA_FRAMEWORK Cocoa REQUIRED )
 find_library( OPENGL_FRAMEWORK OpenGL REQUIRED )
@@ -146,7 +141,6 @@ source_group( "cinder\\app\\cocoa"      FILES ${SRC_SET_APP_COCOA} )
 source_group( "cinder\\audio\\cocoa"    FILES ${SRC_SET_AUDIO_COCOA} )
 
 set( MACOS_SUBFOLDER            "${CINDER_PATH}/lib/${CINDER_TARGET_SUBFOLDER}" )
-set( CINDER_STATIC_LIBS_DEPENDS "${MACOS_SUBFOLDER}/libboost_filesystem.a ${MACOS_SUBFOLDER}/libboost_system.a" )
 
 if( NOT ( "Xcode" STREQUAL "${CMAKE_GENERATOR}" ) )
 	if(NOT CMAKE_LIBTOOL)


### PR DESCRIPTION
This seems to be a residual from the recent Boost dependency removal that got missed on macOS and currently breaks compilation through CMake.

Tested on macOS 10.13.6 with Clang 9.0.0 and Cinder's current `master` branch.