### PR TITLE
Cmake update :: Visual Studio 2019 + videoInput

### DIFF
--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -31,11 +31,13 @@ target_compile_definitions( cinder PUBLIC ${CINDER_DEFINES} )
 if( CINDER_MSW )
 	set( PLATFORM_TOOLSET "$(PlatformToolset)" )
 	if( NOT ( "${CMAKE_GENERATOR}" MATCHES "Visual Studio.+" ) )
-		# Assume Visual Studio 2015
-		set( PLATFORM_TOOLSET "v140" )
-		if( MSVC_VERSION LESS 1900 ) # Visual Studio 2013
-			set( PLATFORM_TOOLSET "v120" )
-		elseif( MSVC_VERSION LESS 1800 )
+		# Assume Visual Studio 2019
+        set( PLATFORM_TOOLSET "v142" )
+		if( MSVC_VERSION LESS 1920 ) # Visual Studio 2015
+            set( PLATFORM_TOOLSET "v140" )
+        elseif( MSVC_VERSION LESS 1900 ) # Visual Studio 2013
+            set( PLATFORM_TOOLSET "v120" )
+        elseif( MSVC_VERSION LESS 1800 ) 
 			message( FATAL_ERROR "Unsupported MSVC version: ${MSVC_VERSION}" )
 		endif()
 	endif()
@@ -72,13 +74,17 @@ elseif( CINDER_COCOA_TOUCH )
 elseif( CINDER_LINUX )
 endif()
 
-# Check compiler support for enabling c++11 or c++14.
+# Check compiler support for enabling c++11 or c++14 or c++17.
 if( CINDER_MSW AND MSVC )
     if( MSVC_VERSION LESS 1800 ) # Older version of Visual Studio
         message( FATAL_ERROR "Unsupported MSVC version: ${MSVC_VERSION}" )
     elseif( MSVC_VERSION LESS 1900 ) # Visual Studio 2013
         set( COMPILER_SUPPORTS_CXX11 true )
-    else() # Visual Studio 2015
+    elseif( MSVC_VERSION LESS 1920 ) # Visual Studio 2015
+        set( COMPILER_SUPPORTS_CXX14 true )
+        set( COMPILER_SUPPORTS_CXX11 true )
+    else() # Visual Studio 2019
+        set( COMPILER_SUPPORTS_CXX17 true )
         set( COMPILER_SUPPORTS_CXX14 true )
         set( COMPILER_SUPPORTS_CXX11 true )
     endif()
@@ -96,17 +102,23 @@ endif()
 if( COMPILER_SUPPORTS_CXX17 )
     if( NOT MSVC )
         set( CINDER_CXX_FLAGS "-std=c++17" )
+    else()
+        set( CINDER_CXX_FLAGS "/std:c++17" )
     endif()
 elseif( COMPILER_SUPPORTS_CXX14 )
     if( NOT MSVC )
-    	set( CINDER_CXX_FLAGS "-std=c++14" )
+        set( CINDER_CXX_FLAGS "-std=c++14" )
+    else()
+        set( CINDER_CXX_FLAGS "/std:c++14")
     endif()
 elseif( COMPILER_SUPPORTS_CXX11 )
     if( NOT MSVC )
         set( CINDER_CXX_FLAGS "-std=c++11" )
+    else()
+        set( CINDER_CXX_FLAGS "/std:c++11")
     endif()
 else()
-	message( FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has neither C++11 or C++14 support. Please use a different C++ compiler." )
+	message( FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has neither C++11 or C++14 or C++17 support. Please use a different C++ compiler." )
 endif()
 
 # TODO: it would be nice to the following, but we can't until min required cmake is 3.3

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -102,6 +102,7 @@ source_group( "cinder\\audio\\dsp"	FILES ${SRC_SET_CINDER_AUDIO_DSP} )
 
 list( APPEND CINDER_INCLUDE_SYSTEM_PRIVATE
 	${CINDER_INC_DIR}/msw/zlib
+	${CINDER_INC_DIR}/msw
 )
 
 # NOTE: UNICODE and _UNICODE forces generator to use Unicode instead of MultiByte

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -4,6 +4,7 @@ set( CINDER_PLATFORM "MSW" )
 
 list( APPEND SRC_SET_MSW
 	${CINDER_SRC_DIR}/cinder/CaptureImplDirectShow.cpp
+	${CINDER_SRC_DIR}/videoInput/videoInput.cpp
 	${CINDER_SRC_DIR}/cinder/msw/CinderMsw.cpp
 	${CINDER_SRC_DIR}/cinder/msw/CinderMswGdiPlus.cpp
 	${CINDER_SRC_DIR}/cinder/msw/StackWalker.cpp


### PR DESCRIPTION
Based on  MSVC version, the right toolset and compiler options are extracted and CXX_FLAGS are written. Solved a massive headache with VS 2019 not defaulting to c++17.

Also by adding `videoInput.cpp` to the cmake definition for Windows and setting the proper include path for it, CaptureBasic sample builds fine.