### PR TITLE
Fix missing "slice" when drawing large circles with geom::Circle

### DIFF
--- a/src/cinder/GeomIo.cpp
+++ b/src/cinder/GeomIo.cpp
@@ -1886,13 +1886,18 @@ void Circle::loadInto( Target *target, const AttribSet &/*requestedAttribs*/ ) c
 	// iterate the segments
 	const float tDelta = 1 / (float)mNumSubdivisions * 2.0f * 3.14159f;
 	float t = 0;
-	for( int s = 0; s <= mNumSubdivisions; s++ ) {
+	for( int s = 0; s <= mNumSubdivisions-1; s++ ) {
 		vec2 unit( math<float>::cos( t ), math<float>::sin( t ) );
 		positions.emplace_back( mCenter + unit * mRadius );
 		texCoords.emplace_back( unit * 0.5f + vec2( 0.5f ) );
 		normals.emplace_back( 0, 0, 1 );
 		t += tDelta;
 	}
+
+	vec2 unit(math<float>::cos(0), math<float>::sin(0));
+	positions.emplace_back(mCenter + unit * mRadius);
+	texCoords.emplace_back(unit * 0.5f + vec2(0.5f));
+	normals.emplace_back(0, 0, 1);
 
 	target->copyAttrib( Attrib::POSITION, 2, 0, (const float*)positions.data(), mNumVertices );
 	target->copyAttrib( Attrib::NORMAL, 3, 0, (const float*)normals.data(), mNumVertices );


### PR DESCRIPTION
If rendering a large solid circle with geom::circle, the circle doesn't go all the way around. This makes it so that the last point outside the circle is at the same location as the first outer point, thus ensuring the circle is complete.

The following class will test the circle.

```
#include "cinder/app/App.h"
#include "cinder/app/RendererGl.h"
#include "cinder/gl/gl.h"


using namespace ci;
using namespace ci::app;
using namespace std;

class CircleTestApp : public App {
  public:
	void setup() override;
	void mouseDown( MouseEvent event ) override;
	void update() override;
	void draw() override;
	
	ci::gl::BatchRef mRenderBatch;
	ci::gl::GlslProgRef mShaderProg;
};

void CircleTestApp::setup()
{
	mShaderProg = ci::gl::getStockShader(ci::gl::ShaderDef().color());
}

void CircleTestApp::mouseDown( MouseEvent event )
{
}

void CircleTestApp::update()
{
}

void CircleTestApp::draw()
{
	//a big radius
	auto radius = 1920*2;
	
	//set the center so that the right edge is visible 
	auto center = getWindowCenter();
	center.x =  -radius + center.x;

	gl::clear( Color( 0, 0, 0 ) ); 
	
	//draw a circle in white using drawSolidCircle. This works fine!
	gl::color(Color(1, 1, 1));
	gl::drawSolidCircle(center, radius);

	//make a red circle over top of the white one
	
	gl::color(Color(1, 0, 0));
	auto theCircle = ci::geom::Circle().radius(radius).center(center);
	
	if (mRenderBatch) mRenderBatch->replaceVboMesh(ci::gl::VboMesh::create(theCircle));
	else mRenderBatch = ci::gl::Batch::create(theCircle,mShaderProg);

	//draw the renderbatch circle. The result should be a solid red circle.
	//without the fix you'll get a small white sliver showing through the red circle.
	mRenderBatch->draw();
}

CINDER_APP( CircleTestApp, RendererGl )
```