### PR TITLE
Add a boolean to cinder::gl::Fbo::readPixels8u and cinder::gl::Fbo::r…

### DIFF
--- a/include/cinder/gl/Fbo.h
+++ b/include/cinder/gl/Fbo.h
@@ -171,10 +171,10 @@ class CI_API Fbo : public std::enable_shared_from_this<Fbo> {
 	//! Sets the debugging label associated with the Fbo. Calls glObjectLabel() when available.
 	void				setLabel( const std::string &label );
 	
-	//! Returns a copy of the pixels in \a attachment within \a area (cropped to the bounding rectangle of the attachment) as a Surface8u. \a attachment ignored on ES 2.
-	Surface8u		readPixels8u( const Area &area, GLenum attachment = GL_COLOR_ATTACHMENT0 ) const;
-	//! Returns a copy of the pixels in \a attachment within \a area (cropped to the bounding rectangle of the attachment) as a Surface32f. \a attachment ignored on ES 2.
-	Surface32f		readPixels32f( const Area &area, GLenum attachment = GL_COLOR_ATTACHMENT0 ) const;
+	//! Returns a copy of the pixels in \a attachment within \a area (cropped to the bounding rectangle of the attachment) as a Surface8u. Optionally specify if the returned Surface8u contains an alpha channel. \a attachment ignored on ES 2.
+	Surface8u		readPixels8u( const Area &area, GLenum attachment = GL_COLOR_ATTACHMENT0, bool alpha = true ) const;
+	//! Returns a copy of the pixels in \a attachment within \a area (cropped to the bounding rectangle of the attachment) as a Surface32f. Optionally specify if the returned Surface32f contains an alpha channel. \a attachment ignored on ES 2.
+	Surface32f		readPixels32f( const Area &area, GLenum attachment = GL_COLOR_ATTACHMENT0, bool alpha = true ) const;
 	
 	//! \brief Defines the Format of the Fbo, which is passed in via create().
 	//!

--- a/src/cinder/gl/Fbo.cpp
+++ b/src/cinder/gl/Fbo.cpp
@@ -749,15 +749,16 @@ void Fbo::setLabel( const std::string &label )
 	env()->objectLabel( GL_FRAMEBUFFER, mId, (GLsizei)label.size(), label.c_str() );
 }
 
-Surface8u Fbo::readPixels8u( const Area &area, GLenum attachment ) const
+Surface8u Fbo::readPixels8u( const Area &area, GLenum attachment, bool alpha ) const
 {
 	// resolve first, before our own bind so that we don't force a resolve unnecessarily
 	resolveTextures();
 	ScopedFramebuffer readScp( GL_FRAMEBUFFER, mId );
 
 	Area readArea = prepareReadPixels( area, attachment );
-	Surface8u result( readArea.getWidth(), readArea.getHeight(), true );
-	glReadPixels( readArea.x1, readArea.y1, readArea.getWidth(), readArea.getHeight(), GL_RGBA, GL_UNSIGNED_BYTE, result.getData() );
+	Surface8u result( readArea.getWidth(), readArea.getHeight(), alpha );
+	GLenum format = alpha ? GL_RGBA : GL_RGB;
+	glReadPixels( readArea.x1, readArea.y1, readArea.getWidth(), readArea.getHeight(), format, GL_UNSIGNED_BYTE, result.getData() );
 
 	if( result.getHeight() > 1 ) {
 		// glReadPixels returns pixels which are bottom-up
@@ -767,15 +768,16 @@ Surface8u Fbo::readPixels8u( const Area &area, GLenum attachment ) const
 	return result;
 }
 
-Surface32f Fbo::readPixels32f( const Area &area, GLenum attachment ) const
+Surface32f Fbo::readPixels32f( const Area &area, GLenum attachment, bool alpha ) const
 {
 	// resolve first, before our own bind so that we don't force a resolve unnecessarily
 	resolveTextures();
 	ScopedFramebuffer readScp( GL_FRAMEBUFFER, mId );
 
 	Area readArea = prepareReadPixels( area, attachment );
-	Surface32f result( readArea.getWidth(), readArea.getHeight(), true );
-	glReadPixels( readArea.x1, readArea.y1, readArea.getWidth(), readArea.getHeight(), GL_RGBA, GL_FLOAT, result.getData() );
+	Surface32f result( readArea.getWidth(), readArea.getHeight(), alpha );
+	GLenum format = alpha ? GL_RGBA : GL_RGB;
+	glReadPixels( readArea.x1, readArea.y1, readArea.getWidth(), readArea.getHeight(), format, GL_FLOAT, result.getData() );
 
 	if( result.getHeight() > 1 ) {
 		// glReadPixels returns pixels which are bottom-up


### PR DESCRIPTION
…eadPixels32f to enable or disable the alpha channel in the returned Surface8u or Surface32f.