### PR TITLE
Remove trailing slash from CINDER_LIB_DIRECTORY

### DIFF
--- a/proj/cmake/configure.cmake
+++ b/proj/cmake/configure.cmake
@@ -135,4 +135,4 @@ endif()
 
 # CINDER_LIB_DIRECTORY is the platform-specific, relative path that will be used to define
 # CMAKE_ARCHIVE_OUTPUT_DIRECTORY for libcinder and also specifies where user apps will locate the cinder package
-set( CINDER_LIB_DIRECTORY "lib/${CINDER_TARGET_SUBFOLDER}/${CMAKE_BUILD_TYPE}/" )
+set( CINDER_LIB_DIRECTORY "lib/${CINDER_TARGET_SUBFOLDER}/${CMAKE_BUILD_TYPE}" )


### PR DESCRIPTION
The trailing slash is causing a double slash in my ```cinderConfig.cmake``` and subsequent cmake failures for apps. Removing the trailing slash seems to solve the issue and is also more in line with general policy to **not** add trailing slashes to cmake path variables.

If this is really a bug I'm a bit surprised because this doesn't look like it's a recent change and I'd expect it to have been causing a lot of issues.

Tested using:
* OSX 10.15.5
* CMAKE version 3.17.3
