### PR TITLE
Fix to Screensaver on MacOS

### DIFF
--- a/src/cinder/app/AppScreenSaver.cpp
+++ b/src/cinder/app/AppScreenSaver.cpp
@@ -26,6 +26,7 @@
 #include "cinder/CinderAssert.h"
 
 #if defined( CINDER_MAC )
+#include <list>
 	#import "cinder/app/cocoa/AppImplMacScreenSaver.h"
 	#include "cinder/app/cocoa/PlatformCocoa.h"
 	#include "cinder/ImageSourceFileQuartz.h"

--- a/src/cinder/app/cocoa/AppImplMacScreenSaver.mm
+++ b/src/cinder/app/cocoa/AppImplMacScreenSaver.mm
@@ -104,6 +104,9 @@ static bool sFirstView = true; // records whether a call is the first to initVie
 		[super drawRect:rect]; // draws black by default
 		return;
 	}
+    
+    
+    [mCinderView draw];
 }
 
 - (void)animateOneFrame


### PR DESCRIPTION
This commit fixes an error preventing new screensaver projects from rendering on MacOS.

It implements a solution found by athens and shared in [this forum post](https://discourse.libcinder.org/t/screensaver-on-osx-just-black-screen/1686/4).