### PR TITLE
Replace std::result_of with decltype

### DIFF
--- a/include/cinder/app/AppBase.h
+++ b/include/cinder/app/AppBase.h
@@ -408,7 +408,7 @@ class CI_API AppBase {
 	void	dispatchAsync( const std::function<void()> &fn );
 	
 	template<typename T>
-	typename std::result_of<T()>::type dispatchSync( T fn );
+	decltype(std::declval<T>()()) dispatchSync( T fn );
 
 	//! Returns the default Renderer which will be used when creating a new Window. Set by the app instantiation macro automatically.
 	RendererRef	getDefaultRenderer() const { return mDefaultRenderer; }
@@ -614,12 +614,12 @@ inline ::CGContextRef	createWindowCgContext() { return (std::dynamic_pointer_cas
 //@}
 
 template<typename T>
-typename std::result_of<T()>::type AppBase::dispatchSync( T fn )
+decltype(std::declval<T>()()) AppBase::dispatchSync( T fn )
 {
 	if( isMainThread() )
 		return fn();
 	else {
-		typedef typename std::result_of<T()>::type result_type;
+		typedef decltype(std::declval<T>()()) result_type;
 		std::packaged_task<result_type()> task( std::move( fn ) );
 
 		auto fute = task.get_future();


### PR DESCRIPTION
std::result_of is deprecated in C++17 and removed in C++20, breaking downstream projects that use C++20 with MSVC

This could be replaced by a wrapper type trait that dispatches to std::invoke_result_t for C++17 and later or to std::result_of for
earlier versions but since it is only used in one place for nullary functors, decltype will be simpler.

The vendored version of boost::asio uses std::result_of so this PR will not allow Cinder to be built in C++20 mode yet, but since asio is only used internally and not in Cinder's interface it should allow downstream project to use C++20.

Fixes #2206 