### PR TITLE
findAncestor* path

### DIFF
--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -48,9 +48,9 @@ CI_API fs::path getDocumentsDirectory();
 CI_API void limitDirectoryFileCount( const fs::path& directoryPath, size_t maxFileCount, std::function<bool(const fs::path&, const fs::path&)> sortFn = []( const fs::path& p1, const fs::path& p2 ) -> bool { return fs::last_write_time( p1 ) > fs::last_write_time( p2 ); } );
 
 //! Searches upwards from \a start (file or directory) for an ancestor directory where \a relativeSearch exists, up to \a maxDepth levels; returns absolute path if found, otherwise empty path.
-CI_API std::filesystem::path findAncestorDir( const std::filesystem::path& start, const std::filesystem::path& relativeSearch, int maxDepth = 10 );
+CI_API fs::path findAncestorDir( const fs::path& start, const fs::path& relativeSearch, int maxDepth = 10 );
 //! Searches upwards from \a start (file or directory) for an ancestor file where \a relativeSearch exists, up to \a maxDepth levels; returns absolute path if found, otherwise empty path.
-CI_API std::filesystem::path findAncestorFile( const std::filesystem::path& start, const std::filesystem::path& relativeSearch, int maxDepth = 10 );
+CI_API fs::path findAncestorFile( const fs::path& start, const fs::path& relativeSearch, int maxDepth = 10 );
 
 //! Launches a path in a web browser
 CI_API void launchWebBrowser( const Url &url );

--- a/include/cinder/Utilities.h
+++ b/include/cinder/Utilities.h
@@ -47,6 +47,11 @@ CI_API fs::path getDocumentsDirectory();
 //! Removes all files beyond maxFileCount.
 CI_API void limitDirectoryFileCount( const fs::path& directoryPath, size_t maxFileCount, std::function<bool(const fs::path&, const fs::path&)> sortFn = []( const fs::path& p1, const fs::path& p2 ) -> bool { return fs::last_write_time( p1 ) > fs::last_write_time( p2 ); } );
 
+//! Searches upwards from \a start (file or directory) for an ancestor directory where \a relativeSearch exists, up to \a maxDepth levels; returns absolute path if found, otherwise empty path.
+CI_API std::filesystem::path findAncestorDir( const std::filesystem::path& start, const std::filesystem::path& relativeSearch, int maxDepth = 10 );
+//! Searches upwards from \a start (file or directory) for an ancestor file where \a relativeSearch exists, up to \a maxDepth levels; returns absolute path if found, otherwise empty path.
+CI_API std::filesystem::path findAncestorFile( const std::filesystem::path& start, const std::filesystem::path& relativeSearch, int maxDepth = 10 );
+
 //! Launches a path in a web browser
 CI_API void launchWebBrowser( const Url &url );
 	

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -78,7 +78,7 @@ void limitDirectoryFileCount( const fs::path& directoryPath, size_t maxFileCount
 	}
 }
 
