### PR TITLE
Fixes DearImGui crash when the App issues more than one draw per update

### DIFF
--- a/src/cinder/CinderImGui.cpp
+++ b/src/cinder/CinderImGui.cpp
@@ -531,6 +531,7 @@ static bool ImGui_ImplCinder_Init( const ci::app::WindowRef& window, const ImGui
 	sWindowConnections[window] += window->getSignalResize().connect( signalPriority, std::bind( ImGui_ImplCinder_Resize, window ) );
 	if( options.isAutoRenderEnabled() ) {
 		sWindowConnections[window] += ci::app::App::get()->getSignalUpdate().connect( std::bind( ImGui_ImplCinder_NewFrameGuard, window ) );
+		sWindowConnections[window] += window->getSignalDraw().connect( std::bind( ImGui_ImplCinder_NewFrameGuard, window ) );
 		sWindowConnections[window] += window->getSignalPostDraw().connect( ImGui_ImplCinder_PostDraw );
 	}
 


### PR DESCRIPTION
As mentioned in https://github.com/cinder/Cinder/issues/2236 the app draw function is not guarantied to be called only once for each call to the update function. And as explained [here](https://github.com/ocornut/imgui/blob/master/imgui_internal.h#L2476) it is illegal to call ImGui functions after `ImGui::EndFrame()/ImGui::Render()`. Failing to do so will trigger or an assert or crash the app. I believe the `NewFrameGuard` was slightly changed when adapted from `Cinder-ImGui` and is now missing a check before the app emits its draw calls.

This means that currently it is only safe to use ImGui inside the scope of the update function.

This can be easily reproduced on Windows by adding a `ImGui::Text( "WillCrash" )` in the app draw method and dragging the window to the corner of the screen.