### PR TITLE
Fix Could NOT find MPG123 on Ubuntu 24.04 LTS

### DIFF
--- a/proj/cmake/modules/FindMPG123.cmake
+++ b/proj/cmake/modules/FindMPG123.cmake
@@ -8,7 +8,7 @@
 
 set( MPG123_FOUND false )
 
-set( MPG123_INCLUDE_DIRS /opt/local/include /usr/local/include /usr/include )
+set( MPG123_INCLUDE_DIRS /opt/local/include /usr/local/include /usr/include /usr/include/x86_64-linux-gnu )
 set( MPG123_LIBRARY_DIRS /opt/local/lib /usr/local/lib /usr/lib )
 
 set( MPG123_LIB_SUFFIXES lib x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu )


### PR DESCRIPTION
Platform : Ubuntu 24.04 LTS

I installed dependencies found here https://libcinder.org/docs/guides/linux-notes/ubuntu.html
I faced this error:
```
CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find MPG123 (missing: MPG123_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  proj/cmake/modules/FindMPG123.cmake:35 (find_package_handle_standard_args)
  proj/cmake/platform_linux.cmake:143 (find_package)
  CMakeLists.txt:29 (include)
```

Here is a fix i found