### PR TITLE
Adding support for Visual Studio Code

### DIFF
--- a/docs/htmlsrc/guides/cmake/cmake.html
+++ b/docs/htmlsrc/guides/cmake/cmake.html
@@ -23,6 +23,11 @@
 <li><a href="#running-a-cinder-sample-directly-from-cinders-main-project">Running a Cinder sample directly from Cinder's main project.</a></li>
 </ul>
 </li>
+<li><a href="#using-vscode-to-build-libcinder-and-your-application">Using Visual Studio Code to build libcinder and your application</a><ul>
+<li><a href="#custom-configure-vscode">Custom configuration arguments using VS Code when building libcinder</a></li>
+<li><a href="#custom-formatting-vscode">Custom code formatting via .clang-format</a></li>
+</ul>
+</li>
 <li><a href="#structure-of-cinders-cmake-files">Structure of Cinder's CMake Files</a><ul>
 <li><a href="#configurecmake">configure.cmake</a></li>
 <li><a href="#configuring-libcinder">Configuring libcinder</a></li>
@@ -120,6 +125,26 @@ ci_make_app(
 <p>Note that by default, CLion will output build files into a folder called <code>cmake-build-debug</code>. If you want to change this to the usual <code>build</code>, which will automatically get ignored by Cinder's <code>.gitignore</code> file, then navigate to <code>Preferences -&gt; Build, Execution, Deployment</code>, and change the field called 'Generation path:' to 'build'.</p>
 <h3 id="running-a-cinder-sample-directly-from-cinders-main-project">Running a Cinder sample directly from Cinder's main project.</h3>
 <p>There are a couple CMakeCache.txt options that will allow you to conveniently build and run a sample that ships with Cinder alongside building the main library. First, you can set the option <code>CINDER_BUILD_SAMPLE</code> to any of the sample names (ex. <code>CINDER_BUILD_SAMPLE=_opengl/Cube</code>), and then you will be able to run that sample by selecting it in the the <code>Select/Run Configuration</code> drop-down in the top right. Alternatively, you could set <code>CINDER_BUILD_ALL_SAMPLES=On</code>, which will load the configurations for all Cinder samples, and you can then run any one of them from within the IDE.</p>
+<h1 id="using-vscode-to-build-libcinder-and-your-application">Using Visual Studio Code to build libcinder and your application</h1>
+<p>Aside from the command line and the commercial CLion IDE, you can also use <a href="https://code.visualstudio.com/">Visual Studio Code</a> to build and work on both libcinder and your application. By itself, VS Code is an open source code-editor developed by Microsoft but its real power lies in its &quot;Extensions System&quot;. To set up an environment suitable for C++ in general and Cinder in specific, you will need to install two extension in VS Code. One is the <a href="https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools">CPP Tools</a> and the other is the <a href="https://marketplace.visualstudio.com/items?itemName=ms-vscode.cmake-tools"> Cmake Tools</a>. Another extension which is optional but could help with CMake syntaxing is <a href="https://marketplace.visualstudio.com/items?itemName=twxs.cmake">Cmake</a> so you might want to have that installed as well. To install these extensions, launch VS Code Quick Open (Ctrl + P) and type these commands:</p>
+<p><code>ext install ms-vscode.cmake-tools</code></p>
+<p><code>ext install ms-vscode.cpptools</code></p>
+<p><code>ext install twxs.cmake (Optional)</code></p>
+<p>&nbsp;</p>
+<p>The C++ extension enables a multitude of features by utilizing its intellisense, a mechanism that when connected to Cmake Tools as a compilation toolchain, will make a nice cross-platform route to write and debug Cinder code. Much like a full-fledged IDE (resembling Visual Studio), you will have code completion and suggestions, quick fixes, peaking and jumping to declarations/definitions and using <code>clang-format</code> definitions, you can even have custom code formatting. Plus you&rsquo;ll have all the console tabs you&rsquo;ll need and also the ability to attach a debugger to your build to debug and trace. It will be a powerful system for a free and cross-platform solution.</p>
+<p>To build libcinder or any of the samples go to <code>ROOT_PATH/proj/cmake</code> and open the related <code>.workspace</code> file in VS Code. When opened, the extensions will take a little time to set up the environment for you. If it&rsquo;s your first time using this toolchain, you will need to tell the cmake extension which compiler you prefer (here called <code>Kits</code>):<br /></p>
+<ul>
+<li>On linux, GCC already exists but Cinder suggests clang (read the installation guide<a href="https://libcinder.org/docs/branch/master/guides/linux-notes/index.html">here</a>)</li>
+<li>On Windows, you will need to install Visual Studio 2019 C++ Build tools to enable the compiler (download from <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">here</a>)</li>
+<li>On macOS, you will need to have Xcode installed to have clang.&nbsp;</li>
+</ul>
+<p>When done, you can configure and build the library and its samples using Ctrl+P + <code>Cmake:Configure</code> command along with the blue footer in VS Code. We encourage everyone to learn more about the Cmake Tools to be able to find their way around better. </span><a href="https://vector-of-bool.github.io/docs/vscode-cmake-tools/getting_started.html#cmake-tools-quick-start">Here</a> is a nice intro with notes about Kit selection, configuration and building.</p>
+<h3 id="custom-configure-vscode">Custom configuration arguments using VS Code when building libcinder</h3>
+<p>When the workspace is opened, navigate to the root and find the <code>.vs-code</code> folder using the explorer pane of VS Code and open the <code>settings.json</code> file in the editor. Add or modify arguments in to <code>cmake.configureSettings</code> to have them passed to Cmake when configuring the project. By the default you will find <code>BUILD_SHARED_LIBS:off</code> which means that static libraries will be built. To find more about these possible arguments you can check the <code>CmakeCache.txt</code> in the build folder on root after the first configuration.</p>
+<p>There&rsquo;s no need to pass arguments about build type (i.e Debug, Release etc.) because VS Code gives access to those using the blue footer.</p>
+<h3 id="custom-formatting-vscode">Custom code formatting via .clang-format</h3>
+<p>If you needed to change the formatting rules of the C++ extension, you can use the <code>C_CPP:Clang_format_fallback Style</code> settings. As a sample you can use this parameter to follow Cinder&rsquo;s <a href="https://github.com/cinder/Cinder/blob/master/CONTRIBUTING.md">contribution guidelines</a>:</p>
+<p><code>{ BasedOnStyle: Google, IndentWidth: 4, ColumnLimit: 0, SpaceAfterLogicalNot: true, SpaceBeforeAssignmentOperators: true, SpaceBeforeCpp11BracedList: true, SpaceBeforeCtorInitializerColon: true, SpacesInParentheses: true, SpaceBeforeRangeBasedForLoopColon: true, IndentPPDirectives: BeforeHash, Cpp11BracedListStyle: true, BreakBeforeBraces: Custom, BraceWrapping: {BeforeElse: true, AfterFunction: true} , NamespaceIndentation: None, SortIncludes: false, SortUsingDeclarations: false, AllowShortIfStatementsOnASingleLine: Never, AlignConsecutiveDeclarations: true, AccessModifierOffset: -3}</code></p>
 <h1 id="structure-of-cinders-cmake-files">Structure of Cinder's CMake Files</h1>
 <p>This section provides an overview of how CMake build support is structured within the Cinder repo.</p>
 <p>Cinder's CMake scripts live in the common folder <a href="https://github.com/cinder/Cinder/tree/master/proj/cmake">proj/cmake</a>. The root <code>CMakeLists.txt</code> file is largely there so that it is easy to find, and so that our build configuration plays nicely with CMake-based IDEs like CLion.</p>

--- a/proj/cmake/Cinder.code-workspace
+++ b/proj/cmake/Cinder.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.configureSettings": {"BUILD_SHARED_LIBS":false}
+	}
+}

