### PR TITLE
MediaTime

### DIFF
--- a/include/cinder/MediaTime.h
+++ b/include/cinder/MediaTime.h
@@ -1,0 +1,205 @@
+/*
+ Copyright (c) 2020, The Cinder Project: http://libcinder.org All rights reserved.
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "cinder/Cinder.h"
+#include <iosfwd>
+
+namespace cinder {
+
+//! Does not allow negative or zero base
+struct MediaTime {
+  public:
+	static constexpr int32_t DEFAULT_TIME_BASE = 1000000; // microseconds
+	static constexpr int64_t MAX_TIME_BASE = 2147483647;
+
+	MediaTime() : value( 0 ), base( 1 ), epoch( 0 ) {} // zero
+	MediaTime( int64_t value, int32_t base, int64_t epoch = 0 );
+	
+	explicit MediaTime( int value ) : value( value ), base( 1 ), epoch( 0 ) {}
+	explicit MediaTime( int64_t value ) : value( value ), base( 1 ), epoch( 0 ) {}
+	explicit MediaTime( double seconds )
+		: value( (int64_t)( seconds * DEFAULT_TIME_BASE ) ), base( DEFAULT_TIME_BASE ), epoch( 0 )
+	{}
+
+	int64_t		getValue() const { return value; }
+	int32_t		getBase() const { return base; }
+	int64_t		getEpoch() const { return epoch; }
+	double		getSeconds() const { return value / (double)base; }
+
+	//! Scale value to 'newBase'. value is set to floor if necessary.
+	void		setBase( int32_t newBase );
+
+	//! Returns value as scaled to \a otherBase
+	int64_t		getValueAsBase( int32_t otherBase ) const { return ( base == otherBase ) ? value : ( value * otherBase / base ); }
+
+	bool operator<( const MediaTime &rhs ) const {
+		if( epoch != rhs.epoch ) return epoch < rhs.epoch;
+		if( base == rhs.base ) return value < rhs.value;
+		else return value * rhs.base < rhs.value * base;
+	}
+
+	bool operator>( const MediaTime &rhs ) const {
+		if( epoch != rhs.epoch ) return epoch > rhs.epoch;
+		if( base == rhs.base ) return value > rhs.value;
+		else return value * rhs.base > rhs.value * base;
+	}
+
+	bool operator<=( const MediaTime &rhs ) const {
+		if( epoch != rhs.epoch ) return epoch <= rhs.epoch;
+		if( base == rhs.base ) return value <= rhs.value;
+		else return value * rhs.base <= rhs.value * base;
+	}
+
+	bool operator>=( const MediaTime &rhs ) const {
+		if( epoch != rhs.epoch ) return epoch >= rhs.epoch;
+		if( base == rhs.base ) return value >= rhs.value;
+		else return value * rhs.base >= rhs.value * base;
+	}
+
+	//! Tests for mathematical equivalence, not bitwise equivalence
+	bool operator==( const MediaTime &rhs ) const {
+		if( epoch != rhs.epoch ) return false;
+		else if( base == rhs.base ) return value == rhs.value;
+		else return value * rhs.base == rhs.value * base;
+	}
+
+	bool operator!=( const MediaTime &rhs ) const {
+		if( epoch != rhs.epoch ) return true;
+		else if( base == rhs.base ) return value != rhs.value;
+		else return value * rhs.base != rhs.value * base;
+	}
+
+	//! Epoch is max of epochs. If base overflows, DEFAULT_TIME_BASE is selected
+	MediaTime operator-( const MediaTime &rhs ) const {
+		if( rhs.base == base ) return MediaTime( value - rhs.value, base, epoch > rhs.epoch ? epoch : rhs.epoch );
+		else {
+			int64_t lhsValue = value, rhsValue = rhs.value;
+			int32_t newBase = simplifyBases( &lhsValue, base, &rhsValue, rhs.base );
+			return MediaTime( lhsValue - rhsValue, newBase, epoch > rhs.epoch ? epoch : rhs.epoch );
+		}
+	}
+
+	//! Epoch is max of epochs. If base overflows, DEFAULT_TIME_BASE is selected
+	MediaTime operator+( const MediaTime &rhs ) const {
+		if( rhs.base == base ) return MediaTime( value + rhs.value, base, epoch > rhs.epoch ? epoch : rhs.epoch );
+		else {
+			int64_t lhsValue = value, rhsValue = rhs.value;
+			int32_t newBase = simplifyBases( &lhsValue, base, &rhsValue, rhs.base );
+			return MediaTime( lhsValue + rhsValue, newBase, epoch > rhs.epoch ? epoch : rhs.epoch );
+		}
+	}
+
+	//! Epoch is max of epochs. If base overflows, DEFAULT_TIME_BASE is selected
+	MediaTime operator*( const MediaTime &rhs ) const {
+		if( base * rhs.base <= DEFAULT_TIME_BASE ) return MediaTime( value * rhs.value, base * rhs.base, epoch > rhs.epoch ? epoch : rhs.epoch );
+		else {
+			int64_t lhsValue = value * DEFAULT_TIME_BASE / base, rhsValue = rhs.value * DEFAULT_TIME_BASE / rhs.base;
+			return MediaTime( lhsValue * rhsValue / DEFAULT_TIME_BASE, DEFAULT_TIME_BASE, epoch > rhs.epoch ? epoch : rhs.epoch );
+		}
+	}
+
+	//! Epoch is max of epochs. If base overflows, DEFAULT_TIME_BASE is selected
+	MediaTime operator/( const MediaTime &rhs ) const {
+		// exchanges 'value' and 'base' of 'rhs' and multiplies
+		if( base * rhs.value <= (int64_t)DEFAULT_TIME_BASE ) return MediaTime( value * rhs.base, (int32_t)(base * rhs.value), epoch > rhs.epoch ? epoch : rhs.epoch );
+		else {
+			int64_t lhsValue = value * DEFAULT_TIME_BASE / base, rhsValue = (int64_t)rhs.base * DEFAULT_TIME_BASE / rhs.value;
+			return MediaTime( lhsValue * rhsValue / DEFAULT_TIME_BASE, DEFAULT_TIME_BASE, epoch > rhs.epoch ? epoch : rhs.epoch );
+		}
+	}
+
+	//! Does not affect epoch. If base overflows, DEFAULT_TIME_BASE is selected
+	MediaTime& operator-=( const MediaTime &rhs ) {
+		MediaTime newTime = *this - rhs;
+		value = newTime.value;
+		base = newTime.base;
+		return *this;
+	}
+
+	//! Does not affect epoch. If base overflows, DEFAULT_TIME_BASE is selected
+	MediaTime& operator+=( const MediaTime &rhs ) {
+		MediaTime newTime = *this + rhs;
+		value = newTime.value;
+		base = newTime.base;
+		return *this;
+	}
+
+	//! Does not affect epoch. If base overflows, DEFAULT_TIME_BASE is selected
+	MediaTime& operator*=( const MediaTime &rhs ) {
+		MediaTime newTime = *this * rhs;
+		value = newTime.value;
+		base = newTime.base;
+		return *this;
+	}
+
+	//! Does not affect epoch. If base overflows, DEFAULT_TIME_BASE is selected
+	MediaTime& operator/=( const MediaTime &rhs ) {
+		MediaTime newTime = *this / MediaTime( rhs.value, rhs.base, rhs.epoch );
+		value = newTime.value;
+		base = newTime.base;
+		return *this;
+	}
+
+	MediaTime operator-() const {
+		return MediaTime( -value, base, epoch );
+	}
+
+	friend std::ostream& operator<<( std::ostream &os, const MediaTime &mt );
+
+	//! Divides the value and base by the greatest common common divisor of both. Does not affect epoch
+	void simplify();
+
+	//! returns a new common base, and re-bases 'lhsValue' and 'rhsValue' to this new base. If no legal common base, then uses DEFAULT_TIME_BASE
+	static int32_t simplifyBases( int64_t *lhsValue, int32_t lhsBase, int64_t *rhsValue, int32_t rhsBase );
+
+	int64_t		value;
+	int32_t		base;
+	int64_t		epoch;
+};
+
+inline MediaTime operator*( int lhs, const MediaTime &rhs ) { return MediaTime( rhs.value * lhs, rhs.base, rhs.epoch ); }
+inline MediaTime operator*( const MediaTime &lhs, int rhs ) { return MediaTime( lhs.value * rhs, lhs.base, lhs.epoch ); }
+inline MediaTime operator*( double lhs, const MediaTime &rhs ) { return MediaTime( lhs ) * rhs; }
+inline MediaTime operator*( const MediaTime &lhs, double rhs ) { return lhs * MediaTime( rhs ); }
+inline MediaTime operator*( float lhs, const MediaTime &rhs ) { return MediaTime( lhs ) * rhs; }
+inline MediaTime operator*( const MediaTime &lhs, float rhs ) { return lhs * MediaTime( rhs ); }
+
+inline MediaTime operator/( int lhs, const MediaTime &rhs ) { return MediaTime( lhs ) / rhs; }
+inline MediaTime operator/( const MediaTime &lhs, int rhs ) { return lhs / MediaTime( rhs ); }
+inline MediaTime operator/( double lhs, const MediaTime &rhs ) { return MediaTime( lhs ) / rhs; }
+inline MediaTime operator/( const MediaTime &lhs, double rhs ) { return lhs / MediaTime( rhs ); }
+inline MediaTime operator/( float lhs, const MediaTime &rhs ) { return MediaTime( lhs ) / rhs; }
+inline MediaTime operator/( const MediaTime &lhs, float rhs ) { return lhs / MediaTime( rhs ); }
+
+inline MediaTime operator"" _sec( long double seconds )
+{
+	return MediaTime( (int64_t)(seconds * MediaTime::DEFAULT_TIME_BASE ), MediaTime::DEFAULT_TIME_BASE );
+}
+
+inline MediaTime operator"" _sec( unsigned long long seconds )
+{
+	return MediaTime( (int64_t)(seconds * MediaTime::DEFAULT_TIME_BASE ), MediaTime::DEFAULT_TIME_BASE );
+}
+
+} // namespace cinder

--- a/include/cinder/MediaTime.h
+++ b/include/cinder/MediaTime.h
@@ -50,8 +50,14 @@ struct MediaTime {
 	//! Scale value to 'newBase'. value is set to floor if necessary.
 	void		setBase( int32_t newBase );
 
+	void		setEpoch( int64_t newEpoch ) { epoch = newEpoch; }
+
 	//! Returns value as scaled to \a otherBase
 	int64_t		getValueAsBase( int32_t otherBase ) const { return ( base == otherBase ) ? value : ( value * otherBase / base ); }
+
+	MediaTime	asBase( int32_t otherBase ) const { auto temp = *this; temp.setBase( otherBase ); return temp; }
+	MediaTime	asEpoch( int64_t otherEpoch ) const { return MediaTime( value, base, otherEpoch ); }
+	MediaTime	as( int32_t otherBase, int64_t otherEpoch ) const { auto temp = *this; temp.setBase( otherBase ); temp.setEpoch( otherEpoch ); return temp; }
 
 	bool operator<( const MediaTime &rhs ) const {
 		if( epoch != rhs.epoch ) return epoch < rhs.epoch;
@@ -170,7 +176,7 @@ struct MediaTime {
 	//! Divides the value and base by the greatest common common divisor of both. Does not affect epoch
 	void simplify();
 
-	//! returns a new common base, and re-bases 'lhsValue' and 'rhsValue' to this new base. If no legal common base, then uses DEFAULT_TIME_BASE
+	//! returns a new common base, and re-bases \a lhsValue and \a rhsValue to this new base. If no legal common base, then uses DEFAULT_TIME_BASE
 	static int32_t simplifyBases( int64_t *lhsValue, int32_t lhsBase, int64_t *rhsValue, int32_t rhsBase );
 
 	int64_t		value;

--- a/include/cinder/MediaTime.h
+++ b/include/cinder/MediaTime.h
@@ -112,7 +112,7 @@ struct MediaTime {
 
 	//! Epoch is max of epochs. If base overflows, DEFAULT_TIME_BASE is selected
 	MediaTime operator*( const MediaTime &rhs ) const {
-		if( base * rhs.base <= DEFAULT_TIME_BASE ) return MediaTime( value * rhs.value, base * rhs.base, epoch > rhs.epoch ? epoch : rhs.epoch );
+		if( base * (int64_t)rhs.base <= (int64_t)DEFAULT_TIME_BASE ) return MediaTime( value * rhs.value, base * rhs.base, epoch > rhs.epoch ? epoch : rhs.epoch );
 		else {
 			int64_t lhsValue = value * DEFAULT_TIME_BASE / base, rhsValue = rhs.value * DEFAULT_TIME_BASE / rhs.base;
 			return MediaTime( lhsValue * rhsValue / DEFAULT_TIME_BASE, DEFAULT_TIME_BASE, epoch > rhs.epoch ? epoch : rhs.epoch );
@@ -122,7 +122,7 @@ struct MediaTime {
 	//! Epoch is max of epochs. If base overflows, DEFAULT_TIME_BASE is selected
 	MediaTime operator/( const MediaTime &rhs ) const {
 		// exchanges 'value' and 'base' of 'rhs' and multiplies
-		if( base * rhs.value <= (int64_t)DEFAULT_TIME_BASE ) return MediaTime( value * rhs.base, (int32_t)(base * rhs.value), epoch > rhs.epoch ? epoch : rhs.epoch );
+		if( base * (int64_t)rhs.value <= (int64_t)DEFAULT_TIME_BASE ) return MediaTime( value * rhs.base, (int32_t)(base * rhs.value), epoch > rhs.epoch ? epoch : rhs.epoch );
 		else {
 			int64_t lhsValue = value * DEFAULT_TIME_BASE / base, rhsValue = (int64_t)rhs.base * DEFAULT_TIME_BASE / rhs.value;
 			return MediaTime( lhsValue * rhsValue / DEFAULT_TIME_BASE, DEFAULT_TIME_BASE, epoch > rhs.epoch ? epoch : rhs.epoch );

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -36,6 +36,7 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/Json.cpp
 	${CINDER_SRC_DIR}/cinder/Log.cpp
 	${CINDER_SRC_DIR}/cinder/Matrix.cpp
+	${CINDER_SRC_DIR}/cinder/MediaTime.cpp
 	${CINDER_SRC_DIR}/cinder/ObjLoader.cpp
 	${CINDER_SRC_DIR}/cinder/Path2d.cpp
 	${CINDER_SRC_DIR}/cinder/Perlin.cpp

--- a/proj/vc2019/cinder.vcxproj
+++ b/proj/vc2019/cinder.vcxproj
@@ -820,6 +820,7 @@
     <ClCompile Include="..\..\src\cinder\Json.cpp" />
     <ClCompile Include="..\..\src\cinder\Log.cpp" />
     <ClCompile Include="..\..\src\cinder\Matrix.cpp" />
+    <ClCompile Include="..\..\src\cinder\MediaTime.cpp" />
     <ClCompile Include="..\..\src\cinder\ObjLoader.cpp" />
     <ClCompile Include="..\..\src\cinder\Path2D.cpp" />
     <ClCompile Include="..\..\src\cinder\Perlin.cpp" />
@@ -1133,6 +1134,7 @@
     <ClInclude Include="..\..\include\cinder\Matrix22.h" />
     <ClInclude Include="..\..\include\cinder\Matrix33.h" />
     <ClInclude Include="..\..\include\cinder\Matrix44.h" />
+    <ClInclude Include="..\..\include\cinder\MediaTime.h" />
     <ClInclude Include="..\..\include\cinder\Plane.h" />
     <ClInclude Include="..\..\include\cinder\Function.h" />
     <ClInclude Include="..\..\include\cinder\Signals.h" />

--- a/proj/vc2019/cinder.vcxproj.filters
+++ b/proj/vc2019/cinder.vcxproj.filters
@@ -1080,6 +1080,9 @@
     <ClCompile Include="..\..\src\cinder\gl\nv\Multicast.cpp">
       <Filter>Source Files\gl\nv</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\cinder\MediaTime.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AntTweakBar\AntPerfTimer.h">
@@ -2269,6 +2272,9 @@
     </ClInclude>
     <ClInclude Include="..\..\include\cinder\gl\nv\Multicast.h">
       <Filter>Header Files\gl\nv</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\cinder\MediaTime.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/proj/xcode/cinder.xcodeproj/project.pbxproj
+++ b/proj/xcode/cinder.xcodeproj/project.pbxproj
@@ -116,6 +116,9 @@
 		003ADB9B1038974A00ACF6F2 /* TwColors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 003ADB8D1038974A00ACF6F2 /* TwColors.cpp */; };
 		003ADB9D1038974A00ACF6F2 /* TwBar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 003ADB8F1038974A00ACF6F2 /* TwBar.cpp */; };
 		003ADBA01038996800ACF6F2 /* AntTweakBar.h in Headers */ = {isa = PBXBuildFile; fileRef = 003ADB9E1038996800ACF6F2 /* AntTweakBar.h */; };
