### PR TITLE
Added gl::StencilOp, gl::stencilOpSeparate, gl::StencilFunc…

### DIFF
--- a/include/cinder/gl/Context.h
+++ b/include/cinder/gl/Context.h
@@ -76,6 +76,44 @@ class CI_API Context {
 #endif
 	};
 
+	struct CI_API StencilOp
+	{
+		StencilOp() = default;
+		StencilOp(GLenum stencilFail, GLenum depthFail, GLenum depthPass) : stencilFail(stencilFail), depthFail(depthFail), depthPass(depthPass) {}
+
+		bool operator==(const StencilOp& rhs) const
+		{
+			return stencilFail == rhs.stencilFail && depthFail == rhs.depthFail && depthPass == rhs.depthPass;
+		}
+		bool operator!=(const StencilOp& rhs) const
+		{
+			return !(*this == rhs);
+		}
+
+		GLenum stencilFail;
+		GLenum depthFail;
+		GLenum depthPass;
+	};
+
+	struct CI_API StencilFunc
+	{
+		StencilFunc() = default;
+		StencilFunc(GLenum func, GLint ref, GLuint mask) : func(func), ref(ref), mask(mask) {}
+
+		bool operator==(const StencilFunc& rhs) const
+		{
+			return func == rhs.func && ref == rhs.ref && mask == rhs.mask;
+		}
+		bool operator!=(const StencilFunc& rhs) const
+		{
+			return !(*this == rhs);
+		}
+
+		GLenum func;
+		GLint ref;
+		GLuint mask;
+	};
+
 	//! Creates a new OpenGL context, sharing resources and pixel format with sharedContext. This (essentially) must be done from the primary thread on MSW. ANGLE doesn't support multithreaded use. Destroys the platform Context on destruction.
 	static ContextRef	create( const Context *sharedContext );	
 	//! Creates based on an existing platform-specific GL context. \a platformContext is CGLContextObj on Mac OS X, EAGLContext on iOS, HGLRC on MSW. \a platformContext is an HDC on MSW and ignored elsewhere. Does not assume ownership of the platform's context.