-std::filesystem::path findAncestorFile( const std::filesystem::path& start, const std::filesystem::path& relativeSearch, int maxDepth )
+fs::path findAncestorFile( const fs::path& start, const fs::path& relativeSearch, int maxDepth )
 {
 	size_t parentCt = 0;
 	for( fs::path curPath = start; curPath.has_parent_path() && parentCt <= maxDepth; curPath = curPath.parent_path(), ++parentCt ) {
@@ -87,10 +87,10 @@ std::filesystem::path findAncestorFile( const std::filesystem::path& start, cons
 			return testDir;
 	}
 
-	return std::filesystem::path();
+	return fs::path();
 }
 
-std::filesystem::path findAncestorDir( const std::filesystem::path& start, const std::filesystem::path& relativeSearch, int maxDepth )
+fs::path findAncestorDir( const fs::path& start, const fs::path& relativeSearch, int maxDepth )
 {
 	size_t parentCt = 0;
 	for( fs::path curPath = start; curPath.has_parent_path() && parentCt <= maxDepth; curPath = curPath.parent_path(), ++parentCt ) {
@@ -99,7 +99,7 @@ std::filesystem::path findAncestorDir( const std::filesystem::path& start, const
 			return testDir;
 	}
 
-	return std::filesystem::path();
+	return fs::path();
 }
 
 void launchWebBrowser( const Url &url )

--- a/src/cinder/Utilities.cpp
+++ b/src/cinder/Utilities.cpp
@@ -78,6 +78,30 @@ void limitDirectoryFileCount( const fs::path& directoryPath, size_t maxFileCount
 	}
 }
 
+std::filesystem::path findAncestorFile( const std::filesystem::path& start, const std::filesystem::path& relativeSearch, int maxDepth )
+{
+	size_t parentCt = 0;
+	for( fs::path curPath = start; curPath.has_parent_path() && parentCt <= maxDepth; curPath = curPath.parent_path(), ++parentCt ) {
+		const fs::path testDir = curPath / relativeSearch;
+		if( fs::exists( testDir ) && fs::is_regular_file( testDir ) )
+			return testDir;
+	}
+
+	return std::filesystem::path();
+}
+
+std::filesystem::path findAncestorDir( const std::filesystem::path& start, const std::filesystem::path& relativeSearch, int maxDepth )
+{
+	size_t parentCt = 0;
+	for( fs::path curPath = start; curPath.has_parent_path() && parentCt <= maxDepth; curPath = curPath.parent_path(), ++parentCt ) {
+		const fs::path testDir = curPath / relativeSearch;
+		if( fs::exists( testDir ) && fs::is_directory( testDir ) )
+			return testDir;
+	}
+
+	return std::filesystem::path();
+}
+
 void launchWebBrowser( const Url &url )
 {
 	app::Platform::get()->launchWebBrowser( url );

--- a/src/cinder/app/Platform.cpp
+++ b/src/cinder/app/Platform.cpp
@@ -146,7 +146,7 @@ const vector<fs::path>& Platform::getAssetDirectories() const
 
 void Platform::findAndAddDefaultAssetPath()
 {
-	fs::path assetDir = findAncestorDir( getExecutablePath().parent_path(), "assets", ASSET_SEARCH_DEPTH );
+	fs::path assetDir = findAncestorDir( getExecutablePath(), "assets", ASSET_SEARCH_DEPTH );
 	if( ! assetDir.empty() )
 		addAssetDirectory( assetDir );
 }

--- a/src/cinder/app/Platform.cpp
+++ b/src/cinder/app/Platform.cpp
@@ -146,7 +146,7 @@ const vector<fs::path>& Platform::getAssetDirectories() const
 
 void Platform::findAndAddDefaultAssetPath()
 {
-	std::filesystem::path assetDir = findAncestorDir( getExecutablePath().parent_path(), "assets", ASSET_SEARCH_DEPTH );
+	fs::path assetDir = findAncestorDir( getExecutablePath().parent_path(), "assets", ASSET_SEARCH_DEPTH );
 	if( ! assetDir.empty() )
 		addAssetDirectory( assetDir );
 }

--- a/src/cinder/app/Platform.cpp
+++ b/src/cinder/app/Platform.cpp
@@ -23,6 +23,7 @@
 
 #include "cinder/app/Platform.h"
 #include "cinder/CinderAssert.h"
+#include "cinder/Utilities.h"
 
 #if defined( CINDER_COCOA )
 	#include "cinder/app/cocoa/PlatformCocoa.h"
@@ -145,20 +146,9 @@ const vector<fs::path>& Platform::getAssetDirectories() const
 
 void Platform::findAndAddDefaultAssetPath()
 {
-	// first search the local directory, then its parent, up to ASSET_SEARCH_DEPTH levels up
-	// check at least the app path, even if it has no parent directory
-	auto execPath = getExecutablePath();
-	size_t parentCt = 0;
-	for( fs::path curPath = execPath; curPath.has_parent_path() || ( curPath == execPath ); curPath = curPath.parent_path(), ++parentCt ) {
-		if( parentCt >= ASSET_SEARCH_DEPTH )
-			break;
-
-		const fs::path curAssetDir = curPath / fs::path( "assets" );
-		if( fs::exists( curAssetDir ) && fs::is_directory( curAssetDir ) ) {
-			addAssetDirectory( curAssetDir );
-			break;
-		}
-	}
+	std::filesystem::path assetDir = findAncestorDir( getExecutablePath().parent_path(), "assets", ASSET_SEARCH_DEPTH );
+	if( ! assetDir.empty() )
+		addAssetDirectory( assetDir );
 }
 
 std::ostream& Platform::console()


### PR DESCRIPTION
This PR adds two new functions, `findAncestorFile()` and `findAncesorDir()`. These are utility functions for locating a relative path somewhere up the disk hierarchy from another path.

A good example is how Cinder automatically locates the _assets_ directory relative to the application, and in fact this PR reimplements that functionality to use `findAncestorDir()` internally. Also useful for a scenario where you have an external resource like an .exe dependency. An example call would be `auto toolPath = findAncestorFile( getAppPath(), "external\\tools\\example.exe" )`