### PR TITLE
ImGui: fix "stuck" right shift key in InputText on Windows (#2193)

### DIFF
--- a/src/cinder/CinderImGui.cpp
+++ b/src/cinder/CinderImGui.cpp
@@ -406,10 +406,10 @@ static void ImGui_ImplCinder_KeyDown( ci::app::KeyEvent& event )
 		sAccelKeys.push_back( event.getCode() );
 	}
 
-	io.KeyCtrl = io.KeysDown[ci::app::KeyEvent::KEY_LCTRL] || io.KeysDown[ci::app::KeyEvent::KEY_RCTRL];
-	io.KeyShift = io.KeysDown[ci::app::KeyEvent::KEY_LSHIFT] || io.KeysDown[ci::app::KeyEvent::KEY_RSHIFT];
-	io.KeyAlt = io.KeysDown[ci::app::KeyEvent::KEY_LALT] || io.KeysDown[ci::app::KeyEvent::KEY_RALT];
-	io.KeySuper = io.KeysDown[ci::app::KeyEvent::KEY_LMETA] || io.KeysDown[ci::app::KeyEvent::KEY_RMETA] || io.KeysDown[ci::app::KeyEvent::KEY_LSUPER] || io.KeysDown[ci::app::KeyEvent::KEY_RSUPER];
+	io.KeyCtrl = event.isControlDown();
+	io.KeyShift = event.isShiftDown();
+	io.KeyAlt = event.isAltDown();
+	io.KeySuper = event.isMetaDown();
 
 	event.setHandled( io.WantCaptureKeyboard );
 }
@@ -425,9 +425,10 @@ static void ImGui_ImplCinder_KeyUp( ci::app::KeyEvent& event )
 	}
 	sAccelKeys.clear();
 
-	io.KeyCtrl = io.KeysDown[ci::app::KeyEvent::KEY_LCTRL] || io.KeysDown[ci::app::KeyEvent::KEY_RCTRL] || io.KeysDown[ci::app::KeyEvent::KEY_LMETA] || io.KeysDown[ci::app::KeyEvent::KEY_RMETA];
-	io.KeyShift = io.KeysDown[ci::app::KeyEvent::KEY_LSHIFT] || io.KeysDown[ci::app::KeyEvent::KEY_RSHIFT];
-	io.KeyAlt = io.KeysDown[ci::app::KeyEvent::KEY_LALT] || io.KeysDown[ci::app::KeyEvent::KEY_RALT];
+	io.KeyCtrl = event.isControlDown();
+	io.KeyShift = event.isShiftDown();
+	io.KeyAlt = event.isAltDown();
+	io.KeySuper = event.isMetaDown();
 
 	event.setHandled( io.WantCaptureKeyboard );
 }


### PR DESCRIPTION
The way modifier key state was sent to ImGui seemed flaky (it failed on Windows in the right-shift case because of the issue I describe in #2193); there are already `KeyEvent` tests that work well to indicate which modifiers are down.

This fixes the issue with `InputText` (and `InputTextMultiline`) on Windows, and should also be valid for Mac (even if it doesn't specifically fix an issue there).
