### PR TITLE
ignore .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,8 @@ cinderConfig.cmake
 blocks/
 !blocks/[__AppTemplates,Box2D,Cairo,FMOD,LocationManager,MotionManager,OSC,QuickTime,TUIO]
 
-#ImGui stored settings
+# ImGui stored settings
 imgui.ini
+
+# VS code artifacts
+.vscode


### PR DESCRIPTION
Hello!

Just a small PR to ignore vscode artifacts
- I always end up adding it for my local branches
  - But then I manually commit a subset of the changes to a separate branch without it
- IMO, It would be more developer friendly to include it in the master repo as .vscode is quite popular

I kind of always wondered how nobody opened a PR/issue for this XD

Best regards