+		003CE47F242A9823007BE072 /* MediaTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 003CE47E242A9823007BE072 /* MediaTime.cpp */; };
+		003CE480242A9823007BE072 /* MediaTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 003CE47E242A9823007BE072 /* MediaTime.cpp */; };
+		003CE481242A9823007BE072 /* MediaTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 003CE47E242A9823007BE072 /* MediaTime.cpp */; };
 		003FAA9F1290CC90002D6860 /* Clipboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 003FAA9E1290CC90002D6860 /* Clipboard.cpp */; };
 		003FAAA31290CCB1002D6860 /* Clipboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 003FAAA21290CCB1002D6860 /* Clipboard.h */; };
 		004172FA14C9BE520070C0D1 /* Frustum.h in Headers */ = {isa = PBXBuildFile; fileRef = 004172F914C9BE520070C0D1 /* Frustum.h */; };
@@ -1717,6 +1720,8 @@
 		003ADB8D1038974A00ACF6F2 /* TwColors.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; name = TwColors.cpp; path = ../../src/AntTweakBar/TwColors.cpp; sourceTree = SOURCE_ROOT; };
 		003ADB8F1038974A00ACF6F2 /* TwBar.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; name = TwBar.cpp; path = ../../src/AntTweakBar/TwBar.cpp; sourceTree = SOURCE_ROOT; };
 		003ADB9E1038996800ACF6F2 /* AntTweakBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AntTweakBar.h; path = ../../src/AntTweakBar/AntTweakBar.h; sourceTree = SOURCE_ROOT; };
+		003CE47E242A9823007BE072 /* MediaTime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaTime.cpp; sourceTree = "<group>"; };
+		003CE482242A983C007BE072 /* MediaTime.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaTime.h; sourceTree = "<group>"; };
 		003FAA9E1290CC90002D6860 /* Clipboard.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = Clipboard.cpp; sourceTree = "<group>"; };
 		003FAAA21290CCB1002D6860 /* Clipboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Clipboard.h; sourceTree = "<group>"; };
 		004172F914C9BE520070C0D1 /* Frustum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Frustum.h; sourceTree = "<group>"; };
@@ -2687,6 +2692,7 @@
 				277C2CEC1366632B00178A29 /* Matrix22.h */,
 				277C2CED1366632B00178A29 /* Matrix33.h */,
 				277C2CEE1366632B00178A29 /* Matrix44.h */,
