### PR TITLE
Documentation updates for Raspberry Pi

### DIFF
--- a/docs/htmlsrc/guides/linux-notes/rpi2.html
+++ b/docs/htmlsrc/guides/linux-notes/rpi2.html
@@ -71,7 +71,7 @@ gstreamer1.0-plugins-bad
 <pre><code>git clone --recursive https://github.com/cinder/Cinder.git
 cd Cinder
 mkdir build &amp;&amp; cd build
-cmake .. -DCINDER_TARGET_GL=es2-rpi
+cmake .. -DCINDER_TARGET_GL=es3-rpi
 make -j 3
 </code></pre>
 
@@ -79,7 +79,7 @@ make -j 3
 		<h3 id="building">Building</h3>
 <pre><code>cd samples/BasicApp/proj/cmake
 mkdir build &amp;&amp; cd build
-cmake .. -DCINDER_TARGET_GL=es2-rpi
+cmake .. -DCINDER_TARGET_GL=es3-rpi
 make</code></pre>
 
 		<h3 id="running">Running</h3>

--- a/docs/htmlsrc/guides/linux-notes/rpi3.html
+++ b/docs/htmlsrc/guides/linux-notes/rpi3.html
@@ -52,7 +52,11 @@ gstreamer1.0-libav \
 gstreamer1.0-alsa \
 gstreamer1.0-pulseaudio \
 gstreamer1.0-plugins-bad \
-libboost-filesystem-dev
+libboost-filesystem-dev \
+libxrandr-dev \
+libxinerama-dev \
+libx11-xcb-dev \
+libxi-dev
 </code></pre>
 
 		<h1 id="building-cinder">Building Cinder</h1>
@@ -60,7 +64,7 @@ libboost-filesystem-dev
 <pre><code>git clone --recursive https://github.com/cinder/Cinder.git
 cd Cinder
 mkdir build &amp;&amp; cd build
-cmake .. -DCINDER_TARGET_GL=es2-rpi
+cmake .. -DCINDER_TARGET_GL=es3-rpi
 make -j 3
 </code></pre>
 
@@ -77,7 +81,7 @@ make -j 3
 		<h3 id="building">Building</h3>
 <pre><code>cd samples/BasicApp/proj/cmake
 mkdir build &amp;&amp; cd build
-cmake .. -DCINDER_TARGET_GL=es2-rpi
+cmake .. -DCINDER_TARGET_GL=es3-rpi
 make</code></pre>
 
 		<h3 id="running">Running</h3>

--- a/proj/cmake/configure.cmake
+++ b/proj/cmake/configure.cmake
@@ -60,7 +60,7 @@ else()
 	set( CINDER_TARGET_GL_DEFAULT "" )
 endif()
 
-set( CINDER_TARGET_GL ${CINDER_TARGET_GL_DEFAULT} CACHE STRING "Target GL for the system. Valid options: ogl, es2, es3, es31, es32, es2-rpi" )
+set( CINDER_TARGET_GL ${CINDER_TARGET_GL_DEFAULT} CACHE STRING "Target GL for the system. Valid options: ogl, es2, es3, es31, es32, es3-rpi" )
 
 if( CINDER_TARGET_GL )
 	ci_log_v( "CINDER_TARGET_GL: ${CINDER_TARGET_GL}" )


### PR DESCRIPTION
The documentation for Pi 2 and Pi 3 says to use `es2-rpi` for `CINDER_TARGET_GL`, but given https://github.com/cinder/Cinder/blob/master/proj/cmake/configure.cmake#L83 this looks to be out-of-date and it triggers the "Unexpected value for CINDER_TARGET_GL" error. The error message itself also claims `es2-rpi` is valid when it's not.

I was running this on Raspbian Buster and also ran into a few missing X-related dependencies which I added into the documentation. I suppose this applies identically on `rpi2.html` but I'll leave it up to you whether that needs updating or not.