### PR TITLE
Fix for font outlines. See below:

### DIFF
--- a/src/cinder/Font.cpp
+++ b/src/cinder/Font.cpp
@@ -653,7 +653,7 @@ Shape2d Font::getGlyphShape( Glyph glyphIndex ) const
 	static const MAT2 matrix = { { 0, 1 }, { 0, 0 }, { 0, 0 }, { 0, -1 } };
 	GLYPHMETRICS metrics;
 	DWORD bytesGlyph = ::GetGlyphOutlineW( FontManager::instance()->getFontDc(), glyphIndex,
-							GGO_NATIVE | GGO_GLYPH_INDEX, &metrics, 0, NULL, &matrix);
+							GGO_NATIVE | GGO_GLYPH_INDEX | GGO_UNHINTED, &metrics, 0, NULL, &matrix);
 
     if( bytesGlyph == GDI_ERROR )
 		throw FontGlyphFailureExc();
@@ -665,7 +665,7 @@ Shape2d Font::getGlyphShape( Glyph glyphIndex ) const
     }
 
     if( ::GetGlyphOutlineW( FontManager::instance()->getFontDc(), glyphIndex,
-			  GGO_NATIVE | GGO_GLYPH_INDEX, &metrics, bytesGlyph, buffer.get(), &matrix) == GDI_ERROR ) {
+			  GGO_NATIVE | GGO_GLYPH_INDEX | GGO_UNHINTED, &metrics, bytesGlyph, buffer.get(), &matrix) == GDI_ERROR ) {
 		throw FontGlyphFailureExc();
     }
 
@@ -689,8 +689,8 @@ Shape2d Font::getGlyphShape( Glyph glyphIndex ) const
 				break;
 				case TT_PRIM_QSPLINE:
 					for( int i = 0; i < curve->cpfx - 1; i++ ) {
-						vec2 p1 = resultShape.getCurrentPoint(), p2;
-						vec2 c = msw::toVec2( points[i] ), c1, c2;
+						vec2 c = msw::toVec2( points[i] );
+						vec2 p2;
 						if( i + 1 == curve->cpfx - 1 ) {
 							p2 = msw::toVec2( points[i + 1] );
 						}
@@ -698,10 +698,13 @@ Shape2d Font::getGlyphShape( Glyph glyphIndex ) const
 							// records with more than one curve use interpolation for control points, per http://support.microsoft.com/kb/q87115/
 							p2 = ( c + msw::toVec2( points[i + 1] ) ) / 2.0f;
 						}
-	
-						c1 = 2.0f * c / 3.0f + p1 / 3.0f;
-						c2 = 2.0f * c / 3.0f + p2 / 3.0f;
-						resultShape.curveTo( c1, c2, p2 );
+
+						//vec2 p1 = resultShape.getCurrentPoint();
+						//vec2 c1 = 2.0f * c / 3.0f + p1 / 3.0f;
+						//vec2 c2 = 2.0f * c / 3.0f + p2 / 3.0f;
+						//resultShape.curveTo( c1, c2, p2 );
+
+						resultShape.quadTo( c, p2 );
 					}
 				break;
 				case TT_PRIM_CSPLINE:


### PR DESCRIPTION
* Outlines were hinted, causing deformations to the actual clean outline. Outlines are now unhinted.

This is the letter `X` of the Arial font with hinting enabled:

![image](https://github.com/cinder/Cinder/assets/304908/b6cee7b0-336f-4dee-bf97-e0bb34178b30)


Here is the same letter, but with hinting disabled:

![image](https://github.com/cinder/Cinder/assets/304908/09f1ddad-343e-41f4-a340-5f4136c4d6e7)



* Quadratic curves were converted to cubic curves. This unnecessarily increases complexity of the outlines and introduces extra vertices. If triangulated, these extra vertices cause extra triangles, etc. There is no need to convert quadratic curves, as they are natively supported by the Path2d class.

This is the letter `e` of the Arial font triangulated after extracting the outline using the old version, which converts quadratic curves to cubic curves, resulting in this case in 70 triangles:

![image](https://github.com/cinder/Cinder/assets/304908/8018f246-d12b-4450-bf83-bd2678c24f53)


Here is the same letter, but using the quadratic curves defined by the font, leading to far fewer triangles (in this case 45) and a reduced number of vertices:

![image](https://github.com/cinder/Cinder/assets/304908/39ed95f3-ccf7-4cbe-a1d9-dd8813376379)
