### PR TITLE
Get rid of most warnings when building OSC block

### DIFF
--- a/blocks/OSC/src/cinder/osc/Osc.h
+++ b/blocks/OSC/src/cinder/osc/Osc.h
@@ -289,7 +289,11 @@ class Message {
 	//! Helper to calculate how many zeros to buffer to create a 4 byte
 	static uint8_t getTrailingZeros( size_t bufferSize ) { return 4 - ( bufferSize % 4 ); }
 	//! Helper to get current offset into the buffer.
-	size_t getCurrentOffset() { return mDataBuffer.size(); }
+	int32_t getCurrentOffset() {
+		CI_ASSERT_MSG( mDataBuffer.size() <= std::numeric_limits<int32_t>::max(),
+			"Argument offset must fit in int32_t" );
+		return static_cast<int32_t>( mDataBuffer.size() );
+	}
 	//! Helper to retrieve the data view of an Argument. Checks the type provided and
 	//! throws ExcNonConvertible if data view cannot convert the type.
 	template<typename T>
@@ -323,7 +327,7 @@ class Message {
 	
 	//! Helper to to insert data starting at \a begin for \a with resize/fill in the amount
 	//! of \a trailingZeros
-	void appendDataBuffer( const void *begin, uint32_t size, uint32_t trailingZeros = 0 );
+	void appendDataBuffer( const void *begin, size_t size, uint32_t trailingZeros = 0 );
 	
 	//! Returns a complete byte array of this OSC message as a ByteBufferRef type.
 	//! The byte buffer is constructed lazily and is cached until the cache is

--- a/test/unit/src/RandTest.cpp
+++ b/test/unit/src/RandTest.cpp
@@ -120,7 +120,7 @@ TEST_CASE("Rand", "[noisy]")
 		printDistribution( nums, 20 );	
 	}
 
-	#ifndef DEBUG
+	#ifdef NDEBUG
 	SECTION("test timing for 100000000 floats")
 	{
 		Timer t;


### PR DESCRIPTION
- these were particularly verbose on Windows, mainly related to possible loss of data during size conversions (`size_t` to `int32_t` or `uint32_t`).
- there are still a few other warnings from ASIO, but fixing those may require replacing/updating the ASIO library.

I also added asserts (for extra safety/correctness), but if you don't like those they can be removed. We can "probably" assume no one will try to send OSC messages, arguments or blobs that are more than 2GB or 4GB in size, but just in case... (-;

*(unrelated)* I also fixed a bug in the `Rand` unit test, where I assume it was intending to only run a performance test in Release builds, but was instead doing it in Debug (which took forever). At least on Windows, `DEBUG` wasn't defined in the project (although `_DEBUG` is) -- but the proper test is normally `#ifdef NDEBUG` if you want optimized (Release) builds. This should work across all platforms.
