### PR TITLE
OSC: added methods for removing all listeners and getting all listeners.

### DIFF
--- a/blocks/OSC/src/cinder/osc/Osc.cpp
+++ b/blocks/OSC/src/cinder/osc/Osc.cpp
@@ -1141,6 +1141,18 @@ void ReceiverBase::removeListener( const std::string &address )
 		mListeners.erase( foundListener );
 }
 
+void ReceiverBase::removeAllListeners()
+{
+	std::lock_guard<std::mutex> lock( mListenerMutex );
+	mListeners.clear();
+}
+
+ReceiverBase::Listeners ReceiverBase::getListeners() const
+{
+	std::lock_guard<std::mutex> lock( mListenerMutex );
+	return mListeners;
+}
+
 void ReceiverBase::dispatchMethods( uint8_t *data, uint32_t size, const asio::ip::address &senderIpAddress, uint16_t senderPort )
 {
 	std::vector<Message> messages;

--- a/blocks/OSC/src/cinder/osc/Osc.h
+++ b/blocks/OSC/src/cinder/osc/Osc.h
@@ -651,7 +651,11 @@ public:
 	void		setListener( const std::string &address, ListenerFn listener );
 	//! Removes the listener associated with \a address.
 	void		removeListener( const std::string &address );
-	
+	//! Removes all listeners
+	void		removeAllListeners();
+	//! Returns all listeners by value
+	Listeners getListeners() const;
+
   protected:
 	ReceiverBase() = default;
 	//! Non-copyable.
@@ -680,7 +684,7 @@ public:
 	virtual void closeImpl() = 0;
 	
 	Listeners				mListeners;
-	std::mutex				mListenerMutex;
+	mutable std::mutex		mListenerMutex;
 	std::set<std::string>	mDisregardedAddresses;
 };
 	


### PR DESCRIPTION
I use `removeAllListeners()` when doing complete re-initializations, and `getListeners()` for showing clients in the GUI. 