### PR TITLE
Added comparison functions for floats and doubles…

### DIFF
--- a/include/cinder/CinderMath.h
+++ b/include/cinder/CinderMath.h
@@ -123,41 +123,74 @@ struct CI_API math<float>
 #define M_PI           3.14159265358979323846
 #endif
 
-const double EPSILON_VALUE = 4.37114e-05;
-#define EPSILON EPSILON_VALUE
-
-CI_API inline bool approxZero( float n, float epsilon = float(EPSILON) )
+CI_API inline bool approxZero( float n, float epsilon = FLT_EPSILON )
 {
 	return std::abs( n ) < epsilon;
 }
 
-CI_API inline bool approxZero( double n, double epsilon = EPSILON )
+CI_API inline bool approxZero( double n, double epsilon = DBL_EPSILON )
 {
 	return std::abs( n ) < epsilon;
 }
 
-CI_API inline float roundToZero( float n, float epsilon = float(EPSILON) )
+CI_API inline float roundToZero( float n, float epsilon = FLT_EPSILON )
 {
 	if( std::abs( n ) < epsilon )
 		return 0.0f;
 	return n;
 }
 
-CI_API inline double roundToZero( double n, double epsilon = EPSILON )
+CI_API inline double roundToZero( double n, double epsilon = DBL_EPSILON )
 {
 	if( std::abs( n ) < epsilon )
 		return 0.0;
 	return n;
 }
 
-CI_API inline bool approxEqual( float a, float b, float epsilon = float(EPSILON) )
+CI_API inline bool approxEqual( float a, float b, float epsilon = FLT_EPSILON )
 {
 	return std::abs( b - a ) < epsilon;
 }
 
-CI_API inline bool approxEqual( double a, double b, double epsilon = EPSILON )
+CI_API inline bool approxEqual( double a, double b, double epsilon = DBL_EPSILON )
 {
 	return std::abs( b - a ) < epsilon;
+}
+
+CI_API inline bool approxEqualRelative( float a, float b, float maxRelDiff = FLT_EPSILON )
+{
+	// See: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+
+	// Calculate the difference.
+	float diff = std::abs( a - b );
+	a = std::abs( a );
+	b = std::abs( b );
+
+	// Find the largest.
+	float largest = ( b > a ) ? b : a;
+
+	if( diff <= largest * maxRelDiff )
+		return true;
+
+	return false;
+}
+
+CI_API inline bool approxEqualRelative( double a, double b, double maxRelDiff = DBL_EPSILON )
+{
+	// See: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+
+	// Calculate the difference.
+	double diff = std::abs( a - b );
+	a = std::abs( a );
+	b = std::abs( b );
+
+	// Find the largest.
+	double largest = ( b > a ) ? b : a;
+
+	if( diff <= largest * maxRelDiff )
+		return true;
+
+	return false;
 }
 
 inline float toRadians( float x )

--- a/include/cinder/CinderMath.h
+++ b/include/cinder/CinderMath.h
@@ -138,16 +138,12 @@ CI_API inline bool approxZero( double n, double epsilon = EPSILON_VALUE )
 
 CI_API inline float roundToZero( float n, float epsilon = float(EPSILON_VALUE) )
 {
-	if( approxZero( n, epsilon ) )
-		return 0.0f;
-	return n;
+	return approxZero( n, epsilon ) ? 0.0f : n;
 }
 
 CI_API inline double roundToZero( double n, double epsilon = EPSILON_VALUE )
 {
-	if( approxZero( n, epsilon ) )
-		return 0.0;
-	return n;
+	return approxZero( n, epsilon ) ? 0.0 : n;
 }
 
 CI_API inline bool approxEqual( float a, float b, float epsilon = float(EPSILON_VALUE) )
