### PR TITLE
Fix Windows warnings about APIENTRY from GLAD library

### DIFF
--- a/include/glad/glad.h
+++ b/include/glad/glad.h
@@ -466,15 +466,14 @@
 #ifndef __glad_h_
 #define __glad_h_
 
-#pragma push_macro("APIENTRY")
-
-
 #ifdef __gl_h_
 #error OpenGL header already included, remove this include, glad already provides it
 #endif
 #define __gl_h_
 
 #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
+#pragma push_macro("APIENTRY")
+#define GLAD_PUSHED_APIENTRY
 #define APIENTRY __stdcall
 #endif
 
@@ -14161,6 +14160,9 @@ GLAPI int GLAD_GL_S3_s3tc;
 }
 #endif
 
+#ifdef GLAD_PUSHED_APIENTRY
+#undef GLAD_PUSHED_APIENTRY
 #pragma pop_macro("APIENTRY")
+#endif // GLAD_PUSHED_APIENTRY
 
 #endif

--- a/include/glad/glad.h
+++ b/include/glad/glad.h
@@ -466,6 +466,9 @@
 #ifndef __glad_h_
 #define __glad_h_
 
+#pragma push_macro("APIENTRY")
+
+
 #ifdef __gl_h_
 #error OpenGL header already included, remove this include, glad already provides it
 #endif
@@ -14157,5 +14160,7 @@ GLAPI int GLAD_GL_S3_s3tc;
 #ifdef __cplusplus
 }
 #endif
+
+#pragma pop_macro("APIENTRY")
 
 #endif


### PR DESCRIPTION
This is an alternative to my PR #2332, which didn't actually solve the problem with these GLAD warnings with MSVC, and not as "heavy" as updating to GLAD 2:

```
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.20348.0\shared\minwindef.h(130,1): warning C4005: 'APIENTRY': macro redefinition
1>(compiling source file '../../src/cinder/gl/wrapper.cpp')
1>C:\Users\holag\Documents\Work\...\cinder\include\glad\glad.h(518,1):
1>see previous definition of 'APIENTRY'
```

This happens when building with MSVC, depending on the include order of GLAD headers vs Windows headers that define `APIENTRY`. Adding the push/pop seems like a simple solution to the problem.