### PR TITLE
Added missing <algorithm> header includes 

### DIFF
--- a/src/cinder/Stream.cpp
+++ b/src/cinder/Stream.cpp
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <string>
 #include <cstring>
+#include <algorithm>
 using std::string;
 using std::memcpy;
 

--- a/src/cinder/UrlImplWinInet.cpp
+++ b/src/cinder/UrlImplWinInet.cpp
@@ -27,6 +27,7 @@
 #include <Windows.h>
 #include <Wininet.h>
 #include <Strsafe.h>
+#include <algorithm>
 #pragma comment( lib, "wininet.lib" )
 
 namespace cinder {


### PR DESCRIPTION
For some reason std::min and std::max couldn't be found without the inclusion of `<algorithm>` when building on windows via cmake