### PR TITLE
[CI] Update travis CI to use only supported ubuntu images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,22 +90,23 @@ matrix:
         - TOOL="xcode-ios-sim"
         - DESCRIPTION=OS X build/test via Xcode"
 
-    # OS X CMake
+    #OS X CMake
     - os: osx
       osx_image: xcode9.2
       env:
         - TOOL="cmake"
         - DESCRIPTION="OS X build/test via CMake"
-    - os: osx
-      osx_image: xcode8.3
-      env:
-        - TOOL="cmake"
-        - DESCRIPTION="OS X build/test via CMake"
-    - os: osx
-      osx_image: xcode7.3
-      env:
-        - TOOL="cmake"
-        - DESCRIPTION="OS X build/test via CMake"
+    # TODO: find fast way to install cmake 3.10 on these systems
+    #- os: osx
+    #  osx_image: xcode8.3
+    #  env:
+    #    - TOOL="cmake"
+    #    - DESCRIPTION="OS X build/test via CMake"
+    #- os: osx
+    #  osx_image: xcode7.3
+    #  env:
+    #    - TOOL="cmake"
+    #    - DESCRIPTION="OS X build/test via CMake"
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,80 +11,32 @@ matrix:
     # linux version have unique dependencies, so we set them up individually
     # linux version have unique dependencies, so we set them up individually
     - os: linux
-      dist: trusty
       compiler: gcc
-      sudo: required
-      addons: 
-        apt:
-          update: true
+      dist: bionic
       env:
-        - TARGET="trusty"
-        - DESCRIPTION="Ubuntu Trusty build/test via CMake & gcc"
+        - DESCRIPTION="Ubuntu Bionic build/test via CMake & gcc"
         - MATRIX_EVAL="CC=gcc && CXX=g++"
 
     - os: linux
-      dist: trusty
       compiler: clang
-      sudo: required
-      addons:
-        apt:
-          update: true
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            # clang requires newer standard library to work properly
-            - g++-4.9
+      dist: bionic
       env:
-        - TARGET="trusty"
-        - DESCRIPTION="Ubuntu Trusty build/test via CMake & clang"
+        - DESCRIPTION="Ubuntu Bionic build/test via CMake & clang"
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 
     - os: linux
-      dist: trusty
+      compiler: gcc
+      dist: focal
+      env:
+        - DESCRIPTION="Ubuntu Bionic build/test via CMake & gcc"
+        - MATRIX_EVAL="CC=gcc && CXX=g++"
+
+    - os: linux
       compiler: clang
-      sudo: required
-      addons:
-        apt:
-          update: true
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-            - clang++-3.5
+      dist: focal
       env:
-        - TARGET="trusty"
-        - DESCRIPTION="Ubuntu Trusty build/test via CMake & clang-3.5"
-        - MATRIX_EVAL="CC=clang-3.5 && CXX=clang++-3.5"
-
-    - os: linux
-      dist: trusty
-      sudo: required
-      addons:
-        apt:
-          update: true
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-         - TARGET="trusty"
-         - DESCRIPTION="Ubuntu Trusty build/test via CMake & g++5"
-         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-
-    - os: linux
-      dist: trusty
-      sudo: required
-      addons:
-        apt:
-          update: true
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env:
-         - TARGET="trusty"
-         - DESCRIPTION="Ubuntu Trusty build/test via CMake & g++6"
-         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+        - DESCRIPTION="Ubuntu Bionic build/test via CMake & clang"
+        - MATRIX_EVAL="CC=clang && CXX=clang++"
 
 
     # OS X Xcode
@@ -165,7 +117,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      tools/linux/scripts/"$TARGET"-install-deps.sh;
+      tools/linux/scripts/trusty-install-deps.sh;
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$TOOL" == "cmake" ]]; then
       tools/osx/scripts/cmake-brew-install.sh;
     fi

--- a/tools/linux/scripts/trusty-install-deps.sh
+++ b/tools/linux/scripts/trusty-install-deps.sh
@@ -24,12 +24,5 @@ sudo apt-get -y install \
   gstreamer1.0-alsa \
   gstreamer1.0-pulseaudio \
   gstreamer1.0-plugins-bad \
-  libboost-filesystem-dev
-
-# mpg123
-wget https://sourceforge.net/projects/mpg123/files/mpg123/1.22.4/mpg123-1.22.4.tar.bz2/download -O mpg123-1.22.4.tar.bz2
-tar -xvf mpg123-1.22.4.tar.bz2 && \
-  cd mpg123-1.22.4 && \
-  ./configure --prefix=/opt/local && \
-  make && \
-  sudo make install
+  libboost-filesystem-dev \
+  libmpg123-dev


### PR DESCRIPTION
The oldest ubuntu distro, compiler and c++ standard and cmake version supported by cinder have changed quite a bit. 
Also travis itself has changed the environments it provides and what options are available. 
This PR cleans up the travis-ci file and tests cinder only with the default g++ and clang++ compiler on ubuntu bionic and focal respectively.

The main goal here is to make the ci-results usable again for development. Extending the test matrix to more compilers and more standard settings is left for a future PR.