### PR TITLE
Add EqualizerNode (a FilterNode which supports an abritrary number of…

### DIFF
--- a/include/cinder/audio/EqualizerNode.h
+++ b/include/cinder/audio/EqualizerNode.h
@@ -1,0 +1,94 @@
+/*
+ Copyright (c) 2022, The Cinder Project
+
+ This code is intended to be used with the Cinder C++ library, http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and
+ the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "cinder/audio/Node.h"
+#include "cinder/audio/dsp/Biquad.h"
+
+#include <mutex>
+#include <vector>
+
+namespace cinder { namespace audio {
+
+//! Equalizer class which is defined by a set of biquad (two pole, two zero) filters.
+class CI_API EqualizerNode : public Node {
+  public:
+    //! The filter class is a set of coefficients to form a biquad filter.
+    class Filter {
+    public:
+        //! The modes that are available as 'preset' coefficients, which set the frequency response to a common type of filter.
+        enum class Mode { LOWPASS, HIGHPASS, BANDPASS, LOWSHELF, HIGHSHELF, PEAKING, ALLPASS, NOTCH, CUSTOM };
+
+        Filter() {};
+        explicit Filter(Mode mode, float freq, float q, float gain);
+        Filter& operator=(const Filter& other);
+
+        //! Returns the current mode.
+        Mode	getMode() const			{ return mMode; }
+        //! Returns the current frequency in hertz.
+        float	getFreq() const			{ return mFreq; }
+        //! Returns the q, or 'quality', parameter of the Biquad.
+        float	getQ() const			{ return mQ; }
+        //! Returns the gain of the filter in decibels.
+        float	getGain() const			{ return mGain; }
+
+    protected:
+        bool mCoeffsDirty = true;
+        Mode mMode = Mode::PEAKING;
+        float mFreq = 200.0f;
+        float mQ = 1.0f;
+        float mGain = 0.0f;
+
+        friend class EqualizerNode;
+    };
+
+    //! Constructs a EqualizerNode. Can optionally provide \a format.
+    EqualizerNode(const Format &format = Format() );
+    virtual ~EqualizerNode() {}
+
+    //! Sets a set of filters, which updates the appropriate coefficients. \see Filter.
+    void setFilters(const std::vector<Filter>& filters);
+    //! Returns the current set of filters.
+    std::vector<Filter> getFilters() const { return mFilters; }
+
+  protected:
+    void initialize()				override;
+    void uninitialize()				override;
+    void process( Buffer *buffer )	override;
+
+    void updateBiquadParams();
+
+    BufferT<double> mBufferd;
+    size_t mNiquist;
+
+    std::mutex mFiltersMutex;
+    std::vector<Filter> mFilters;
+    bool mFiltersDirty = true;
+
+    // first/outer vector counts filters, second/inner vector counts channels.
+    std::vector<std::vector<dsp::Biquad>> mBiquads;
+};
+
+} } // namespace cinder::audio
+

--- a/include/cinder/audio/dsp/Biquad.h
+++ b/include/cinder/audio/dsp/Biquad.h
@@ -69,11 +69,11 @@ class CI_API Biquad {
 	Biquad();
     virtual ~Biquad();
 
-    void setLowpassParams( double cutoffFreq, double resonance );
-    void setHighpassParams( double frequency, double resonance );
+    void setLowpassParams( double cutoffFreq, double Q );
+    void setHighpassParams( double frequency, double Q );
     void setBandpassParams( double frequency, double Q );
-    void setLowShelfParams( double frequency, double dbGain );
-    void setHighShelfParams( double frequency, double dbGain );
+    void setLowShelfParams( double frequency, double dbGain, double Q );
+    void setHighShelfParams( double frequency, double dbGain, double Q );
     void setPeakingParams( double frequency, double Q, double dbGain );
     void setAllpassParams( double frequency, double Q );
     void setNotchParams( double frequency, double Q );

--- a/proj/android/CMakeLists.txt
+++ b/proj/android/CMakeLists.txt
@@ -566,6 +566,7 @@ set( CINDER_CXX_SRC_FILES
 
     ${CINDER_SRC_DIR}/cinder/audio/Node.cpp
     ${CINDER_SRC_DIR}/cinder/audio/ChannelRouterNode.cpp
+    ${CINDER_SRC_DIR}/cinder/audio/EqualizerNode.cpp
     ${CINDER_SRC_DIR}/cinder/audio/FilterNode.cpp
     ${CINDER_SRC_DIR}/cinder/audio/NodeMath.cpp
     ${CINDER_SRC_DIR}/cinder/audio/SampleRecorderNode.cpp

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -104,6 +104,7 @@ if( NOT CINDER_DISABLE_AUDIO )
 		${CINDER_SRC_DIR}/cinder/audio/Context.cpp
 		${CINDER_SRC_DIR}/cinder/audio/DelayNode.cpp
 		${CINDER_SRC_DIR}/cinder/audio/Device.cpp
+		${CINDER_SRC_DIR}/cinder/audio/EqualizerNode.cpp
 		${CINDER_SRC_DIR}/cinder/audio/FileOggVorbis.cpp
 		${CINDER_SRC_DIR}/cinder/audio/FilterNode.cpp
 		${CINDER_SRC_DIR}/cinder/audio/GenNode.cpp

--- a/src/cinder/audio/EqualizerNode.cpp
+++ b/src/cinder/audio/EqualizerNode.cpp
@@ -1,0 +1,151 @@
+/*
+ Copyright (c) 2022, The Cinder Project
+
+ This code is intended to be used with the Cinder C++ library, http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and
+ the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cinder/audio/EqualizerNode.h"
+
+using namespace std;
+
+namespace cinder { namespace audio {
+
+EqualizerNode::EqualizerNode( const Format &format )
+    : Node( format )
+{
+}
+
+void EqualizerNode::setFilters(const std::vector<Filter>& filters)
+{
+    const std::lock_guard<std::mutex> lock(mFiltersMutex);
+
+    mFilters.resize(filters.size());
+    for( size_t i = 0; i < filters.size(); ++i ) {
+        mFilters.at(i) = filters.at(i);
+    }
+    mFiltersDirty = true;
+}
+
+void EqualizerNode::initialize()
+{
+    // Convert from Hertz to normalized frequency 0 -> 1.
+    mNiquist = getSampleRate() / 2;
+
+    mBufferd = BufferT<double>( getFramesPerBlock(), getNumChannels() );
+
+    updateBiquadParams();
+}
+
+void EqualizerNode::uninitialize()
+{
+    mBiquads.clear();
+}
+
+void EqualizerNode::process( Buffer *buffer )
+{
+    updateBiquadParams();
+
+    const size_t numFrames = buffer->getNumFrames();
+
+    for( auto& b : mBiquads ) {
+        for( size_t ch = 0; ch < getNumChannels(); ch++ ) {
+            float *channel = buffer->getChannel( ch );
+            b[ch].process( channel, channel, numFrames );
+        }
+    }
+}
+
+void EqualizerNode::updateBiquadParams()
+{
+    const std::lock_guard<std::mutex> lock(mFiltersMutex);
+
+    if (!mFiltersDirty)
+        return;
+
+    mBiquads.resize(mFilters.size());
+    for( auto& b : mBiquads ) {
+        b.resize( getNumChannels() );
+    }
+    mFiltersDirty = false;
+
+    for( size_t i = 0; i < mFilters.size(); ++i ) {
+        if( !mFilters[i].mCoeffsDirty )
+            continue;
+        mFilters[i].mCoeffsDirty = false;
+        const double normalizedFrequency = mFilters[i].getFreq() / mNiquist;
+        switch( mFilters[i].getMode() ) {
+        case Filter::Mode::LOWPASS:
+            for( size_t ch = 0; ch < getNumChannels(); ch++ )
+                mBiquads[i][ch].setLowpassParams( normalizedFrequency, mFilters[i].getQ() );
+            break;
+        case Filter::Mode::HIGHPASS:
+            for( size_t ch = 0; ch < getNumChannels(); ch++ )
+                mBiquads[i][ch].setHighpassParams( normalizedFrequency, mFilters[i].getQ() );
+            break;
+        case Filter::Mode::BANDPASS:
+            for( size_t ch = 0; ch < getNumChannels(); ch++ )
+                mBiquads[i][ch].setBandpassParams( normalizedFrequency, mFilters[i].getQ() );
+            break;
+        case Filter::Mode::LOWSHELF:
+            for( size_t ch = 0; ch < getNumChannels(); ch++ )
+                mBiquads[i][ch].setLowShelfParams( normalizedFrequency, mFilters[i].getGain(), mFilters[i].getQ() );
+            break;
+        case Filter::Mode::HIGHSHELF:
+            for( size_t ch = 0; ch < getNumChannels(); ch++ )
+                mBiquads[i][ch].setHighShelfParams( normalizedFrequency, mFilters[i].getGain(), mFilters[i].getQ() );
+            break;
+        case Filter::Mode::PEAKING:
+            for( size_t ch = 0; ch < getNumChannels(); ch++ )
+                mBiquads[i][ch].setPeakingParams( normalizedFrequency, mFilters[i].getQ(), mFilters[i].getGain() );
+            break;
+        case Filter::Mode::ALLPASS:
+            for( size_t ch = 0; ch < getNumChannels(); ch++ )
+                mBiquads[i][ch].setBandpassParams( normalizedFrequency, mFilters[i].getQ() );
+            break;
+        case Filter::Mode::NOTCH:
+            for( size_t ch = 0; ch < getNumChannels(); ch++ )
+                mBiquads[i][ch].setNotchParams( normalizedFrequency, mFilters[i].getQ() );
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+EqualizerNode::Filter::Filter(Mode mode, float freq, float q, float gain) :
+    mMode(mode), mFreq(freq), mQ(q), mGain(gain)
+{
+}
+
+EqualizerNode::Filter& EqualizerNode::Filter::operator=(const Filter& other)
+{
+    if (mMode != other.mMode || mFreq != other.mFreq || mQ != other.mQ || mGain != other.mGain) {
+        mMode = other.mMode;
+        mFreq = other.mFreq;
+        mQ = other.mQ;
+        mGain = other.mGain;
+
+        mCoeffsDirty = true;
+    }
+
+    return *this;
+}
+
+} } // namespace cinder::audio

--- a/src/cinder/audio/FilterNode.cpp
+++ b/src/cinder/audio/FilterNode.cpp
@@ -82,11 +82,11 @@ void FilterBiquadNode::updateBiquadParams()
 			break;
 		case Mode::LOWSHELF:
 			for( size_t ch = 0; ch < getNumChannels(); ch++ )
-				mBiquads[ch].setLowShelfParams( mFreq, mGain );;
+				mBiquads[ch].setLowShelfParams( mFreq, mGain, mQ );
 			break;
 		case Mode::HIGHSHELF:
 			for( size_t ch = 0; ch < getNumChannels(); ch++ )
-				mBiquads[ch].setHighShelfParams( mFreq, mGain );;
+				mBiquads[ch].setHighShelfParams( mFreq, mGain, mQ );
 			break;
 		case Mode::PEAKING:
 			for( size_t ch = 0; ch < getNumChannels(); ch++ )


### PR DESCRIPTION
EqualizerNode is a FilterNode which supports an arbitrary number of filters, while the _FilterBiquadNode_ only supports a single filter.

This also fixes quite a few bugs in shelving and low/high pass filters...
Please tell me what you think