+				003CE482242A983C007BE072 /* MediaTime.h */,
 				00FF554C1AEADF9C0085071E /* CameraUi.h */,
 				002DFD530FA5602900E45AE0 /* ObjLoader.h */,
 				00CFE37B113B85F60091E310 /* Path2d.h */,
@@ -2772,6 +2778,7 @@
 				43F78EF11516DAB700EB63B5 /* Json.cpp */,
 				0003F47E1992DA9A00647C8B /* Log.cpp */,
 				00241ABD0E830DD5004D34EB /* Matrix.cpp */,
+				003CE47E242A9823007BE072 /* MediaTime.cpp */,
 				002DFD500FA5600900E45AE0 /* ObjLoader.cpp */,
 				001F52090FCF99A10021731E /* Path2d.cpp */,
 				00D2F1850F8D8ACD00A7189A /* Perlin.cpp */,
@@ -4813,6 +4820,7 @@
 				27C100231BD16D4800AF387F /* Stream.cpp in Sources */,
 				27C100241BD16D4800AF387F /* ChannelRouterNode.cpp in Sources */,
 				27C100251BD16D4800AF387F /* framing.c in Sources */,
+				003CE481242A9823007BE072 /* MediaTime.cpp in Sources */,
 				27C100261BD16D4800AF387F /* AppBase.cpp in Sources */,
 				27C100271BD16D4800AF387F /* Color.cpp in Sources */,
 				27C100281BD16D4800AF387F /* Checkerboard.cpp in Sources */,
