### PR TITLE
Add definitions for iOS / GLES2 extension functions and constants

### DIFF
--- a/include/cinder/gl/platform.h
+++ b/include/cinder/gl/platform.h
@@ -232,3 +232,25 @@
 #else
 	#define CINDER_GL_HAS_KHR_DEBUG
 #endif
+
+#if defined( CINDER_COCOA_TOUCH ) && defined( CINDER_GL_ES_2 )
+	#define GL_DEPTH_COMPONENT24					GL_DEPTH_COMPONENT24_OES
+	#define GL_DEPTH24_STENCIL8						GL_DEPTH24_STENCIL8_OES
+	#define GL_RGBA8								GL_RGBA8_OES
+	#define glRenderbufferStorageMultisample		glRenderbufferStorageMultisampleAPPLE
+	#define GL_READ_FRAMEBUFFER						GL_READ_FRAMEBUFFER_APPLE
+	#define GL_DRAW_FRAMEBUFFER						GL_DRAW_FRAMEBUFFER_APPLE
+	#define GL_READ_FRAMEBUFFER_BINDING				GL_READ_FRAMEBUFFER_BINDING_APPLE
+	#define GL_DRAW_FRAMEBUFFER_BINDING				GL_DRAW_FRAMEBUFFER_BINDING_APPLE
+	#define GL_MAX_SAMPLES							GL_MAX_SAMPLES_APPLE
+	#define glGenVertexArrays						glGenVertexArraysOES
+	#define glDeleteVertexArrays					glDeleteVertexArraysOES
+	#define glBindVertexArray						glBindVertexArrayOES
+	#define glResolveMultisampleFramebuffer			glResolveMultisampleFramebufferAPPLE
+	#define glVertexAttribDivisor					glVertexAttribDivisorEXT
+	#define glMapBuffer								glMapBufferOES
+	#define glUnmapBuffer							glUnmapBufferOES
+	#define glMapBufferRange						glMapBufferRangeEXT
+	#define GL_MAP_WRITE_BIT						GL_MAP_WRITE_BIT_EXT
+	#define GL_MAP_INVALIDATE_BUFFER_BIT			GL_MAP_INVALIDATE_BUFFER_BIT_EXT
+#endif

--- a/src/cinder/app/cocoa/RendererImplGlCocoaTouch.mm
+++ b/src/cinder/app/cocoa/RendererImplGlCocoaTouch.mm
@@ -29,16 +29,6 @@
 #include "cinder/gl/Environment.h"
 #include "cinder/Log.h"
 
-#if defined( CINDER_GL_ES_2 )
-	#define GL_DEPTH_COMPONENT24						GL_DEPTH_COMPONENT24_OES
-	#define GL_DEPTH24_STENCIL8							GL_DEPTH24_STENCIL8_OES
-	#define GL_RGBA8									GL_RGBA8_OES
-	#define glRenderbufferStorageMultisample			glRenderbufferStorageMultisampleAPPLE
-	#define GL_READ_FRAMEBUFFER							GL_READ_FRAMEBUFFER_APPLE
-	#define GL_DRAW_FRAMEBUFFER							GL_DRAW_FRAMEBUFFER_APPLE
-	#define GL_MAX_SAMPLES								GL_MAX_SAMPLES_APPLE
-#endif
-
 @implementation RendererImplGlCocoaTouch
 
 - (id)initWithFrame:(CGRect)frame cinderView:(UIView *)cinderView renderer:(cinder::app::RendererGl *)renderer sharedRenderer:(cinder::app::RendererGlRef)sharedRenderer

--- a/src/cinder/gl/ConstantConversions.cpp
+++ b/src/cinder/gl/ConstantConversions.cpp
@@ -86,8 +86,9 @@ std::string	constantToString( GLenum constant )
 		sSymbols[GL_SAMPLER_2D] = "SAMPLER_2D";
 		sSymbols[GL_SAMPLER_CUBE] = "SAMPLER_CUBE";
 
-
+#if ! defined( CINDER_GL_ES_2 )
 		sSymbols[GL_HALF_FLOAT] = "HALF_FLOAT";
+#endif
 #if ! defined( CINDER_GL_ES )
 		sSymbols[GL_SAMPLER_BUFFER] = "SAMPLER_BUFFER";
 		sSymbols[GL_UNSIGNED_INT_SAMPLER_BUFFER] = "UNSIGNED_INT_SAMPLER_BUFFER";
@@ -150,13 +151,17 @@ std::string	constantToString( GLenum constant )
 #endif		
 
 		sSymbols[GL_RED] = "GL_RED";
+#if ! defined( CINDER_GL_ES_2 )
 		sSymbols[GL_RG] = "GL_RG";
 		sSymbols[GL_R8] = "GL_R8";
 		sSymbols[GL_RG8] = "GL_RG8";
 		sSymbols[GL_RGB8] = "GL_RGB8";
+#endif
 		sSymbols[GL_RGBA4] = "GL_RGBA4";
 		sSymbols[GL_RGB5_A1] = "GL_RGB5_A1";
 		sSymbols[GL_RGBA8] = "GL_RGBA8";
+
+#if ! defined( CINDER_GL_ES_2 )
 		sSymbols[GL_R16F] = "GL_R16F";
 		sSymbols[GL_RG16F] = "GL_RG16F";
 		sSymbols[GL_RGB16F] = "GL_RGB16F";
@@ -169,7 +174,6 @@ std::string	constantToString( GLenum constant )
 		sSymbols[GL_R11F_G11F_B10F] = "GL_R11F_G11F_B10F";
 		sSymbols[GL_RGB9_E5] = "GL_RGB9_E5";
 		
-#if ! defined( CINDER_GL_ES_2 )
 		sSymbols[GL_R8I] = "GL_R8I";
 		sSymbols[GL_R8UI] = "GL_R8UI";
 		sSymbols[GL_R16I] = "GL_R16I";


### PR DESCRIPTION
This fixes the iOS build when compiling with `-DCINDER_GL_ES_2` on Xcode 13.3.

Some of these were already defined in `RendererImplGlCocoaTouch.mm`. I've moved those definitions to `platform.h` since some are needed in other files. There's still one instance of an `glResolveMultisampleFramebufferAPPLE` being used. I've left this one unchanged since it's in a platform specific file.