### PR TITLE
Adding install dependencies script for Fedora Linux

### DIFF
--- a/tools/linux/scripts/trusty-install-deps-fedora.sh
+++ b/tools/linux/scripts/trusty-install-deps-fedora.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Packages
+sudo dnf -y upgrade
+sudo dnf -y install \
+  libXcursor-devel \
+  libXrandr-devel \
+  libXinerama-devel \
+  libXi-devel \
+  mesa-libGL-devel \
+  libglvnd-devel \
+  zlib-devel \
+  expat-devel \
+  freetype-devel \
+  uuid-devel \
+  libsndfile-devel \
+  pulseaudio-libs-devel \
+  alsa-lib-devel \
+  libcurl-devel \
+  gstreamer1-devel \
+  gstreamer1-plugins-bad-free-devel \
+  gstreamer1-plugins-base-devel \
+  gstreamer1-libav \
+  boost-devel \
+  mpg123-devel


### PR DESCRIPTION
Hello! 🌸

Seeing if I can get cinder working on Fedora Linux. Just spent about an hour tracking down all the equivalent packages from the apt script and figured I'd make a pull request with the resulting script. Don't know if it'll be helpful but figured I'd offer it up.

Not sure if missed any packages so I'm marking this pr as a draft in case I need to add some later in the process. Also don't have a clean install to test this at the moment. (I already have a ton of gstreamer packages installed from things like openFrameworks)

Couldn't find the equivalent of `gstreamer1.0-alsa` and `gstreamer1.0-pulseaudio`.

Happy to make changes if you like. 💖