@@ -5065,6 +5073,7 @@
 				27C1FECD1BD0AE3400AF387F /* Stream.cpp in Sources */,
 				27C1FECE1BD0AE3400AF387F /* ChannelRouterNode.cpp in Sources */,
 				27C1FECF1BD0AE3400AF387F /* framing.c in Sources */,
+				003CE480242A9823007BE072 /* MediaTime.cpp in Sources */,
 				27C1FED01BD0AE3400AF387F /* AppBase.cpp in Sources */,
 				27C1FED11BD0AE3400AF387F /* Color.cpp in Sources */,
 				27C1FED21BD0AE3400AF387F /* Checkerboard.cpp in Sources */,
@@ -5423,6 +5432,7 @@
 				B322C4791DC7DC7100D2E661 /* inffast.c in Sources */,
 				00419C6F11057CC6007EC9AD /* Fill.cpp in Sources */,
 				B3EA40AC1DD0F00900E34348 /* ftpatent.c in Sources */,
+				003CE47F242A9823007BE072 /* MediaTime.cpp in Sources */,
 				00419C7011057CC6007EC9AD /* Flip.cpp in Sources */,
 				00419C7111057CC6007EC9AD /* Grayscale.cpp in Sources */,
 				00419C7211057CC6007EC9AD /* Hdr.cpp in Sources */,

