### PR TITLE
Added a `geom::CubeSphere` class,… 

### DIFF
--- a/include/cinder/GeomIo.h
+++ b/include/cinder/GeomIo.h
@@ -305,6 +305,39 @@ class CI_API Cube : public Source {
 	std::array<ColorAf, 6>	mColors;
 };
 
+class CI_API CubeSphere : public Source {
+  public:
+	CubeSphere();
+
+	//! Enables default colors. Disabled by default.
+	CubeSphere&		colors( bool enable = true ) { mHasColors = enable; return *this; }
+	//! Enables per-face colors ordered { +X, -X, +Y, -Y, +Z, -Z }. Colors are disabled by default.
+	CubeSphere&		colors( const ColorAf &posX, const ColorAf &negX, const ColorAf &posY, const ColorAf &negY, const ColorAf &posZ, const ColorAf &negZ );
+
+	CubeSphere&		subdivisions( int sub ) { mSubdivisions = ivec3( std::max<int>( 1, sub ) ); return *this; }
+	CubeSphere&		subdivisionsX( int sub ) { mSubdivisions.x = std::max<int>( 1, sub ); return *this; }
+	CubeSphere&		subdivisionsY( int sub ) { mSubdivisions.y = std::max<int>( 1, sub ); return *this; }
+	CubeSphere&		subdivisionsZ( int sub ) { mSubdivisions.z = std::max<int>( 1, sub ); return *this; }
+	CubeSphere&		size( const vec3 &sz ) { mSize = sz; return *this; }
+	CubeSphere&		size( float x, float y, float z ) { mSize = vec3( x, y, z ); return *this; }
+	CubeSphere&		equalSpacing( bool enabled = true ) { mEqualSpacing = enabled; return *this; }
+
+	size_t		getNumVertices() const override;
+	size_t		getNumIndices() const override;
+	Primitive	getPrimitive() const override { return Primitive::TRIANGLES; }
+	uint8_t		getAttribDims( Attrib attr ) const override;
+	AttribSet	getAvailableAttribs() const override;
+	void		loadInto( Target *target, const AttribSet &requestedAttribs ) const override;
+	CubeSphere*	clone() const override { return new CubeSphere( *this ); }
+
+  protected:
+	ivec3					mSubdivisions;
+	vec3					mSize;
+	bool					mHasColors;
+	bool					mEqualSpacing;
+	std::array<ColorAf, 6>	mColors;
+};
+
 class CI_API Icosahedron : public Source {
   public:
 	Icosahedron();

--- a/samples/Geometry/assets/phong.frag
+++ b/samples/Geometry/assets/phong.frag
@@ -50,7 +50,7 @@ void main()
 	float blinn = pow( max( dot( N, H ), 0.0 ), kMaterialShininess ) * kNormalization;
 
 	// diffuse coefficient
-	vec3 diffuse = vec3( phong );
+	vec3 diffuse = vec3( phong ) * 0.75 + 0.25;
 
 	if( uTexturingMode == 1 ) {
 		diffuse *= vec3( 0.7, 0.5, 0.3 );
@@ -58,6 +58,8 @@ void main()
 	}
 	else if ( uTexturingMode == 2 )
 		diffuse *= texture( uTex0, vVertexIn.texCoord.st ).rgb;
+	
+	diffuse *= vVertexIn.color.rgb;
 
 	// specular coefficient 
 	vec3 specular = blinn * cSpecular;

--- a/samples/Geometry/src/GeometryApp.cpp
+++ b/samples/Geometry/src/GeometryApp.cpp
@@ -23,7 +23,7 @@ class GeometryApp : public App {
 public:
 	GeometryApp();
 
-	enum Primitive { CAPSULE, CONE, CUBE, CYLINDER, HELIX, ICOSAHEDRON, ICOSPHERE, SPHERE, TEAPOT, TORUS, TORUSKNOT, PLANE, RECT, ROUNDEDRECT, CIRCLE, RING, PRIMITIVE_COUNT };
+	enum Primitive { CAPSULE, CONE, CUBE, CUBESPHERE, CYLINDER, HELIX, ICOSAHEDRON, ICOSPHERE, SPHERE, TEAPOT, TORUS, TORUSKNOT, PLANE, RECT, ROUNDEDRECT, CIRCLE, RING, PRIMITIVE_COUNT };
 	enum Quality { LOW, DEFAULT, HIGH };
 	enum ViewMode { SHADED, WIREFRAME };
 	enum TexturingMode { NONE, PROCEDURAL, SAMPLER };
@@ -86,6 +86,8 @@ private:
 
 	float				mConeRatio;
 
+	bool				mCubeSphereEqualSpacing;
+
 	float				mHelixRatio;
 	unsigned			mHelixTwist;
 	float				mHelixOffset;
@@ -116,6 +118,7 @@ void prepareSettings( App::Settings* settings )
 GeometryApp::GeometryApp()
 	: mCapsuleRadius( 0.5f ), mCapsuleLength( 1 )
 	, mConeRatio( 0.5f )
+	, mCubeSphereEqualSpacing( true )
 	, mHelixRatio( 0.25f ), mHelixTwist( 0 ), mHelixOffset( 0 ), mHelixCoils( 3 )
 	, mRingWidth( 0.25f )
 	, mRoundedRectRadius( 0.2f )
@@ -348,7 +351,7 @@ void GeometryApp::fileDrop( FileDropEvent event )
 void GeometryApp::updateGui()
 {
 #if ! defined( CINDER_GL_ES )
-	static vector<string> primitives = { "Capsule", "Cone", "Cube", "Cylinder", "Helix", "Icosahedron", "Icosphere", "Sphere", "Teapot", "Torus", "Torus Knot", "Plane", "Rectangle", "Rounded Rectangle", "Circle", "Ring" };
+	static vector<string> primitives = { "Capsule", "Cone", "Cube", "Cube Sphere", "Cylinder", "Helix", "Icosahedron", "Icosphere", "Sphere", "Teapot", "Torus", "Torus Knot", "Plane", "Rectangle", "Rounded Rectangle", "Circle", "Ring" };
 	static vector<string> qualities = { "Low", "Default", "High" };
 	static vector<string> viewModes = { "Shaded", "Wireframe" };
 	static vector<string> texturingModes = { "None", "Procedural", "Sampler" };
@@ -384,6 +387,9 @@ void GeometryApp::updateGui()
 		break;
 	case GeometryApp::CONE:
 		changed |= ImGui::DragFloat( "Cone: Ratio", &mConeRatio, 0.01f );
+		break;
+	case GeometryApp::CUBESPHERE:
+		changed |= ImGui::Checkbox( "Cube Sphere: Equal Spacing", &mCubeSphereEqualSpacing );
 		break;
 	case GeometryApp::HELIX:
 		changed |= ImGui::DragFloat( "Helix: Ratio", &mHelixRatio, 0.01f );
@@ -460,7 +466,14 @@ void GeometryApp::createGeometry()
 			switch( mQualityCurrent ) {
 				case DEFAULT:	loadGeomSource( geom::Cube(), geom::WireCube() ); break;
 				case LOW:		loadGeomSource( geom::Cube().subdivisions( 1 ), geom::WireCube() ); break;
-				case HIGH:		loadGeomSource( geom::Cube().subdivisions( 10 ), geom::WireCube() ); break;
+				case HIGH:		loadGeomSource( geom::Cube().subdivisions( 64 ), geom::WireCube() ); break;
+			}
+			break;
+		case CUBESPHERE:
+			switch( mQualityCurrent ) {
+				case DEFAULT:	loadGeomSource( geom::CubeSphere().equalSpacing( mCubeSphereEqualSpacing ), geom::WireSphere() ); break;
+				case LOW:		loadGeomSource( geom::CubeSphere().equalSpacing( mCubeSphereEqualSpacing ).subdivisions( 4 ), geom::WireSphere() ); break;
+				case HIGH:		loadGeomSource( geom::CubeSphere().equalSpacing( mCubeSphereEqualSpacing ).subdivisions( 64 ), geom::WireSphere() ); break;
 			}
 			break;
 		case CYLINDER:


### PR DESCRIPTION
… which creates a sphere primitive by normalizing the faces of a cube. Optionally, you can adjust the distribution of the vertices for a more pleasant look using `CubeSphere().equalSpacing()`. The Geometry sample has been updated to include this new primitive.

See also: https://youtu.be/sLqXFF8mlEU?t=97

![Screenshot 2021-11-04 112842](https://user-images.githubusercontent.com/304908/140298412-259dd3ad-5b9e-46dc-a7b1-a8635c4144d4.png)
EU