### PR TITLE
[CMake] Fix setting msvc link directories in make app

### DIFF
--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -126,10 +126,7 @@ function( ci_make_app )
 			# Force multiprocess compilation
 			add_compile_options( /MP )
 			# Add lib dirs
-			cmake_policy( PUSH )
-			cmake_policy( SET CMP0015 OLD )
-			link_directories( "${CINDER_PATH}/lib/${CINDER_TARGET_SUBFOLDER}" )
-			cmake_policy( POP )
+			link_directories( "${ARG_CINDER_PATH}/lib/${CINDER_TARGET_SUBFOLDER}" )
 		endif()
 	endif()
 


### PR DESCRIPTION
- CINDER_PATH should  be ARG_CINDER_PATH (argument passed to function instead of global variable)
- No apparent reason, why policy CMP0015 should be set to old.
  Remove this to silince cmake warnings about using outdated policies.