--- a/src/cinder/MediaTime.cpp
+++ b/src/cinder/MediaTime.cpp
@@ -1,0 +1,101 @@
+/*
+ Copyright (c) 2020, The Cinder Project: http://libcinder.org All rights reserved.
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "cinder/MediaTime.h"
+#include "cinder/CinderAssert.h"
+#include <algorithm>
+#include <iostream>
+
+namespace cinder {
+
+MediaTime::MediaTime( int64_t value, int32_t base, int64_t epoch )
+	: value( value ), base( base ), epoch( epoch )
+{
+	if( base < 0 ) {
+		value = -value;
+		base = -base;
+	}
+	CI_ASSERT( base > 0 );
+}
+
+void MediaTime::setBase( int32_t newBase )
+{
+	CI_ASSERT( newBase > 0 ); value = value * newBase / base; base = newBase;
+}
+
+// Divides the value and base by the greatest common common divisor of both. Does not affect epoch
+void MediaTime::simplify()
+{
+	CI_ASSERT( base > 0 );
+
+	if( value == 0 ) {
+		base = 1;
+		return;
+	}
+
+	int64_t u = value, v = base;
+	while( v != 0 ) {
+		int64_t r = u % v;
+		u = v;
+		v = r;
+	}
+	value /= u;
+	base /= (int32_t)u;
+}
+
+//! returns a new common base, and re-bases 'lhsValue' and 'rhsValue' to this new base. If no legal common base, then uses DEFAULT_TIME_BASE
+int32_t MediaTime::simplifyBases( int64_t *lhsValue, int32_t lhsBase, int64_t *rhsValue, int32_t rhsBase )
+{
+	CI_ASSERT( lhsBase > 0 && rhsBase > 0 );
+
+	// calculate gcdV = gcd( lhsBase, rhsBase )
+	int64_t a = (int64_t)lhsBase, b = (int64_t)rhsBase;
+	while( b != 0 )  {
+		int64_t t = b;
+		b = a % b;
+		a = t;
+	}
+	const int64_t gcdV = a;
+
+	// lcm(a,b) = a / gcd(a,b) * b
+	int64_t lcmV = (int64_t)lhsBase / gcdV * rhsBase;
+	// if lcm is acceptably small, use that
+	if( lcmV <= DEFAULT_TIME_BASE ) {
+		*lhsValue = (int64_t)(*lhsValue) * lcmV / lhsBase;
+		*rhsValue = (int64_t)(*rhsValue) * lcmV / rhsBase;
+		return (int32_t)lcmV;
+	}
+	// we're going to have to rebase using DEFAULT_BASE
+	*lhsValue = (int64_t)(*lhsValue) * DEFAULT_TIME_BASE / lhsBase;
+	*rhsValue = (int64_t)(*rhsValue) * DEFAULT_TIME_BASE / rhsBase;
+	return DEFAULT_TIME_BASE;
+}
+
+std::ostream& operator<<( std::ostream &os, const MediaTime &mt )
+{
+	if( mt.epoch == 0 )
+		return os << mt.value << "/" << mt.base;
+	else
+		return os << mt.value << "/" << mt.base << "[" << mt.epoch << "]";
+}
+
+} // namespace cinder

--- a/src/cinder/MediaTime.cpp
+++ b/src/cinder/MediaTime.cpp
@@ -27,6 +27,9 @@
 
 namespace cinder {
 
+const int32_t MediaTime::DEFAULT_TIME_BASE;
+const int64_t MediaTime::MAX_TIME_BASE;
+
 MediaTime::MediaTime( int64_t value, int32_t base, int64_t epoch )
 	: value( value ), base( base ), epoch( epoch )
 {

--- a/test/unit/proj/cmake/CMakeLists.txt
+++ b/test/unit/proj/cmake/CMakeLists.txt
@@ -19,6 +19,7 @@ set( SOURCES
 	${UNIT_DIR}/src/TestMain.cpp
 	${UNIT_DIR}/src/UnicodeTest.cpp
 	${UNIT_DIR}/src/Utilities.cpp
+	${UNIT_DIR}/src/MediaTime.cpp
 	${UNIT_DIR}/src/Path2dTest.cpp
 	${UNIT_DIR}/src/PolyLineTest.cpp
 	${UNIT_DIR}/src/audio/BufferUnit.cpp

--- a/test/unit/src/MediaTime.cpp
+++ b/test/unit/src/MediaTime.cpp
@@ -1,0 +1,147 @@
+#include "catch.hpp"
+
+#include "cinder/Cinder.h"
+#include "cinder/app/App.h"
+#include "cinder/MediaTime.h"
+
+using namespace std;
+using namespace ci;
+
+TEST_CASE( "MediaTime" )
+{
+	SECTION( "Comparison" )
+	{
+		MediaTime oneOverOne( 1, 1 );
+		MediaTime twoOverTwo( 2, 2 );
+		MediaTime oneOverTwo( 1, 2 );
+		MediaTime twoOverOne( 2, 1 );
+		MediaTime oneOverTwoEpoch1( 1, 2, 1 );
+		
+		// >
+		REQUIRE( oneOverOne > oneOverTwo );
+		REQUIRE( twoOverOne > oneOverOne );
+		REQUIRE( twoOverOne > oneOverTwo );
+		REQUIRE( oneOverTwoEpoch1 > twoOverOne );
+		
+		// <
+		REQUIRE( oneOverTwo < oneOverOne );
+		REQUIRE( oneOverOne < twoOverOne );
+		REQUIRE( oneOverTwo < twoOverOne );
+		REQUIRE( oneOverTwo < oneOverTwoEpoch1 );
+
+		// >=
+		REQUIRE( oneOverOne >= oneOverTwo );
+		REQUIRE( twoOverOne >= oneOverOne );
+		REQUIRE( twoOverOne >= oneOverTwo );
+		REQUIRE( oneOverTwoEpoch1 >= twoOverOne );
+		REQUIRE( oneOverTwo >= oneOverTwo );
+		REQUIRE( oneOverTwoEpoch1 >= oneOverTwoEpoch1 );
+		REQUIRE( oneOverOne >= twoOverTwo );
+
+		// <=
+		REQUIRE( oneOverTwo <= oneOverOne );
+		REQUIRE( oneOverOne <= twoOverOne );
+		REQUIRE( oneOverTwo <= twoOverOne );
+		REQUIRE( oneOverTwo <= oneOverTwoEpoch1 );
+		REQUIRE( oneOverTwo <= oneOverTwo );
+		REQUIRE( oneOverTwoEpoch1 <= oneOverTwoEpoch1 );
+		REQUIRE( twoOverTwo <= oneOverOne );
+
+		// ==
+		REQUIRE( oneOverOne == oneOverOne );
+		REQUIRE( oneOverOne == twoOverTwo );		
+
+		// !=
+		REQUIRE( oneOverOne != oneOverTwo );
+		REQUIRE( oneOverTwo != oneOverTwoEpoch1 );		
+	}
+
+	SECTION( "Operations" )
+	{
+		MediaTime zero( 0 );
+		MediaTime oneOverOne( 1, 1 );
+		MediaTime twoOverTwo( 2, 2 );
+		MediaTime oneOverTwo( 1, 2 );
+		MediaTime twoOverOne( 2, 1 );
+		MediaTime oneOverOneEpoch1( 1, 1, 1 );
+		MediaTime oneOverTwoEpoch1( 1, 2, 1 );
+		MediaTime oneEpoch1( 1, 1, 1 );
+		MediaTime oneOverFour( 1, 4 );
+		MediaTime oneOverFourEpoch1( 1, 4, 1 );
+		
+		// -
+		REQUIRE( oneOverOne - zero == oneOverOne );
+		REQUIRE( oneOverOne - oneOverOne == zero );
+		REQUIRE( twoOverTwo - oneOverOne == zero );
+		REQUIRE( twoOverOne - oneOverOne == oneOverOne );
+		REQUIRE( oneOverOne - twoOverOne == -oneOverOne ); // negative
+		
+		// +
+		REQUIRE( zero + zero == zero );
+		REQUIRE( zero + oneOverOne == oneOverOne );
+		REQUIRE( oneOverOne + oneOverOne == twoOverOne );
+		REQUIRE( oneOverTwoEpoch1 + oneOverTwoEpoch1 == oneEpoch1 );
+
+		// *
+		REQUIRE( oneOverOne * oneOverOne == oneOverOne );
+		REQUIRE( oneOverOne * oneOverTwo == oneOverTwo );
+		REQUIRE( oneOverTwo * oneOverTwo == oneOverFour );
+		REQUIRE( oneOverTwoEpoch1 * oneOverTwoEpoch1 == oneOverFourEpoch1 );
+		REQUIRE( oneOverTwo * oneOverTwoEpoch1 == oneOverFourEpoch1 ); // max epochs
+		REQUIRE( oneOverFour * 2 == oneOverTwo );
+		REQUIRE( 2 * oneOverFour == oneOverTwo );
+		REQUIRE( 2 * oneOverFourEpoch1 == oneOverTwoEpoch1 );
+		REQUIRE( (2.5 * oneOverFourEpoch1).getSeconds() == Approx( 0.625f ) );
+
+		// /
+		REQUIRE( oneOverOne / oneOverOne == oneOverOne );
+		REQUIRE( oneOverTwo / oneOverTwo == oneOverOne );
+		REQUIRE( oneOverOne / oneOverTwo == twoOverOne );
+		REQUIRE( oneOverOne / 2 == oneOverTwo );
+		REQUIRE( oneOverOneEpoch1 / 2 == oneOverTwoEpoch1 );
+		
+		// unary -
+		REQUIRE( -oneOverOne == MediaTime( -1, 1 ) );
+
+		// -=
+		{
+			auto oneOverOneTemp = oneOverOne;
+			oneOverOneTemp -= oneOverOne;
+			REQUIRE( oneOverOneTemp == zero );
+		}
+
+		// +=
+		{
+			auto oneOverOneTemp = oneOverOne;
+			oneOverOneTemp += oneOverOne;
+			REQUIRE( oneOverOneTemp == twoOverOne );
+		}
+
+		// *=
+		{
+			auto oneOverTwoTemp = oneOverTwo;
+			oneOverTwoTemp *= oneOverTwo;
+			REQUIRE( oneOverTwoTemp == oneOverFour );
+		}
+
+		// /=
+		{
+			auto oneOverTwoTemp = oneOverTwo;
+			oneOverTwoTemp /= twoOverOne;
+			REQUIRE( oneOverTwoTemp == oneOverFour );
+		}
+		
+		// suffix
+		{
+			REQUIRE( MediaTime( 2 ) == 2_sec );
+			REQUIRE( (2.5_sec).getSeconds() == Approx(2.5) );
+		}
+		
+		// simplify
+		{
+			auto twoOverTwo = MediaTime( 2, 2 );
+			auto twoOverTwoSimplified = twoOverTwo; twoOverTwoSimplified.simplify();
+			REQUIRE( twoOverTwoSimplified == MediaTime( 1 ) );
+		}
+	}
+}

--- a/test/unit/src/MediaTime.cpp
+++ b/test/unit/src/MediaTime.cpp
@@ -68,6 +68,8 @@ TEST_CASE( "MediaTime" )
 		MediaTime oneEpoch1( 1, 1, 1 );
 		MediaTime oneOverFour( 1, 4 );
 		MediaTime oneOverFourEpoch1( 1, 4, 1 );
+		MediaTime oneOverTwoBigBase( 500000, 1000000 );
+		MediaTime oneOverFourBigBase( 500000, 2000000 );
 		
 		// -
 		REQUIRE( oneOverOne - zero == oneOverOne );
@@ -92,6 +94,9 @@ TEST_CASE( "MediaTime" )
 		REQUIRE( 2 * oneOverFour == oneOverTwo );
 		REQUIRE( 2 * oneOverFourEpoch1 == oneOverTwoEpoch1 );
 		REQUIRE( (2.5 * oneOverFourEpoch1).getSeconds() == Approx( 0.625f ) );
+		REQUIRE( (2.5 * oneOverFourEpoch1).getSeconds() == Approx( 0.625f ) );
+		REQUIRE( (oneOverTwoBigBase * oneOverFourBigBase).getSeconds() == Approx( 0.125f ) );
+		REQUIRE( (oneOverTwoBigBase * oneOverFourBigBase).base == MediaTime::DEFAULT_TIME_BASE );
 
 		// /
 		REQUIRE( oneOverOne / oneOverOne == oneOverOne );
@@ -99,6 +104,8 @@ TEST_CASE( "MediaTime" )
 		REQUIRE( oneOverOne / oneOverTwo == twoOverOne );
 		REQUIRE( oneOverOne / 2 == oneOverTwo );
 		REQUIRE( oneOverOneEpoch1 / 2 == oneOverTwoEpoch1 );
+		REQUIRE( (oneOverTwoBigBase / oneOverFourBigBase).getSeconds() == Approx( 2.0f ) );
+		REQUIRE( (oneOverTwoBigBase / oneOverFourBigBase).base == MediaTime::DEFAULT_TIME_BASE );
 		
 		// unary -
 		REQUIRE( -oneOverOne == MediaTime( -1, 1 ) );

--- a/test/unit/src/MediaTime.cpp
+++ b/test/unit/src/MediaTime.cpp
@@ -141,6 +141,7 @@ TEST_CASE( "MediaTime" )
 		// suffix
 		{
 			REQUIRE( MediaTime( 2 ) == 2_sec );
+			REQUIRE( MediaTime( 0 ) == 0_sec );
 			REQUIRE( (2.5_sec).getSeconds() == Approx(2.5) );
 		}
 		
@@ -149,6 +150,21 @@ TEST_CASE( "MediaTime" )
 			auto twoOverTwo = MediaTime( 2, 2 );
 			auto twoOverTwoSimplified = twoOverTwo; twoOverTwoSimplified.simplify();
 			REQUIRE( twoOverTwoSimplified == MediaTime( 1 ) );
+		}
+
+		// "as" convenience
+		{
+			auto oneOverTwo = MediaTime( 1, 2 );
+			REQUIRE( oneOverTwo.asBase( 4 ) == oneOverTwo );
+			REQUIRE( oneOverTwo.asBase( 4 ).base == 4 );
+			REQUIRE( oneOverTwo.asEpoch( 1 ) != oneOverTwo );
+			REQUIRE( oneOverTwo.asEpoch( 1 ) == MediaTime( 1, 2, 1 ) );
+			REQUIRE( oneOverTwo.asEpoch( 1 ).epoch == 1 );
+			REQUIRE( oneOverTwo.asEpoch( 1 ) != oneOverTwo );
+			REQUIRE( oneOverTwo.asEpoch( 1 ) == MediaTime( 1, 2, 1 ) );
+			REQUIRE( oneOverTwo.as( 4, 1 ) != oneOverTwo );
+			REQUIRE( oneOverTwo.as( 4, 1 ).base == 4 );
+			REQUIRE( oneOverTwo.as( 4, 1 ).epoch == 1 );
 		}
 	}
 }

--- a/test/unit/vc2019/unit.vcxproj
+++ b/test/unit/vc2019/unit.vcxproj
@@ -518,6 +518,7 @@ xcopy /y "..\..\..\lib\msw\x86\d3dcompiler_46.dll" "$(OutDir)"</Command>
     <ClCompile Include="..\src\Base64Test.cpp" />
     <ClCompile Include="..\src\FileWatcherTest.cpp" />
     <ClCompile Include="..\src\JsonTest.cpp" />
+    <ClCompile Include="..\src\MediaTime.cpp" />
     <ClCompile Include="..\src\ObjLoaderTest.cpp" />
     <ClCompile Include="..\src\RandTest.cpp" />
     <ClCompile Include="..\src\ShaderPreprocessorTest.cpp" />

--- a/test/unit/vc2019/unit.vcxproj.filters
+++ b/test/unit/vc2019/unit.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClCompile Include="..\src\FileWatcherTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\MediaTime.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\catch.hpp">

--- a/test/unit/xcode/UnitTests.xcodeproj/project.pbxproj
+++ b/test/unit/xcode/UnitTests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		000703221DEB7DE00086D6CA /* Path2dTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 000703211DEB7DE00086D6CA /* Path2dTest.cpp */; };
+		00C7BBC024120160001D5238 /* MediaTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00C7BBBF24120160001D5238 /* MediaTime.cpp */; };
 		114CE0E91E2F03930002A384 /* ShaderPreprocessorTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 114CE0E71E2F03930002A384 /* ShaderPreprocessorTest.cpp */; };
 		114CE0EA1E2F03930002A384 /* Utilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 114CE0E81E2F03930002A384 /* Utilities.cpp */; };
 		117BC7781E836FDF003D8F25 /* FileWatcherTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 117BC7771E836FDF003D8F25 /* FileWatcherTest.cpp */; };
