### PR TITLE
Added optional ${CINDER_IMGUI_DIR} cmake variable to build with an external version of ImGui

### DIFF
--- a/include/cinder/CinderImGui.h
+++ b/include/cinder/CinderImGui.h
@@ -26,8 +26,11 @@
 #if ! defined( IMGUI_USER_CONFIG )
 #define IMGUI_USER_CONFIG "cinder/CinderImGuiConfig.h"
 #endif
+#if ! defined( CINDER_IMGUI_EXTERNAL )
 #include "imgui/imgui.h"
-#include "imgui/imgui_stdlib.h"
+#else
+#include "imgui.h"
+#endif
 
 #include "cinder/Filesystem.h"
 #include "cinder/CinderGlm.h"

--- a/proj/cmake/libcinder_configure.cmake
+++ b/proj/cmake/libcinder_configure.cmake
@@ -25,11 +25,23 @@ list( APPEND CINDER_INCLUDE_USER_PRIVATE
 	${CINDER_INC_DIR}
 	${CINDER_INC_DIR}/jsoncpp
 	${CINDER_INC_DIR}/tinyexr
-	${CINDER_INC_DIR}/imgui
 	${CINDER_SRC_DIR}/linebreak
 	${CINDER_SRC_DIR}/oggvorbis/vorbis
 	${CINDER_SRC_DIR}/r8brain
 )
+
+# *_PRIVATE includes for imgui taking into account a potential custom path
+if( CINDER_IMGUI_DIR )
+	list( APPEND CINDER_INCLUDE_USER_PRIVATE 
+		${CINDER_IMGUI_DIR}
+		${CINDER_IMGUI_DIR}/backends
+		${CINDER_IMGUI_DIR}/misc/freetype
+		${CINDER_IMGUI_DIR}/misc/cpp
+	)
+	list( APPEND CINDER_DEFINES "CINDER_IMGUI_EXTERNAL" )
+else()
+	list( APPEND CINDER_INCLUDE_USER_PRIVATE ${CINDER_INC_DIR}/imgui )
+endif()
 
 if( CINDER_HEADLESS_GL_EGL )
 	list( APPEND CINDER_INCLUDE_USER_PRIVATE ${CINDER_INC_DIR}/EGL-Registry )

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -326,15 +326,30 @@ endif()
 
 if( CINDER_IMGUI_ENABLED )
 	list( APPEND SRC_SET_CINDER_IMGUI ${CINDER_SRC_DIR}/cinder/CinderImGui.cpp )
-	list( APPEND SRC_SET_IMGUI
-		${CINDER_SRC_DIR}/imgui/imgui.cpp
-		${CINDER_SRC_DIR}/imgui/imgui_demo.cpp
-		${CINDER_SRC_DIR}/imgui/imgui_draw.cpp
-		${CINDER_SRC_DIR}/imgui/imgui_freetype.cpp
-		${CINDER_SRC_DIR}/imgui/imgui_impl_opengl3.cpp
-		${CINDER_SRC_DIR}/imgui/imgui_stdlib.cpp
-		${CINDER_SRC_DIR}/imgui/imgui_widgets.cpp
-	)
+	if( CINDER_IMGUI_DIR )
+		list( APPEND SRC_SET_IMGUI
+			${CINDER_IMGUI_DIR}/imgui.cpp
+			${CINDER_IMGUI_DIR}/imgui_demo.cpp
+			${CINDER_IMGUI_DIR}/imgui_draw.cpp
+			${CINDER_IMGUI_DIR}/imgui_widgets.cpp
+			${CINDER_IMGUI_DIR}/backends/imgui_impl_opengl3.cpp
+			${CINDER_IMGUI_DIR}/misc/freetype/imgui_freetype.cpp
+			${CINDER_IMGUI_DIR}/misc/cpp/imgui_stdlib.cpp
+		)
+		if( EXISTS ${CINDER_IMGUI_DIR}/imgui_tables.cpp )
+			list( APPEND SRC_SET_IMGUI ${CINDER_IMGUI_DIR}/imgui_tables.cpp )
+		endif()
+	else()
+		list( APPEND SRC_SET_IMGUI
+			${CINDER_SRC_DIR}/imgui/imgui.cpp
+			${CINDER_SRC_DIR}/imgui/imgui_demo.cpp
+			${CINDER_SRC_DIR}/imgui/imgui_draw.cpp
+			${CINDER_SRC_DIR}/imgui/imgui_freetype.cpp
+			${CINDER_SRC_DIR}/imgui/imgui_impl_opengl3.cpp
+			${CINDER_SRC_DIR}/imgui/imgui_stdlib.cpp
+			${CINDER_SRC_DIR}/imgui/imgui_widgets.cpp
+		)
+	endif()
 
 	list( APPEND CINDER_SRC_FILES
 		${SRC_SET_CINDER_IMGUI}

--- a/src/cinder/CinderImGui.cpp
+++ b/src/cinder/CinderImGui.cpp
@@ -1,5 +1,5 @@
 #include "cinder/CinderImGui.h"
-#include "imgui/imgui_impl_opengl3.h"
+#include "imgui_impl_opengl3.h"
 
 #include "cinder/app/App.h"
 #include "cinder/Log.h"


### PR DESCRIPTION
This PR allows to ship _Cinder_ along with an external version of _DearImGui_. 

It's great to have a script to update the version cinder is shipping with but it's a far less convenient solution when trying to setup a repository with a custom version of imgui. When working with a team it is easier to rely on submodules and cmake than having to depend on users to execute a python script.

The cmake changes are minimal but there's a couple of small required changes on the cpp side. Mostly the addition of a new `CINDER_IMGUI_EXTERNAL` preprocessor define to switch between the cinder friendly `#include "imgui/imgui.h"` and the standard `#include "imgui` used by _DearImGui_ (and all libraries built upon _DearImGui_). This is taken care of by appending to the `CINDER_DEFINES` cmake variable.

This PR also removes the unused `#include "imgui/imgui_stdlib.h"` present at the top of `CinderImGui.h`. This hopefully shouldn't cause any major issue as cinder is not using the content of that file.