### PR TITLE
Add missing ci::Color( vec3 ) overload.

### DIFF
--- a/include/cinder/Color.h
+++ b/include/cinder/Color.h
@@ -50,6 +50,10 @@ class CI_API ColorT
 	ColorT( const ColorT<T> &src ) 
 		: r( src.r ), g( src.g ), b( src.b )
 	{}
+	ColorT( const vec3 &src )
+		: r( CHANTRAIT<T>::convert( src.r ) ), g( CHANTRAIT<T>::convert( src.g ) ), b( CHANTRAIT<T>::convert( src.b ) )
+	{}
+
 	ColorT( const char *svgColorName );
 
 	ColorT( ColorModel cm, const vec3 &v );


### PR DESCRIPTION
`ColorA( vec4 )` already exists, the analog was missing for 3-channel `ColorT` class. After this change, code like the following works:

```cpp
vec3 col = { 1, 0, 0 };
ci::Color boneColor = col;
```

Some of my code gets shared with GLSL, so it's nice in some cases to use `vec3` instead as an RGB color like you do in shaders, but then for other that use `ci::Color`, seemlessly convert to what you need. Without, you must do:

```cpp
vec3 col = { 1, 0, 0 };
ci::Color boneColor( col.x, col.y, col.z );
// or:
ci::Color boneColor = {  col.x, col.y, col.z };
```

However as I first noted, [there is already a constructor](https://github.com/cinder/Cinder/blob/e10faebb9750a74b16ac772e122c59b260dbf003/include/cinder/Color.h#L197-L200) for the 4-channel version that allows for this:

```cpp
vec4 col = { 1,  0, 0, 0.5f };
ci::ColorA boneColor = col;
```