@@ -165,12 +161,12 @@ CI_API inline bool approxEqualRelative( float a, float b, float maxRelDiff = flo
 	// See: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
 
 	// Calculate the difference.
-	float diff = std::abs( a - b );
-	a = std::abs( a );
-	b = std::abs( b );
+	const float diff = std::abs( a - b );
 
 	// Find the largest.
-	float largest = ( b > a ) ? b : a;
+	a = std::abs( a );
+	b = std::abs( b );
+	const float largest = ( b > a ) ? b : a;
 
 	if( diff <= largest * maxRelDiff )
 		return true;
@@ -183,12 +179,12 @@ CI_API inline bool approxEqualRelative( double a, double b, double maxRelDiff = 
 	// See: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
 
 	// Calculate the difference.
-	double diff = std::abs( a - b );
-	a = std::abs( a );
-	b = std::abs( b );
+	const double diff = std::abs( a - b );
 
 	// Find the largest.
-	double largest = ( b > a ) ? b : a;
+	a = std::abs( a );
+	b = std::abs( b );
+	const double largest = ( b > a ) ? b : a;
 
 	if( diff <= largest * maxRelDiff )
 		return true;

--- a/include/cinder/CinderMath.h
+++ b/include/cinder/CinderMath.h
@@ -126,6 +126,40 @@ struct CI_API math<float>
 const double EPSILON_VALUE = 4.37114e-05;
 #define EPSILON EPSILON_VALUE
 
+CI_API inline bool approxZero( float n, float epsilon = float(EPSILON) )
+{
+	return std::abs( n ) < epsilon;
+}
+
+CI_API inline bool approxZero( double n, double epsilon = EPSILON )
+{
+	return std::abs( n ) < epsilon;
+}
+
+CI_API inline float roundToZero( float n, float epsilon = float(EPSILON) )
+{
+	if( std::abs( n ) < epsilon )
+		return 0.0f;
+	return n;
+}
+
+CI_API inline float roundToZero( double n, double epsilon = EPSILON )
+{
+	if( std::abs( n ) < epsilon )
+		return 0.0f;
+	return n;
+}
+
+CI_API inline bool approxEqual( float a, float b, float epsilon = float(EPSILON) )
+{
+	return std::abs( b - a ) < epsilon;
+}
+
+CI_API inline bool approxEqual( double a, double b, double epsilon = EPSILON )
+{
+	return std::abs( b - a ) < epsilon;
+}
+
 inline float toRadians( float x )
 {
 	return x * 0.017453292519943295769f; // ( x * PI / 180 )

--- a/include/cinder/CinderMath.h
+++ b/include/cinder/CinderMath.h
@@ -123,41 +123,44 @@ struct CI_API math<float>
 #define M_PI           3.14159265358979323846
 #endif
 
-CI_API inline bool approxZero( float n, float epsilon = FLT_EPSILON )
+constexpr double EPSILON_VALUE = 4.37114e-05;
+#define EPSILON EPSILON_VALUE
+
+CI_API inline bool approxZero( float n, float epsilon = float(EPSILON_VALUE) )
 {
 	return std::abs( n ) < epsilon;
 }
 
-CI_API inline bool approxZero( double n, double epsilon = DBL_EPSILON )
+CI_API inline bool approxZero( double n, double epsilon = EPSILON_VALUE )
 {
 	return std::abs( n ) < epsilon;
 }
 
-CI_API inline float roundToZero( float n, float epsilon = FLT_EPSILON )
+CI_API inline float roundToZero( float n, float epsilon = float(EPSILON_VALUE) )
 {
-	if( std::abs( n ) < epsilon )
+	if( approxZero( n, epsilon ) )
 		return 0.0f;
 	return n;
 }
 
-CI_API inline double roundToZero( double n, double epsilon = DBL_EPSILON )
+CI_API inline double roundToZero( double n, double epsilon = EPSILON_VALUE )
 {
-	if( std::abs( n ) < epsilon )
+	if( approxZero( n, epsilon ) )
 		return 0.0;
 	return n;
 }
 
-CI_API inline bool approxEqual( float a, float b, float epsilon = FLT_EPSILON )
+CI_API inline bool approxEqual( float a, float b, float epsilon = float(EPSILON_VALUE) )
 {
 	return std::abs( b - a ) < epsilon;
 }
 
-CI_API inline bool approxEqual( double a, double b, double epsilon = DBL_EPSILON )
+CI_API inline bool approxEqual( double a, double b, double epsilon = EPSILON_VALUE )
 {
 	return std::abs( b - a ) < epsilon;
 }
 
-CI_API inline bool approxEqualRelative( float a, float b, float maxRelDiff = FLT_EPSILON )
+CI_API inline bool approxEqualRelative( float a, float b, float maxRelDiff = float(EPSILON_VALUE) )
 {
 	// See: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
 
@@ -175,7 +178,7 @@ CI_API inline bool approxEqualRelative( float a, float b, float maxRelDiff = FLT
 	return false;
 }
 
-CI_API inline bool approxEqualRelative( double a, double b, double maxRelDiff = DBL_EPSILON )
+CI_API inline bool approxEqualRelative( double a, double b, double maxRelDiff = EPSILON_VALUE )
 {
 	// See: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
 

--- a/include/cinder/CinderMath.h
+++ b/include/cinder/CinderMath.h
@@ -143,10 +143,10 @@ CI_API inline float roundToZero( float n, float epsilon = float(EPSILON) )
 	return n;
 }
 
-CI_API inline float roundToZero( double n, double epsilon = EPSILON )
+CI_API inline double roundToZero( double n, double epsilon = EPSILON )
 {
 	if( std::abs( n ) < epsilon )
-		return 0.0f;
+		return 0.0;
 	return n;
 }
 


### PR DESCRIPTION
…providing a safer way to do things like `double value; if( value == 0.0 ){}`.

Compared to previous versions of the code, I have explicitly added the `std::` namespace to `abs`. While this is not necessary in Visual Studio (it already uses std::abs by default), it may be required for other compilers. Using the C++ function `std::abs` if preferred over the C-function `fabsf`.

I also added versions for `double`s.