### PR TITLE
Extenal libs update (ghc/filesystem)

### DIFF
--- a/include/cinder/Filesystem.h
+++ b/include/cinder/Filesystem.h
@@ -33,7 +33,7 @@
 #endif
 
 #ifndef GHC_USE_STD_FS
-	#include <ghc/fs_std.hpp>
+	#include <ghc/fs_std_fwd.hpp>
 	namespace cinder {
 		namespace fs = ghc::filesystem;
 	} 

--- a/include/cinder/Filesystem.h
+++ b/include/cinder/Filesystem.h
@@ -33,7 +33,7 @@
 #endif
 
 #ifndef GHC_USE_STD_FS
-	#include <ghc/fs_fwd.hpp>
+	#include <ghc/fs_std.hpp>
 	namespace cinder {
 		namespace fs = ghc::filesystem;
 	} 

--- a/include/ghc/fs_std.hpp
+++ b/include/ghc/fs_std.hpp
@@ -1,0 +1,56 @@
+//---------------------------------------------------------------------------------------
+//
+// ghc::filesystem - A C++17-like filesystem implementation for C++11/C++14
+//
+//---------------------------------------------------------------------------------------
+//
+// Copyright (c) 2018, Steffen Schümann <s.schuemann@pobox.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//---------------------------------------------------------------------------------------
+// fs_std.hpp - The dynamic switching header that includes std::filesystem if detected
+//              or ghc::filesystem if not, and makes the resulting API available in the
+//              namespace fs.
+//---------------------------------------------------------------------------------------
+#ifndef GHC_FILESYSTEM_STD_H
+#if defined(__cplusplus) && __cplusplus >= 201703L && defined(__has_include)
+#if __has_include(<filesystem>)
+#define GHC_USE_STD_FS
+#include <filesystem>
+namespace fs {
+using namespace std::filesystem;
+using ifstream = std::ifstream;
+using ofstream = std::ofstream;
+using fstream = std::fstream;
+}
+#endif
+#endif
+#ifndef GHC_USE_STD_FS
+#define GHC_WIN_WSTRING_STRING_TYPE
+#include <ghc/filesystem.hpp>
+namespace fs {
+using namespace ghc::filesystem;
+using ifstream = ghc::filesystem::ifstream;
+using ofstream = ghc::filesystem::ofstream;
+using fstream = ghc::filesystem::fstream;
+} 
+#endif
+#endif // GHC_FILESYSTEM_STD_H
+

--- a/include/ghc/fs_std_fwd.hpp
+++ b/include/ghc/fs_std_fwd.hpp
@@ -1,0 +1,60 @@
+//---------------------------------------------------------------------------------------
+//
+// ghc::filesystem - A C++17-like filesystem implementation for C++11/C++14
+//
+//---------------------------------------------------------------------------------------
+//
+// Copyright (c) 2018, Steffen Schümann <s.schuemann@pobox.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//---------------------------------------------------------------------------------------
+// fs_std_fwd.hpp - The forwarding header for the header/implementation seperated usage of
+//                  ghc::filesystem that uses std::filesystem if it detects it.
+// This file can be include at any place, where fs::filesystem api is needed while
+// not bleeding implementation details (e.g. system includes) into the global namespace,
+// as long as one cpp includes fs_std_impl.hpp to deliver the matching implementations.
+//---------------------------------------------------------------------------------------
+#ifndef GHC_FILESYSTEM_STD_FWD_H
+#define GHC_FILESYSTEM_STD_FWD_H
+#if defined(__cplusplus) && __cplusplus >= 201703L && defined(__has_include)
+#if __has_include(<filesystem>)
+#define GHC_USE_STD_FS
+#include <filesystem>
+namespace fs {
+using namespace std::filesystem;
+using ifstream = std::ifstream;
+using ofstream = std::ofstream;
+using fstream = std::fstream;
+}
+#endif
+#endif
+#ifndef GHC_USE_STD_FS
+#define GHC_WIN_WSTRING_STRING_TYPE
+#define GHC_FILESYSTEM_FWD
+#include <ghc/filesystem.hpp>
+namespace fs {
+using namespace ghc::filesystem;
+using ifstream = ghc::filesystem::ifstream;
+using ofstream = ghc::filesystem::ofstream;
+using fstream = ghc::filesystem::fstream;
+} 
+#endif
+#endif // GHC_FILESYSTEM_STD_FWD_H
+

--- a/include/ghc/fs_std_impl.hpp
+++ b/include/ghc/fs_std_impl.hpp
@@ -1,0 +1,43 @@
+//---------------------------------------------------------------------------------------
+//
+// ghc::filesystem - A C++17-like filesystem implementation for C++11/C++14
+//
+//---------------------------------------------------------------------------------------
+//
+// Copyright (c) 2018, Steffen Schümann <s.schuemann@pobox.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//---------------------------------------------------------------------------------------
+// fs_std_impl.hpp - The implementation header for the header/implementation seperated usage of
+//                   ghc::filesystem that does nothing if std::filesystem is detected.
+// This file can be used to hide the implementation of ghc::filesystem into a single cpp.
+// The cpp has to include this before including fs_std_fwd.hpp directly or via a different
+// header to work.
+//---------------------------------------------------------------------------------------
+#if defined(__cplusplus) && __cplusplus >= 201703L && defined(__has_include)
+#if __has_include(<filesystem>)
+#define GHC_USE_STD_FS
+#endif
+#endif
+#ifndef GHC_USE_STD_FS
+#define GHC_WIN_WSTRING_STRING_TYPE
+#define GHC_FILESYSTEM_IMPLEMENTATION
+#include <ghc/filesystem.hpp>
+#endif

--- a/src/cinder/Filesystem.cpp
+++ b/src/cinder/Filesystem.cpp
@@ -29,5 +29,5 @@
 
 #if ! defined( GHC_USE_STD_FS )
 	#undef GHC_FILESYSTEM_H
-	#include <ghc/fs_impl.hpp>
+	#include <ghc/fs_std_impl.hpp>
 #endif


### PR DESCRIPTION
Update ghc::filesystem to the latest version (v 1.3.3) 
This update and including `fs_std_fw.hpp` instead of `fs_fwd.hpp` in Filesystem.h, enables `wchar_t` for path(), making cmake building on windows feasible (using VS C++ build tools 2019)