@@ -59,6 +60,7 @@
 		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		00B995581B128DF400A5C623 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		00B995591B128DF400A5C623 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		00C7BBBF24120160001D5238 /* MediaTime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaTime.cpp; sourceTree = "<group>"; };
 		0BFCCD63DF794B1EAE655DCC /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../../../samples/data/CinderApp.icns; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		114CE0E71E2F03930002A384 /* ShaderPreprocessorTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShaderPreprocessorTest.cpp; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				117BC7771E836FDF003D8F25 /* FileWatcherTest.cpp */,
 				9CA851B81C1F74000049358B /* JsonTest.cpp */,
 				9CA851B91C1F74000049358B /* ObjLoaderTest.cpp */,
+				00C7BBBF24120160001D5238 /* MediaTime.cpp */,
 				4989E06B1DB6889500503C9A /* PolyLineTest.cpp */,
 				9CA851BA1C1F74000049358B /* RandTest.cpp */,
 				114CE0E71E2F03930002A384 /* ShaderPreprocessorTest.cpp */,
@@ -292,6 +295,7 @@
 				117BC7781E836FDF003D8F25 /* FileWatcherTest.cpp in Sources */,
 				9CA851C01C1F74000049358B /* Base64Test.cpp in Sources */,
 				9CA851C31C1F74000049358B /* RandTest.cpp in Sources */,
+				00C7BBC024120160001D5238 /* MediaTime.cpp in Sources */,
 				11E4FC4D1C267DB70082A67E /* FftUnit.cpp in Sources */,
 				4989E06C1DB6889500503C9A /* PolyLineTest.cpp in Sources */,
 				9CA851C11C1F74000049358B /* JsonTest.cpp in Sources */,


### PR DESCRIPTION
This PR implements a new `MediaTime` class designed to represent time as a rational number. It is modeled after FFmpeg's [AVRational](https://ffmpeg.org/doxygen/3.3/group__lavu__math__rational.html) and in particular CoreMedia's [CMTime](https://developer.apple.com/documentation/coremedia/cmtime-u58). It's meant to help bridge Cinder into libraries such as those.

The `epoch` is particularly useful when comparing timestamps from one iteration of say, a looping video or audio clip and another.

We've been using this at Rare Volume for the last year and it's been quite helpful. This PR also includes basic unit tests.