### PR TITLE
Make Ref arguments `const` for ScopedVao and ScopedGlslProg

### DIFF
--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -42,7 +42,7 @@ typedef std::shared_ptr<Sampler>			SamplerRef;
 
 struct CI_API ScopedVao : private Noncopyable {
 	ScopedVao( Vao *vao );
-	ScopedVao( VaoRef &vao );
+	ScopedVao( const VaoRef &vao );
 	~ScopedVao();
 
   private:
@@ -117,7 +117,7 @@ struct CI_API ScopedBlendAdditive : public ScopedBlend
 };
 
 struct CI_API ScopedGlslProg : private Noncopyable {
-	ScopedGlslProg( GlslProgRef &prog );
+	ScopedGlslProg( const GlslProgRef &prog );
 	ScopedGlslProg( const std::shared_ptr<const GlslProg> &prog );
 	ScopedGlslProg( const GlslProg *prog );
 	~ScopedGlslProg();

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -40,7 +40,7 @@ ScopedVao::ScopedVao( Vao *vao )
 	mCtx->pushVao( vao );
 }
 
-ScopedVao::ScopedVao( VaoRef &vao )
+ScopedVao::ScopedVao( const VaoRef &vao )
 	: mCtx( gl::context() )
 {
 	mCtx->pushVao( vao );
@@ -142,7 +142,7 @@ ScopedBlend::~ScopedBlend()
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 // ScopedGlslProg
-ScopedGlslProg::ScopedGlslProg( GlslProgRef& prog )
+ScopedGlslProg::ScopedGlslProg( const GlslProgRef& prog )
 	: mCtx( gl::context() )
 {
 	mCtx->pushGlslProg( prog.get() );


### PR DESCRIPTION
Minor change, just to be consistent with other scoped Ref types, and allowing const `draw()` methods to use these scoped objects.
