### PR TITLE
added ScopedId( const void *ptrId )

### DIFF
--- a/include/cinder/CinderImGui.h
+++ b/include/cinder/CinderImGui.h
@@ -155,6 +155,7 @@ namespace ImGui {
 	struct CI_API ScopedId : public ci::Noncopyable {
 		ScopedId( int int_id );
 		ScopedId( const char* label );
+		ScopedId( const void *ptrId );
 		~ScopedId();
 	};
 

--- a/src/cinder/CinderImGui.cpp
+++ b/src/cinder/CinderImGui.cpp
@@ -166,6 +166,10 @@ namespace ImGui {
 	{
 		ImGui::PushID( label );
 	}
+	ScopedId::ScopedId( const void *ptrId )
+	{
+		ImGui::PushID( ptrId );
+	}
 	ScopedId::~ScopedId()
 	{
 		ImGui::PopID();


### PR DESCRIPTION
Ran into this when updating some code that used Simon's Cinder-ImGui block to the built in imgui wrapper. Old method [here](https://github.com/simongeilfus/Cinder-ImGui/blob/29f75867c8646599e2df7584f396a215aeaa4102/include/CinderImGui.h#L258), and it is also natively supported using `ImGui::PushID( void * )`.