### PR TITLE
Fix using std::filesystem when not available

### DIFF
--- a/include/cinder/Filesystem.h
+++ b/include/cinder/Filesystem.h
@@ -24,12 +24,12 @@
 
 #pragma once
 
-#if ( (! defined(__APPLE__)) && defined(__cplusplus) && __cplusplus >= 201703L && defined(__has_include) && __has_include(<filesystem>)) || defined( _MSC_VER )
-		#define GHC_USE_STD_FS
-		#include <filesystem>
-		namespace cinder {
-			namespace fs = std::filesystem;
-		}
+#if (! defined(__APPLE__)) && defined(__cplusplus) && __cplusplus >= 201703L && defined(__has_include) && __has_include(<filesystem>)
+	#define GHC_USE_STD_FS
+	#include <filesystem>
+	namespace cinder {
+		namespace fs = std::filesystem;
+	}
 #endif
 
 #ifndef GHC_USE_STD_FS


### PR DESCRIPTION
> Ref https://github.com/cinder/Cinder/issues/2316

I simply removed the `_MSC_VER` check.

Feel free to edit or discard.
Cheers!