--- a/samples/ArcballDemo/proj/cmake/ArcballDemo.code-workspace
+++ b/samples/ArcballDemo/proj/cmake/ArcballDemo.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/BasicApp/proj/cmake/BasicApp.code-workspace
+++ b/samples/BasicApp/proj/cmake/BasicApp.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/BasicAppMultiWindow/proj/cmake/BasicAppMultiWindow.code-workspace
+++ b/samples/BasicAppMultiWindow/proj/cmake/BasicAppMultiWindow.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/BezierPath/proj/cmake/BezierPath.code-workspace
+++ b/samples/BezierPath/proj/cmake/BezierPath.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/BezierPathIteration/proj/cmake/BezierPathIteration.code-workspace
+++ b/samples/BezierPathIteration/proj/cmake/BezierPathIteration.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/CairoBasic/proj/cmake/CairoBasic.code-workspace
+++ b/samples/CairoBasic/proj/cmake/CairoBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/CameraPersp/proj/cmake/CameraPersp.code-workspace
+++ b/samples/CameraPersp/proj/cmake/CameraPersp.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/CaptureBasic/proj/cmake/CaptureBasic.code-workspace
+++ b/samples/CaptureBasic/proj/cmake/CaptureBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/CaptureCube/proj/cmake/CaptureCube.code-workspace
+++ b/samples/CaptureCube/proj/cmake/CaptureCube.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/ClipboardBasic/proj/cmake/ClipboardBasic.code-workspace
+++ b/samples/ClipboardBasic/proj/cmake/ClipboardBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Compass/proj/cmake/Compass.code-workspace
+++ b/samples/Compass/proj/cmake/Compass.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Earthquake/proj/cmake/Earthquake.code-workspace
+++ b/samples/Earthquake/proj/cmake/Earthquake.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/EaseGallery/proj/cmake/EaseGallery.code-workspace
+++ b/samples/EaseGallery/proj/cmake/EaseGallery.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Extrude/proj/cmake/Extrude.code-workspace
+++ b/samples/Extrude/proj/cmake/Extrude.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/FallingGears/proj/cmake/FallingGears.code-workspace
+++ b/samples/FallingGears/proj/cmake/FallingGears.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/FlickrTestMultithreaded/proj/cmake/FlickrTestMultithreaded.code-workspace
+++ b/samples/FlickrTestMultithreaded/proj/cmake/FlickrTestMultithreaded.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/FontSample/proj/cmake/FontSample.code-workspace
+++ b/samples/FontSample/proj/cmake/FontSample.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/FrustumCulling/proj/cmake/FrustumCulling.code-workspace
+++ b/samples/FrustumCulling/proj/cmake/FrustumCulling.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Geometry/proj/cmake/Geometry.code-workspace
+++ b/samples/Geometry/proj/cmake/Geometry.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/ImageFileBasic/proj/cmake/ImageFileBasic.code-workspace
+++ b/samples/ImageFileBasic/proj/cmake/ImageFileBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/ImageHeightField/proj/cmake/ImageHeightField.code-workspace
+++ b/samples/ImageHeightField/proj/cmake/ImageHeightField.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Kaleidoscope/proj/cmake/Kaleidoscope.code-workspace
+++ b/samples/Kaleidoscope/proj/cmake/Kaleidoscope.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/LocationManager/proj/cmake/LocationManager.code-workspace
+++ b/samples/LocationManager/proj/cmake/LocationManager.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Logging/proj/cmake/Logging.code-workspace
+++ b/samples/Logging/proj/cmake/Logging.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/MandelbrotGLSL/proj/cmake/MandelbrotGLSL.code-workspace
+++ b/samples/MandelbrotGLSL/proj/cmake/MandelbrotGLSL.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/MotionBasic/proj/cmake/MotionBasic.code-workspace
+++ b/samples/MotionBasic/proj/cmake/MotionBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/MultiTouchBasic/proj/cmake/MultiTouchBasic.code-workspace
+++ b/samples/MultiTouchBasic/proj/cmake/MultiTouchBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/ParamsBasic/proj/cmake/ParamsBasic.code-workspace
+++ b/samples/ParamsBasic/proj/cmake/ParamsBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Picking3D/proj/cmake/Picking3D.code-workspace
+++ b/samples/Picking3D/proj/cmake/Picking3D.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/QuaternionAccum/proj/cmake/QuaternionAccum.code-workspace
+++ b/samples/QuaternionAccum/proj/cmake/QuaternionAccum.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/QuickTimeAdvanced/proj/cmake/QuickTimeAdvanced.code-workspace
+++ b/samples/QuickTimeAdvanced/proj/cmake/QuickTimeAdvanced.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/QuickTimeAvfWriter/proj/cmake/QuickTimeAvfWriter.code-workspace
+++ b/samples/QuickTimeAvfWriter/proj/cmake/QuickTimeAvfWriter.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/QuickTimeBasic/proj/cmake/QuickTimeBasic.code-workspace
+++ b/samples/QuickTimeBasic/proj/cmake/QuickTimeBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/QuickTimeIteration/proj/cmake/QuickTimeIteration.code-workspace
+++ b/samples/QuickTimeIteration/proj/cmake/QuickTimeIteration.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/RDiffusion/proj/cmake/RDiffusion.code-workspace
+++ b/samples/RDiffusion/proj/cmake/RDiffusion.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Renderer2dBasic/proj/cmake/Renderer2dBasic.code-workspace
+++ b/samples/Renderer2dBasic/proj/cmake/Renderer2dBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/SaveImage/proj/cmake/SaveImage.code-workspace
+++ b/samples/SaveImage/proj/cmake/SaveImage.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/SerialCommunication/proj/cmake/SerialCommunication.code-workspace
+++ b/samples/SerialCommunication/proj/cmake/SerialCommunication.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/StereoscopicRendering/proj/cmake/StereoscopicRendering.code-workspace
+++ b/samples/StereoscopicRendering/proj/cmake/StereoscopicRendering.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/SurfaceBasic/proj/cmake/SurfaceBasic.code-workspace
+++ b/samples/SurfaceBasic/proj/cmake/SurfaceBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/TextBox/proj/cmake/TextBox.code-workspace
+++ b/samples/TextBox/proj/cmake/TextBox.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/TextTest/proj/cmake/TextTest.code-workspace
+++ b/samples/TextTest/proj/cmake/TextTest.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/TextureFont/proj/cmake/TextureFont.code-workspace
+++ b/samples/TextureFont/proj/cmake/TextureFont.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Triangulation/proj/cmake/Triangulation.code-workspace
+++ b/samples/Triangulation/proj/cmake/Triangulation.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Tubular/proj/cmake/Tubular.code-workspace
+++ b/samples/Tubular/proj/cmake/Tubular.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/VoronoiGpu/proj/cmake/VoronoiGpu.code-workspace
+++ b/samples/VoronoiGpu/proj/cmake/VoronoiGpu.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/Wisteria/proj/cmake/Wisteria.code-workspace
+++ b/samples/Wisteria/proj/cmake/Wisteria.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/BufferPlayer/proj/cmake/BufferPlayer.code-workspace
+++ b/samples/_audio/BufferPlayer/proj/cmake/BufferPlayer.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/DelayFeedback/proj/cmake/DelayFeedback.code-workspace
+++ b/samples/_audio/DelayFeedback/proj/cmake/DelayFeedback.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/InputAnalyzer/proj/cmake/InputAnalyzer.code-workspace
+++ b/samples/_audio/InputAnalyzer/proj/cmake/InputAnalyzer.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/MultichannelOutput/proj/cmake/MultichannelOutput.code-workspace
+++ b/samples/_audio/MultichannelOutput/proj/cmake/MultichannelOutput.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/NodeAdvanced/proj/cmake/NodeAdvanced.code-workspace
+++ b/samples/_audio/NodeAdvanced/proj/cmake/NodeAdvanced.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/NodeBasic/proj/cmake/NodeBasic.code-workspace
+++ b/samples/_audio/NodeBasic/proj/cmake/NodeBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/NodeSubclassing/proj/cmake/NodeSubclassing.code-workspace
+++ b/samples/_audio/NodeSubclassing/proj/cmake/NodeSubclassing.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/VoiceBasic/proj/cmake/VoiceBasic.code-workspace
+++ b/samples/_audio/VoiceBasic/proj/cmake/VoiceBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_audio/VoiceBasicProcessing/proj/cmake/VoiceBasicProcessing.code-workspace
+++ b/samples/_audio/VoiceBasicProcessing/proj/cmake/VoiceBasicProcessing.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ClothSimulation/proj/cmake/ClothSimulation.code-workspace
+++ b/samples/_opengl/ClothSimulation/proj/cmake/ClothSimulation.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/Cube/proj/cmake/Cube.code-workspace
+++ b/samples/_opengl/Cube/proj/cmake/Cube.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/CubeMapping/proj/cmake/CubeMapping.code-workspace
+++ b/samples/_opengl/CubeMapping/proj/cmake/CubeMapping.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/DeferredShading/proj/cmake/DeferredShading.code-workspace
+++ b/samples/_opengl/DeferredShading/proj/cmake/DeferredShading.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/DeferredShadingAdvanced/proj/cmake/DeferredShadingAdvanced.code-workspace
+++ b/samples/_opengl/DeferredShadingAdvanced/proj/cmake/DeferredShadingAdvanced.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/DynamicCubeMapping/proj/cmake/DynamicCubeMapping.code-workspace
+++ b/samples/_opengl/DynamicCubeMapping/proj/cmake/DynamicCubeMapping.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/FboBasic/proj/cmake/FboBasic.code-workspace
+++ b/samples/_opengl/FboBasic/proj/cmake/FboBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/FboMultipleRenderTargets/proj/cmake/FboMultipleRenderTargets.code-workspace
+++ b/samples/_opengl/FboMultipleRenderTargets/proj/cmake/FboMultipleRenderTargets.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/GeometryShaderBasic/proj/cmake/GeometryShaderBasic.code-workspace
+++ b/samples/_opengl/GeometryShaderBasic/proj/cmake/GeometryShaderBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/HighDynamicRange/proj/cmake/HighDynamicRange.code-workspace
+++ b/samples/_opengl/HighDynamicRange/proj/cmake/HighDynamicRange.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ImmediateMode/proj/cmake/ImmediateMode.code-workspace
+++ b/samples/_opengl/ImmediateMode/proj/cmake/ImmediateMode.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/InstancedTeapots/proj/cmake/InstancedTeapots.code-workspace
+++ b/samples/_opengl/InstancedTeapots/proj/cmake/InstancedTeapots.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/LevelOfDetailBasic/proj/cmake/CMakeLists.txt
+++ b/samples/_opengl/LevelOfDetailBasic/proj/cmake/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE ON )
+
+project( opengl-LevelOfDetailBaisc )
+
+get_filename_component( CINDER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../.." ABSOLUTE )
+get_filename_component( SAMPLE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
+
+include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
+
+set( SRC_FILES
+	${SAMPLE_DIR}/src/LevelOfDetailBaiscApp.cpp
+)
+
+ci_make_app(
+	SOURCES     ${SRC_FILES}
+	CINDER_PATH ${CINDER_PATH}
+	INCLUDES    ${SAMPLE_DIR}/include
+)

--- a/samples/_opengl/LevelOfDetailBasic/proj/cmake/LevelOfDetailBasic.code-workspace
+++ b/samples/_opengl/LevelOfDetailBasic/proj/cmake/LevelOfDetailBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/LevelOfDetailIndirect/proj/cmake/LevelOfDetailIndirect.code-workspace
+++ b/samples/_opengl/LevelOfDetailIndirect/proj/cmake/LevelOfDetailIndirect.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/MipMap/proj/cmake/MipMap.code-workspace
+++ b/samples/_opengl/MipMap/proj/cmake/MipMap.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/MotionBlurFbo/proj/cmake/MotionBlurFbo.code-workspace
+++ b/samples/_opengl/MotionBlurFbo/proj/cmake/MotionBlurFbo.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/MotionBlurVelocityBuffer/proj/cmake/MotionBlurVelocityBuffer.code-workspace
+++ b/samples/_opengl/MotionBlurVelocityBuffer/proj/cmake/MotionBlurVelocityBuffer.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/NVidiaComputeParticles/proj/cmake/NVidiaComputeParticles.code-workspace
+++ b/samples/_opengl/NVidiaComputeParticles/proj/cmake/NVidiaComputeParticles.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/NormalMapping/proj/cmake/NormalMapping.code-workspace
+++ b/samples/_opengl/NormalMapping/proj/cmake/NormalMapping.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/NormalMappingBasic/proj/cmake/NormalMappingBasic.code-workspace
+++ b/samples/_opengl/NormalMappingBasic/proj/cmake/NormalMappingBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/NvidiaMulticast/proj/cmake/NvidiaMulticast.code-workspace
+++ b/samples/_opengl/NvidiaMulticast/proj/cmake/NvidiaMulticast.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ObjLoader/proj/cmake/ObjLoader.code-workspace
+++ b/samples/_opengl/ObjLoader/proj/cmake/ObjLoader.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/PBOReadBack/proj/cmake/PBOReadBack.code-workspace
+++ b/samples/_opengl/PBOReadBack/proj/cmake/PBOReadBack.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ParticleSphereCPU/proj/cmake/ParticleSphereCPU.code-workspace
+++ b/samples/_opengl/ParticleSphereCPU/proj/cmake/ParticleSphereCPU.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ParticleSphereCS/proj/cmake/ParticleSphereCS.code-workspace
+++ b/samples/_opengl/ParticleSphereCS/proj/cmake/ParticleSphereCS.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ParticleSphereGPU/proj/cmake/ParticleSphereGPU.code-workspace
+++ b/samples/_opengl/ParticleSphereGPU/proj/cmake/ParticleSphereGPU.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ParticlesBasic/proj/cmake/ParticlesBasic.code-workspace
+++ b/samples/_opengl/ParticlesBasic/proj/cmake/ParticlesBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/PickingFBO/proj/cmake/PickingFBO.code-workspace
+++ b/samples/_opengl/PickingFBO/proj/cmake/PickingFBO.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/PostProcessingAA/proj/cmake/PostProcessingAA.code-workspace
+++ b/samples/_opengl/PostProcessingAA/proj/cmake/PostProcessingAA.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ShadowMapping/proj/cmake/ShadowMapping.code-workspace
+++ b/samples/_opengl/ShadowMapping/proj/cmake/ShadowMapping.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/ShadowMappingBasic/proj/cmake/ShadowMappingBasic.code-workspace
+++ b/samples/_opengl/ShadowMappingBasic/proj/cmake/ShadowMappingBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/StencilReflection/proj/cmake/StencilReflection.code-workspace
+++ b/samples/_opengl/StencilReflection/proj/cmake/StencilReflection.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/SuperformulaGPU/proj/cmake/SuperformulaGPU.code-workspace
+++ b/samples/_opengl/SuperformulaGPU/proj/cmake/SuperformulaGPU.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/TessellationBasic/proj/cmake/TessellationBasic.code-workspace
+++ b/samples/_opengl/TessellationBasic/proj/cmake/TessellationBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/TessellationBezier/proj/cmake/TessellationBezier.code-workspace
+++ b/samples/_opengl/TessellationBezier/proj/cmake/TessellationBezier.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/TransformFeedbackSmokeParticles/proj/cmake/TransformFeedbackSmokeParticles.code-workspace
+++ b/samples/_opengl/TransformFeedbackSmokeParticles/proj/cmake/TransformFeedbackSmokeParticles.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_opengl/VboMesh/proj/cmake/VboMesh.code-workspace
+++ b/samples/_opengl/VboMesh/proj/cmake/VboMesh.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_svg/AnimatedReveal/proj/cmake/AnimatedReveal.code-workspace
+++ b/samples/_svg/AnimatedReveal/proj/cmake/AnimatedReveal.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_svg/EuroMap/proj/cmake/EuroMap.code-workspace
+++ b/samples/_svg/EuroMap/proj/cmake/EuroMap.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_svg/GoodNightMorning/proj/cmake/GoodNightMorning.code-workspace
+++ b/samples/_svg/GoodNightMorning/proj/cmake/GoodNightMorning.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_svg/SimpleViewer/proj/cmake/SimpleViewer.code-workspace
+++ b/samples/_svg/SimpleViewer/proj/cmake/SimpleViewer.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/BasicAppendTween/proj/cmake/BasicAppendTween.code-workspace
+++ b/samples/_timeline/BasicAppendTween/proj/cmake/BasicAppendTween.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/BasicTween/proj/cmake/BasicTween.code-workspace
+++ b/samples/_timeline/BasicTween/proj/cmake/BasicTween.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/CustomCallback/proj/cmake/CustomCallback.code-workspace
+++ b/samples/_timeline/CustomCallback/proj/cmake/CustomCallback.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/CustomLerp/proj/cmake/CustomLerp.code-workspace
+++ b/samples/_timeline/CustomLerp/proj/cmake/CustomLerp.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/DragTween/proj/cmake/DragTween.code-workspace
+++ b/samples/_timeline/DragTween/proj/cmake/DragTween.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/ImageAccordion/proj/cmake/ImageAccordion.code-workspace
+++ b/samples/_timeline/ImageAccordion/proj/cmake/ImageAccordion.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/PaletteBrowser/proj/cmake/PaletteBrowser.code-workspace
+++ b/samples/_timeline/PaletteBrowser/proj/cmake/PaletteBrowser.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/TextInputTween/proj/cmake/TextInputTween.code-workspace
+++ b/samples/_timeline/TextInputTween/proj/cmake/TextInputTween.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/_timeline/VisualDictionary/proj/cmake/VisualDictionary.code-workspace
+++ b/samples/_timeline/VisualDictionary/proj/cmake/VisualDictionary.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/perlinTest/proj/cmake/perlinTest.code-workspace
+++ b/samples/perlinTest/proj/cmake/perlinTest.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}

--- a/samples/slerpBasic/proj/cmake/slerpBasic.code-workspace
+++ b/samples/slerpBasic/proj/cmake/slerpBasic.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": "../../."
+		}
+	],
+	"settings": {
+		"C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+		"cmake.sourceDirectory": "${workspaceFolder}/proj/cmake",
+		"cmake.buildDirectory": "${workspaceFolder}/proj/cmake/build"
+	}
+}


### PR DESCRIPTION
Added VS Code workspace files to Cinder and all of the samples. Updated Cmake guide to introduce VS Code as a free cross-platform IDE solution and how to use it along with cmakeTools and cppTools extensions in VS Code