### PR TITLE
portability with llvm's libc++ on Linux

### DIFF
--- a/src/cinder/app/linux/PlatformLinux.cpp
+++ b/src/cinder/app/linux/PlatformLinux.cpp
@@ -32,6 +32,7 @@
 
 #include "glfw/glfw3.h"
 
+#include <array>
 #include <sys/types.h>
 #include <unistd.h>
 #include <limits.h>


### PR DESCRIPTION
added `#include <array>` in `src/cinder/app/Linux/PlatformLinux.cpp`

LLVM's libc++ requires that this be included to compile. I tested this on a Linux machine.

The reason for this is src/cinder/app/Linux/PlatformLinux.cpp:496, where an std::array is used. On stdlibc++, it seems that std::array is somehow included already in one of the standard headers; not so on libc++.