### PR TITLE
ci_make_app: specify target_link_libraries with PUBLIC keyword

### DIFF
--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -133,7 +133,7 @@ function( ci_make_app )
 	add_executable( ${ARG_APP_NAME} MACOSX_BUNDLE WIN32 ${ARG_SOURCES} ${ICON_PATH} ${ARG_RESOURCES} )
 
 	target_include_directories( ${ARG_APP_NAME} PUBLIC ${ARG_INCLUDES} )
-	target_link_libraries( ${ARG_APP_NAME} cinder ${ARG_LIBRARIES} )
+	target_link_libraries( ${ARG_APP_NAME} PUBLIC cinder ${ARG_LIBRARIES} )
 
 	if( MSVC )
 		# Ignore Specific Default Libraries for Debug build


### PR DESCRIPTION
Otherwise, target_link_libraries cannot later be called with PUBLIC/PRIVATE/etc, and you get a cmake error if you try:

```
CMake Error at samples/_tutorials/Tutorial01_HelloTriangle/CMakeLists.txt:27 (target_link_libraries):
  The plain signature for target_link_libraries has already been used with
  the target "Tutorial01_HelloTriangle".  All uses of target_link_libraries
  with a target must be either all-keyword or all-plain.

  The uses of the plain signature are here:

   * G:/code/cinder/cinder-main/proj/cmake/modules/cinderMakeApp.cmake:136 (target_link_libraries)

```

Apologies if this is somewhere already in one of the existing PRs / issues found in the nice list on #2189, I needed to make this change for a specific integration of cinder with a different library using cmake and the change is small so thought I would create a separate PR.

Also, I left it as a `PUBLIC` linkage since the line right above to target_include_directories also uses `PUBLIC`, one could argue that it should be `PRIVATE` but then this is creating the end executable, not sure it makes a difference for the `ci_make_app()` utility function.