### PR TITLE
audio: Context::disconnectAllNodes() clears auto-pulled containers

### DIFF
--- a/src/cinder/audio/Context.cpp
+++ b/src/cinder/audio/Context.cpp
@@ -208,6 +208,11 @@ void Context::disconnectAllNodes()
 
 	for( const auto& node : mAutoPulledNodes )
 		disconnectRecursive( node, traversedNodes );
+
+	// clear out all auto-pulled nodes
+	mAutoPulledNodes.clear();
+	mAutoPullCache.clear();
+	mAutoPullCacheDirty = false;
 }
 
 void Context::setOutput( const OutputNodeRef &output )


### PR DESCRIPTION
`audio::Context::disconnectAllNodes()` clears out any auto-pulled nodes after disconnecting all nodes in the graph. Without this, switching between tests results in stray `MonitorNode`s that the user no longer has access to (they were still owned by the `audio::Context`. This assumes that if you are calling the helper `Context::disconnectAllNodes()` function, you'll have to reconnect any `MonitorNode` or other auto-pullables after.

First discovered when testing the updated AudioTests suite added in https://github.com/cinder/Cinder/pull/2335. 