@@ -192,6 +230,36 @@ class CI_API Context {
 	void					popStencilMask( bool forceRestore = false );
 	//! Returns the current stencil mask, which controls the front and back writing of individual bits in the stencil planes (front and back). 
 	glm::u8vec2				getStencilMask();
+
+	//! Set the current stencil operation, which controls the front and back stencil test actions.
+	void					stencilOp( GLenum stencilFail, GLenum depthFail, GLenum depthPass );
+	//! Set the current stencil operation, which controls the front or back stencil test actions.
+	void					stencilOpSeparate( GLenum face, GLenum stencilFail, GLenum depthFail, GLenum depthPass );
+	//! Push the current stencil operation, which controls the front and back stencil test actions.
+	void					pushStencilOp( GLenum stencilFail, GLenum depthFail, GLenum depthPass );
+	//! Push the current stencil operation, which controls the front or back stencil test actions.
+	void					pushStencilOpSeparate( GLenum face, GLenum stencilFail, GLenum depthFail, GLenum depthPass );
+	//! Pops the current stencil operation, which controls the front and back stencil test actions.
+	void					popStencilOp( bool forceRestore = false );
+	//! Pops the current stencil operation, which controls the front or back stencil test actions.
+	void					popStencilOpSeparate( GLenum face, bool forceRestore = false );
+	//! Returns the current stencil operation, which controls the front and back stencil test actions.
+	std::pair<StencilOp,StencilOp>	getStencilOp();
+
+	//! Set the current stencil function, which controls the front and back stencil test actions.
+	void 					stencilFunc( GLenum func, GLint ref, GLuint mask );
+	//! Set the current stencil function, which controls the front or back stencil test actions.
+	void 					stencilFuncSeparate( GLenum face, GLenum func, GLint ref, GLuint mask );
+	//! Push the current stencil function, which controls the front and back stencil test actions.
+	void 					pushStencilFunc( GLenum func, GLint ref, GLuint mask );
+	//! Push the current stencil function, which controls the front or back stencil test actions.
+	void 					pushStencilFuncSeparate( GLenum face, GLenum func, GLint ref, GLuint mask );
+	//! Pops the current stencil function, which controls the front and back stencil test actions.
+	void 					popStencilFunc( bool forceRestore = false );
+	//! Pops the current stencil function, which controls the front or back stencil test actions.
+	void 					popStencilFuncSeparate( GLenum face, bool forceRestore = false );
+	//! Returns the current stencil function, which controls the front and back stencil test actions.
+	std::pair<StencilFunc,StencilFunc>	getStencilFunc();
 	
 #if ! defined( CINDER_GL_ES )
 	//! Analogous to glLogicOp( \a mode ). Valid arguments are \c GL_CLEAR, \c GL_SET, \c GL_COPY, \c GL_COPY_INVERTED, \c GL_NOOP, \c GL_INVERT, \c GL_AND, \c GL_NAND, \c GL_OR, \c GL_NOR, \c GL_XOR, \c GL_EQUIV, \c GL_AND_REVERSE, \c GL_AND_INVERTED, \c GL_OR_REVERSE, or \c GL_OR_INVERTED.
@@ -559,6 +627,10 @@ class CI_API Context {
 
 	std::vector<glm::bvec4>		mColorMaskStack;
 	std::vector<glm::u8vec2>	mStencilMaskStack;
+	std::vector<StencilOp>		mStencilOpFrontStack;
+	std::vector<StencilOp>		mStencilOpBackStack;
+	std::vector<StencilFunc>	mStencilFuncFrontStack;
+	std::vector<StencilFunc>	mStencilFuncBackStack;
 
 #if ! defined( CINDER_GL_ES )
 	std::vector<GLenum>			mLogicOpStack;

--- a/include/cinder/gl/scoped.h
+++ b/include/cinder/gl/scoped.h
@@ -384,6 +384,34 @@ class ScopedStencilMask : private Noncopyable {
 	Context *mCtx;
 };
 
+//! Scopes the front and/or back stencil buffer operation
+class ScopedStencilOp : private Noncopyable {
+public:
+	//!
+	ScopedStencilOp(GLenum sfail, GLenum dpfail, GLenum dppass);
+	//! 
+	ScopedStencilOp(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass);
+	~ScopedStencilOp();
+
+private:
+	Context* mCtx;
+	GLenum mFace;
+};
+
+//! Scopes the front and/or back stencil buffer function
+class ScopedStencilFunc : private Noncopyable {
+public:
+	//!
+	ScopedStencilFunc(GLenum func, GLint ref, GLuint mask);
+	//! 
+	ScopedStencilFunc(GLenum face, GLenum func, GLint ref, GLuint mask);
+	~ScopedStencilFunc();
+
+private:
+	Context* mCtx;
+	GLenum mFace;
+};
+
 #if defined( CINDER_GL_HAS_KHR_DEBUG )
 
 //! Scopes debug group message

--- a/src/cinder/gl/Context.cpp
+++ b/src/cinder/gl/Context.cpp
@@ -93,6 +93,14 @@ Context::Context( const std::shared_ptr<PlatformData> &platformData )
 	// initial state for stencil mask is all bits enabled
 	mStencilMaskStack.emplace_back( 0xFF, 0xFF );
 
+	// initial state for stencil op is GL_KEEP, GL_KEEP, GL_KEEP
+	mStencilOpFrontStack.emplace_back(GL_KEEP, GL_KEEP, GL_KEEP);
+	mStencilOpBackStack.emplace_back(GL_KEEP, GL_KEEP, GL_KEEP);
+
+	// initial state for stencil func is GL_ALWAYS, 0, 0xFF
+	mStencilFuncFrontStack.emplace_back(GL_ALWAYS, 0, 0xFF);
+	mStencilFuncBackStack.emplace_back(GL_ALWAYS, 0, 0xFF);
+
 	// initial state for depth mask is enabled
 	mBoolStateStack[GL_DEPTH_WRITEMASK] = vector<GLboolean>();
 	mBoolStateStack[GL_DEPTH_WRITEMASK].push_back( GL_TRUE );

--- a/src/cinder/gl/scoped.cpp
+++ b/src/cinder/gl/scoped.cpp
@@ -546,6 +546,42 @@ ScopedStencilMask::~ScopedStencilMask()
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
+// ScopedStencilOp
+ScopedStencilOp::ScopedStencilOp( GLenum sfail, GLenum dpfail, GLenum dppass )
+	: ScopedStencilOp( GL_FRONT_AND_BACK, sfail, dpfail, dppass )
+{
+}
+
+ScopedStencilOp::ScopedStencilOp( GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass )
+	: mCtx( gl::context() ), mFace( face )
+{
+	mCtx->pushStencilOpSeparate( mFace, sfail, dpfail, dppass );
+}
+
+ScopedStencilOp::~ScopedStencilOp()
+{
+	mCtx->popStencilOpSeparate( mFace );
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// ScopedStencilFunc
+ScopedStencilFunc::ScopedStencilFunc( GLenum func, GLint ref, GLuint mask )
+	: ScopedStencilFunc( GL_FRONT_AND_BACK, func, ref, mask )
+{
+}
+
+ScopedStencilFunc::ScopedStencilFunc( GLenum face, GLenum func, GLint ref, GLuint mask )
+	: mCtx( gl::context() ), mFace( face )
+{
+	mCtx->pushStencilFuncSeparate( mFace, func, ref, mask );
+}
+
+ScopedStencilFunc::~ScopedStencilFunc()
+{
+	mCtx->popStencilFuncSeparate( mFace );
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
 // ScopedDebugGroup
 #if defined( CINDER_GL_HAS_KHR_DEBUG )
 ScopedDebugGroup::ScopedDebugGroup( const std::string &message )


### PR DESCRIPTION
…and gl::stencilFuncSeparate methods, as well as their push/pop/get variants, to control stencil buffer state. Also added matching gl::ScopedStencilOp and gl::ScopedStencilFunc classes.

While not many people often use the stencil buffer, in recent projects I have used it extensively for effects and path rendering. Being able to properly set and restore the stencil state comes in really handy, especially when doing nested operations.

