### PR TITLE
Fixed zlib build error on macOS

### DIFF
--- a/src/zlib/gzguts.h
+++ b/src/zlib/gzguts.h
@@ -2,6 +2,9 @@
  * Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013, 2016 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
+#ifndef _WIN32
+#  include <unistd.h>
+#endif
 
 #ifdef _LARGEFILE64_SOURCE
 #  ifndef _LARGEFILE_SOURCE


### PR DESCRIPTION
Current master fails to build with the following error in macOS 10.15 with CMake and XCode 12.4 (12D4e).
The pull request contains the missing include file.

```
Building C object CMakeFiles/cinder.dir/src/zlib/gzlib.c.o
.../cinder/src/zlib/gzlib.c:252:9: fatal error: implicit
      declaration of function 'lseek' is invalid in C99
      [-Wimplicit-function-declaration]
        LSEEK(state->fd, 0, SEEK_END);  /* so gzoffset() is correct */
        ^
.../cinder/src/zlib/gzlib.c:14:17: note: expanded from macro
      'LSEEK'
#  define LSEEK lseek
                ^
.../cinder/src/zlib/gzlib.c:252:9: note: did you mean 'fseek'?
.../cinder/src/zlib/gzlib.c:14:17: note: expanded from macro
      'LSEEK'
#  define LSEEK lseek
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/include/stdio.h:162:6: note:
      'fseek' declared here
int      fseek(FILE *, long, int);
         ^
1 error generated.
make[2]: *** [CMakeFiles/cinder.dir/src/zlib/gzlib.c.o] Error 1
make[1]: *** [CMakeFiles/cinder.dir/all] Error 2
make: *** [all] Error 2
```