### PR TITLE
Update xcode-macOS.yml to `macos-13` runner

### DIFF
--- a/.github/workflows/xcode-macOS.yml
+++ b/.github/workflows/xcode-macOS.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-13
     strategy:
       matrix:
         config: [Debug, Release]


### PR DESCRIPTION
The previous macos-11 has been removed