### PR TITLE
Added quasi-random number generator and support for Rand<double>.

### DIFF
--- a/include/cinder/QuasiRand.h
+++ b/include/cinder/QuasiRand.h
@@ -1,0 +1,208 @@
+/*
+ Copyright (c) 2020, The Cinder Project: http://libcinder.org
+ All rights reserved.
+
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Portions of this code based on the excellent article by Martin Roberts:
+ http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "cinder/Export.h"
+#include "cinder/Vector.h"
+
+#include <cstdint>
+#include <random>
+#include <type_traits>
+
+namespace cinder {
+
+template <typename T = float, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+class CI_API QuasiRandT {
+  public:
+	QuasiRandT() = default;
+
+	QuasiRandT( uint32_t seed )
+		: mSeed( seed )
+	{
+	}
+
+	//! Resets the quasi-random generator to the specific seed \a seedValue.
+	void seed( uint32_t seedValue ) { mSeed = seedValue; }
+
+	//! Returns a quasi-random float in the range [0.0f,1.0f).
+	T nextFloat()
+	{
+		static T sIrrational = T{ 1 } / phi( 1 );
+		return recurrence( T{ 0.5 }, sIrrational, ++sSeed );
+	}
+
+	//! Returns a quasi-random float in the range [0.0f,v).
+	T nextFloat( T v ) { return nextFloat() * v; }
+
+	//! Returns a quasi-random float in the range [a,b).
+	T nextFloat( T a, T b ) { return nextFloat() * ( b - a ) + a; }
+
+	//! Returns a quasi-random float in the range [a,b] or the range [-b,-a).
+	T posNegFloat( T a, T b )
+	{
+		static std::mt19937 sBase( 310u );
+		if( sBase() & 1 )
+			return nextFloat( a, b );
+
+		return -nextFloat( a, b );
+	}
+
+	//! Returns two corresponding quasi-random floats in the range [0.0f,1.0f).
+	void nextFloats( T &a, T &b )
+	{
+		static T sIrrationalA = T{ 1 } / phi( 2 );
+		static T sIrrationalB = T{ 1 } / ( phi( 2 ) * phi( 2 ) );
+		++sSeed;
+		a = recurrence( T{ 0.5 }, sIrrationalA, sSeed );
+		b = recurrence( T{ 0.5 }, sIrrationalB, sSeed );
+	}
+
+	//! Returns three corresponding quasi-random floats in the range [0.0f,1.0f).
+	void nextFloats( T &a, T &b, T &c )
+	{
+		static T sIrrationalA = T{ 1 } / phi( 3 );
+		static T sIrrationalB = T{ 1 } / ( phi( 3 ) * phi( 3 ) );
+		static T sIrrationalC = T{ 1 } / ( phi( 3 ) * phi( 3 ) * phi( 3 ) );
+		++sSeed;
+		a = recurrence( T{ 0.5 }, sIrrationalA, sSeed );
+		b = recurrence( T{ 0.5 }, sIrrationalB, sSeed );
+		c = recurrence( T{ 0.5 }, sIrrationalC, sSeed );
+	}
+
+	//! Returns a quasi-random vec2 that represents a point on the unit circle.
+	glm::vec<2, T, glm::defaultp> nextVec2()
+	{
+		const T theta = randFloat() * T{ M_PI * 2.0 };
+		return glm::vec<2, T, glm::defaultp>( cos( theta ), sin( theta ) );
+	}
+
+	//! Returns a quasi-random vec3 that represents a point on the unit sphere.
+	glm::vec<3, T, glm::defaultp> nextVec3()
+	{
+		T phi, cosTheta;
+		randFloats( phi, cosTheta );
+
+		phi *= T{ M_PI * 2.0 };
+		cosTheta = T{ 2 } * cosTheta - T{ 1 };
+
+		T rho = sqrt( T{ 1 } - cosTheta * cosTheta );
+		T x = rho * cos( phi );
+		T y = rho * sin( phi );
+		T z = cosTheta;
+
+		return glm::vec<3, T, glm::defaultp>( x, y, z );
+	}
+
+	//! Resets the static quasi-random generator to the specific seed \a seedValue.
+	static void randSeed( uint32_t seedValue ) { sSeed = seedValue; }
+
+	//! Returns a quasi-random float in the range [0.0f,1.0f).
+	static T randFloat()
+	{
+		static T sIrrational = T{ 1 } / phi( 1 );
+		return recurrence( T{ 0.5 }, sIrrational, ++sSeed );
+	}
+
+	//! Returns two corresponding quasi-random floats in the range [0.0f,1.0f).
+	static void randFloats( T &a, T &b )
+	{
+		static T sIrrationalA = T{ 1 } / phi( 2 );
+		static T sIrrationalB = T{ 1 } / ( phi( 2 ) * phi( 2 ) );
+		++sSeed;
+		a = recurrence( T{ 0.5 }, sIrrationalA, sSeed );
+		b = recurrence( T{ 0.5 }, sIrrationalB, sSeed );
+	}
+
+	//! Returns three corresponding quasi-random floats in the range [0.0f,1.0f).
+	static void randFloats( T &a, T &b, T &c )
+	{
+		static T sIrrationalA = T{ 1 } / phi( 3 );
+		static T sIrrationalB = T{ 1 } / ( phi( 3 ) * phi( 3 ) );
+		static T sIrrationalC = T{ 1 } / ( phi( 3 ) * phi( 3 ) * phi( 3 ) );
+		++sSeed;
+		a = recurrence( T{ 0.5 }, sIrrationalA, sSeed );
+		b = recurrence( T{ 0.5 }, sIrrationalB, sSeed );
+		c = recurrence( T{ 0.5 }, sIrrationalC, sSeed );
+	}
+
+	//! Returns a quasi-random vec2 that represents a point on the unit circle.
+	static glm::vec<2, T, glm::defaultp> randVec2()
+	{
+		const T theta = randFloat() * T{ M_PI * 2.0 };
+		return glm::vec<2, T, glm::defaultp>( cos( theta ), sin( theta ) );
+	}
+
+	//! Returns a quasi-random vec3 that represents a point on the unit sphere.
+	static glm::vec<3, T, glm::defaultp> randVec3()
+	{
+		T phi, cosTheta;
+		randFloats( phi, cosTheta );
+
+		phi *= T{ M_PI * 2.0 };
+		cosTheta = T{ 2 } * cosTheta - T{ 1 };
+
+		T rho = sqrt( T{ 1 } - cosTheta * cosTheta );
+		T x = rho * cos( phi );
+		T y = rho * sin( phi );
+		T z = cosTheta;
+
+		return glm::vec<3, T, glm::defaultp>( x, y, z );
+	}
+
+  private:
+	//! Returns the fractional part of \a value.
+	static T fract( T value )
+	{
+		static T integral;
+		return modf( value, &integral );
+	}
+
+	//! Returns a quasi-random compatible irrational number. For d=1, this is the golden ratio.
+	static T phi( uint32_t d )
+	{
+		T x{ 2 };
+		for( int i = 0; i < 10; ++i )
+			x = pow( T{ 1 } + x, T{ 1 } / ( d + 1 ) );
+		return x;
+	}
+
+	//! Helper function. Returns the n-th value in a recurrence sequence based on \a irrational.
+	static T recurrence( T base, T irrational, uint32_t n ) { return fract( base + n * irrational ); }
+
+
+	uint32_t mSeed = 0;
+
+	static uint32_t sSeed;
+};
+
+using QuasiRand = QuasiRandT<float>;
+using QuasiRandf = QuasiRandT<float>;
+using QuasiRandd = QuasiRandT<double>;
+using QuasiRandld = QuasiRandT<long double>;
+
+} // namespace cinder

--- a/include/cinder/Rand.h
+++ b/include/cinder/Rand.h
@@ -27,226 +27,185 @@
 
 namespace cinder {
 
-class CI_API Rand {
- public:
-	Rand() = default;
+template <typename T = float, std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+class CI_API RandT {
+  public:
+	RandT() = default;
 
-	Rand( uint32_t seed )
+	RandT( uint32_t seed )
 		: mBase( seed )
-	{}
+	{
+	}
 
 	//! Re-seeds the random generator
-	void seed( uint32_t seedValue )
-	{
-		mBase.seed( seedValue );
-	}
+	void seed( uint32_t seedValue ) { mBase.seed( seedValue ); }
 
 	//! returns a random boolean value
-	bool nextBool()
-	{
-		return mBase() & 1;
-	}
+	bool nextBool() { return mBase() & 1; }
 
 	//! returns a random integer in the range [-2147483648,2147483647]
-	int32_t nextInt()
-	{
-		return mBase();
-	}
+	int32_t nextInt() { return mBase(); }
 
 	//! returns a random integer in the range [0,4294967296)
-	uint32_t nextUint()
-	{
-		return mBase();
-	}
+	uint32_t nextUint() { return mBase(); }
 
 	//! returns a random integer in the range [0,v)
 	int32_t nextInt( int32_t v )
 	{
-		if( v <= 0 ) return 0;
+		if( v <= 0 )
+			return 0;
 		return mBase() % v;
 	}
 
 	//! returns a random integer in the range [0,v)
 	uint32_t nextUint( uint32_t v )
 	{
-		if( v == 0 ) return 0;
+		if( v == 0 )
+			return 0;
 		return mBase() % v;
 	}
 
 	//! returns a random integer in the range [a,b)
-	int32_t nextInt( int32_t a, int32_t b )
-	{
-		return nextInt( b - a ) + a;
-	}
+	int32_t nextInt( int32_t a, int32_t b ) { return nextInt( b - a ) + a; }
 
 	//! returns a random float in the range [0.0f,1.0f)
-	float nextFloat()
-	{
-		return mFloatGen( mBase );
-	}
+	T nextFloat() { return mFloatGen( mBase ); }
 
 	//! returns a random float in the range [0.0f,v)
-	float nextFloat( float v )
-	{
-		return mFloatGen( mBase ) * v;
-	}
+	T nextFloat( T v ) { return nextFloat() * v; }
 
 	//! returns a random float in the range [a,b)
-	float nextFloat( float a, float b )
-	{
-		return mFloatGen( mBase ) * ( b - a ) + a;
-	}
+	T nextFloat( T a, T b ) { return nextFloat() * ( b - a ) + a; }
 
 	//! returns a random float in the range [a,b] or the range [-b,-a)
-	float posNegFloat( float a, float b )
+	T posNegFloat( T a, T b )
 	{
 		if( nextBool() )
 			return nextFloat( a, b );
-		else
-			return -nextFloat( a, b );
+
+		return -nextFloat( a, b );
 	}
 
 	//! returns a random vec3 that represents a point on the unit sphere
-	vec3 nextVec3()
+	glm::vec<3, T, glm::defaultp> nextVec3()
 	{
-		float phi = nextFloat( (float)M_PI * 2.0f );
-		float costheta = nextFloat( -1.0f, 1.0f );
+		const T phi = nextFloat( T{ M_PI * 2.0 } );
+		const T cosTheta = nextFloat( T{ -1 }, T{ 1 } );
 
-		float rho = math<float>::sqrt( 1.0f - costheta * costheta );
-		float x = rho * math<float>::cos( phi );
-		float y = rho * math<float>::sin( phi );
-		float z = costheta;
+		const T rho = sqrt( T{ 1 } - cosTheta * cosTheta );
+		const T x = rho * cos( phi );
+		const T y = rho * sin( phi );
+		const T z = cosTheta;
 
-		return vec3( x, y, z );
+		return glm::vec<3, T, glm::defaultp>( x, y, z );
 	}
 
 	//! returns a random vec2 that represents a point on the unit circle
-	vec2 nextVec2()
+	glm::vec<2, T, glm::defaultp> nextVec2()
 	{
-		float theta = nextFloat( (float)M_PI * 2.0f );
-		return vec2( math<float>::cos( theta ), math<float>::sin( theta ) );
+		const T theta = nextFloat( T{ M_PI * 2.0 } );
+		return glm::vec<2, T, glm::defaultp>( cos( theta ), sin( theta ) );
 	}
 
 	//! returns a random float via Gaussian distribution, with a mean of 0 and a standard deviation of 1.0
-	float nextGaussian()
-	{
-		return mNormDist( mBase );
-	}
+	T nextGaussian() { return mNormDist( mBase ); }
 
 	// STATICS
 	//! Resets the static random generator to a random seed
-	static void randomize()
-	{
-		sBase.seed( std::random_device{}() );
-	}
+	static void randomize() { sBase.seed( std::random_device{}() ); }
 
 	//! Resets the static random generator to the specific seed \a seedValue
-	static void	randSeed( uint32_t seedValue )
-	{
-		sBase.seed( seedValue );
-	}
+	static void randSeed( uint32_t seedValue ) { sBase.seed( seedValue ); }
 
 	//! returns a random boolean value
-	static bool randBool()
-	{
-		return sBase() & 1;
-	}
+	static bool randBool() { return sBase() & 1; }
 
 	//! returns a random integer in the range [-2147483648,2147483647]
-	static int32_t randInt()
-	{
-		return sBase();
-	}
+	static int32_t randInt() { return sBase(); }
 
 	//! returns a random integer in the range [0,4294967296)
-	static uint32_t randUint()
-	{
-		return sBase();
-	}
+	static uint32_t randUint() { return sBase(); }
 
 	//! returns a random integer in the range [0,v)
 	static int32_t randInt( int32_t v )
 	{
-		if( v <= 0 ) return 0;
-		else return sBase() % v;
+		if( v <= 0 )
+			return 0;
+
+		return sBase() % v;
 	}
 
 	//! returns a random integer in the range [0,v)
 	static uint32_t randUint( uint32_t v )
 	{
-		if( v == 0 ) return 0;
-		else return sBase() % v;
+		if( v == 0 )
+			return 0;
+
+		return sBase() % v;
 	}
 
 	//! returns a random integer in the range [a,b)
-	static int32_t randInt( int32_t a, int32_t b )
-	{
-		return randInt( b - a ) + a;
-	}
+	static int32_t randInt( int32_t a, int32_t b ) { return randInt( b - a ) + a; }
 
 	//! returns a random float in the range [0.0f,1.0f)
-	static float randFloat()
-	{
-		return sFloatGen( sBase );
-	}
+	static T randFloat() { return sFloatGen( sBase ); }
 
 	//! returns a random float in the range [0.0f,v)
-	static float randFloat( float v )
-	{
-		return sFloatGen( sBase ) * v;
-	}
+	static T randFloat( T v ) { return randFloat() * v; }
 
 	//! returns a random float in the range [a,b)
-	static float randFloat( float a, float b )
-	{
-		return sFloatGen( sBase ) * ( b - a ) + a;
-	}
+	static T randFloat( T a, T b ) { return randFloat() * ( b - a ) + a; }
 
 	//! returns a random float in the range [a,b) or the range [-b,-a)
-	static float randPosNegFloat( float a, float b )
+	static T randPosNegFloat( T a, T b )
 	{
 		if( randBool() )
 			return randFloat( a, b );
-		else
-			return -randFloat( a, b );
+
+		return -randFloat( a, b );
 	}
 
 	//! returns a random vec3 that represents a point on the unit sphere
-	static vec3 randVec3()
+	static glm::vec<3, T, glm::defaultp> randVec3()
 	{
-		float phi = randFloat( (float)M_PI * 2.0f );
-		float costheta = randFloat( -1.0f, 1.0f );
+		const T phi = randFloat( T{ M_PI * 2.0 } );
+		const T cosTheta = randFloat( T{ -1 }, T{ 1 } );
 
-		float rho = math<float>::sqrt( 1.0f - costheta * costheta );
-		float x = rho * math<float>::cos( phi );
-		float y = rho * math<float>::sin( phi );
-		float z = costheta;
+		const T rho = sqrt( T{ 1 } - cosTheta * cosTheta );
+		const T x = rho * cos( phi );
+		const T y = rho * sin( phi );
+		const T z = cosTheta;
 
-		return vec3( x, y, z );
+		return glm::vec<3, T, glm::defaultp>( x, y, z );
 	}
 
 	//! returns a random vec2 that represents a point on the unit circle
-	static vec2 randVec2()
+	static glm::vec<2, T, glm::defaultp> randVec2()
 	{
-		float theta = randFloat( (float)M_PI * 2.0f );
-		return vec2( math<float>::cos( theta ), math<float>::sin( theta ) );
+		const T theta = randFloat( T{ M_PI * 2.0 } );
+		return glm::vec<2, T, glm::defaultp>( math<float>::cos( theta ), math<float>::sin( theta ) );
 	}
 
 	//! returns a random float via Gaussian distribution
-	static float randGaussian()
+	static T randGaussian()
 	{
-		static std::normal_distribution<float> dist{};
+		static std::normal_distribution<T> dist{};
 		return dist( sBase );
 	}
 
   private:
-	std::mt19937 mBase;
-	std::uniform_real_distribution<float>	mFloatGen;
-	std::normal_distribution<float>			mNormDist;
+	std::mt19937                      mBase;
+	std::uniform_real_distribution<T> mFloatGen;
+	std::normal_distribution<T>       mNormDist;
 
-	static std::mt19937 sBase;
-	static std::uniform_real_distribution<float> sFloatGen;
+	static std::mt19937                      sBase;
+	static std::uniform_real_distribution<T> sFloatGen;
 };
+
+using Rand = RandT<float>;
+using Randf = RandT<float>;
+using Randd = RandT<double>;
+using Randld = RandT<long double>;
 
 //! Resets the static random generator to the specific seed \a seedValue
 CI_API inline void randSeed( uint32_t seedValue ) { Rand::randSeed( seedValue ); }

--- a/proj/vc2019/cinder.vcxproj
+++ b/proj/vc2019/cinder.vcxproj
@@ -825,6 +825,7 @@
     <ClCompile Include="..\..\src\cinder\Perlin.cpp" />
     <ClCompile Include="..\..\src\cinder\Plane.cpp" />
     <ClCompile Include="..\..\src\cinder\PolyLine.cpp" />
+    <ClCompile Include="..\..\src\cinder\QuasiRand.cpp" />
     <ClCompile Include="..\..\src\cinder\Rand.cpp" />
     <ClCompile Include="..\..\src\cinder\Ray.cpp" />
     <ClCompile Include="..\..\src\cinder\Rect.cpp" />
@@ -1135,6 +1136,7 @@
     <ClInclude Include="..\..\include\cinder\Matrix44.h" />
     <ClInclude Include="..\..\include\cinder\Plane.h" />
     <ClInclude Include="..\..\include\cinder\Function.h" />
+    <ClInclude Include="..\..\include\cinder\QuasiRand.h" />
     <ClInclude Include="..\..\include\cinder\Signals.h" />
     <ClInclude Include="..\..\include\cinder\svg\Svg.h" />
     <ClInclude Include="..\..\include\cinder\svg\SvgGl.h" />

--- a/proj/vc2019/cinder.vcxproj.filters
+++ b/proj/vc2019/cinder.vcxproj.filters
@@ -1080,6 +1080,9 @@
     <ClCompile Include="..\..\src\cinder\gl\nv\Multicast.cpp">
       <Filter>Source Files\gl\nv</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\cinder\QuasiRand.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AntTweakBar\AntPerfTimer.h">
@@ -2269,6 +2272,9 @@
     </ClInclude>
     <ClInclude Include="..\..\include\cinder\gl\nv\Multicast.h">
       <Filter>Header Files\gl\nv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\cinder\QuasiRand.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/cinder/QuasiRand.cpp
+++ b/src/cinder/QuasiRand.cpp
@@ -1,8 +1,8 @@
 /*
- Copyright (c) 2010, The Barbarian Group
+ Copyright (c) 2020, The Cinder Project: http://libcinder.org
  All rights reserved.
 
- Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
 
  Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  the following conditions are met:
@@ -22,15 +22,12 @@
  POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "cinder/Rand.h"
+#include "cinder/QuasiRand.h"
 
 namespace cinder {
 
-std::mt19937                                RandT<float>::sBase( 310u );
-std::uniform_real_distribution<float>       RandT<float>::sFloatGen;
-std::mt19937                                RandT<double>::sBase( 310u );
-std::uniform_real_distribution<double>      RandT<double>::sFloatGen;
-std::mt19937                                RandT<long double>::sBase( 310u );
-std::uniform_real_distribution<long double> RandT<long double>::sFloatGen;
+uint32_t QuasiRandT<float>::sSeed = 0;
+uint32_t QuasiRandT<double>::sSeed = 0;
+uint32_t QuasiRandT<long double>::sSeed = 0;
 
 } // namespace cinder


### PR DESCRIPTION
Based on the excellent article by Martin Roberts:
http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/

The `QuasiRand` class returns quasi random values in the range [0, 1) which are evenly distributed across the full range. When used to generate points on a sphere, it looks like this:

![QuasiRandomSequencesApp 20-3-2020 15_40_28](https://user-images.githubusercontent.com/304908/77176213-0ba94b80-6ac4-11ea-81f2-19efb5019144.png)

By comparison, fully random points would look like this:

![QuasiRandomSequencesApp 20-3-2020 15_40_56](https://user-images.githubusercontent.com/304908/77176259-1c59c180-6ac4-11ea-9f46-c01df63841b4.png)

The great thing about the algorithm is that it doesn't require you to know the number of values up front. Here's the same sphere after simply adding 4 times as many points:

![QuasiRandomSequencesApp 20-3-2020 16_06_09](https://user-images.githubusercontent.com/304908/77176724-cafe0200-6ac4-11ea-8821-2af2eaf683b0.png)

The class is templated and uses `float` by default, but also supports `double` and `long double`.

I will add a sample later.

Also refactored the `Rand` class by adding a template argument. This allows the use of `double` and `long double` random values. By default it uses `float` values.