### PR TITLE
Update protocol on submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "tools/TinderBox-Mac"]
 	path = tools/TinderBox-Mac
-	url = git://github.com/cinder/TinderBox-Mac.git
+	url = https://github.com/cinder/TinderBox-Mac.git
 	branch = 0.9.3
 [submodule "tools/TinderBox-Win"]
 	path = tools/TinderBox-Win
-	url = git://github.com/cinder/TinderBox-Win.git
+	url = https://github.com/cinder/TinderBox-Win.git
 	branch = 0.9.3


### PR DESCRIPTION
If you pull a fresh copy of cinder, Submodules will no longer download as the git: protocol is no longer supported. This chages the  protocol used to https. You may need to do a `git submodule sync` to update the submodules.