### PR TITLE
Added getSeekFinishedSignal() to GstPlayer.

### DIFF
--- a/include/cinder/linux/GstPlayer.h
+++ b/include/cinder/linux/GstPlayer.h
@@ -176,6 +176,8 @@ class GstPlayer {
 
 		ci::gl::Texture2dRef getVideoTexture();
 
+		ci::signals::Signal<void()>& getSeekFinishedSignal() { return mSignalSeekFinished; }
+
 	private:
 		bool initializeGStreamer();
 
@@ -234,6 +236,8 @@ class GstPlayer {
 		GLint getTextureID( GstBuffer* newBuffer );
 
 		std::atomic<bool> mNewFrame;
+
+		ci::signals::Signal<void()>	mSignalSeekFinished;
 };
 
 }} // namespace gst::video

--- a/include/cinder/linux/Movie.h
+++ b/include/cinder/linux/Movie.h
@@ -133,6 +133,8 @@ class MovieBase {
 	signals::Signal<void()>&	getJumpedSignal() { return mSignalJumped; }
 	signals::Signal<void()>&	getOutputWasFlushedSignal() { return mSignalOutputWasFlushed; }
 	
+	signals::Signal<void()>&	getSeekFinishedSignal();
+	
  protected:
 	MovieBase();
 	void init();

--- a/src/cinder/linux/GstPlayer.cpp
+++ b/src/cinder/linux/GstPlayer.cpp
@@ -289,6 +289,7 @@ gboolean checkBusMessagesAsync( GstBus* bus, GstMessage* message, gpointer userD
 						}
 						else {
 							data.isSeeking = false;
+							data.player->getSeekFinishedSignal().emit();
 						}
 					}
 				}

--- a/src/cinder/linux/Movie.cpp
+++ b/src/cinder/linux/Movie.cpp
@@ -228,6 +228,11 @@ void MovieBase::stop()
     mGstPlayer->stop();
 }
 
+signals::Signal<void()>& MovieBase::getSeekFinishedSignal()
+{ 
+    return mGstPlayer->getSeekFinishedSignal(); 
+}
+
 //! \class MovieGl
 //!
 //!


### PR DESCRIPTION
Seeking in gstreamer is asynchronous.  Knowing when the seek finished is very useful so that you don't do other actions while a seek is happening.