### PR TITLE
osc: fix crash when closing TCP receiver connections

### DIFF
--- a/blocks/OSC/src/cinder/osc/Osc.cpp
+++ b/blocks/OSC/src/cinder/osc/Osc.cpp
@@ -1605,7 +1605,7 @@ asio::error_code ReceiverTcp::closeConnection( uint64_t connectionIdentifier, as
 		return ec;
 	
 	std::lock_guard<std::mutex> lock( mConnectionMutex );
-	auto rem = remove_if( mConnections.begin(), mConnections.end(),
+	auto rem = find_if( mConnections.begin(), mConnections.end(),
 	[connectionIdentifier]( const UniqueConnection &cached ) {
 		return cached->mIdentifier == connectionIdentifier;
 	} );


### PR DESCRIPTION
- replaced remove_if() with find_if(), because removing an unique_ptr
  from a vector causes it to become null, causing a crash later when
  we try to dereference it.