### PR TITLE
Added missing MouseEvent handling in ImGui_ImplCinder_MouseUp

### DIFF
--- a/src/cinder/CinderImGui.cpp
+++ b/src/cinder/CinderImGui.cpp
@@ -366,6 +366,7 @@ static void ImGui_ImplCinder_MouseUp( ci::app::MouseEvent& event )
 	io.MouseDown[0] = false;
 	io.MouseDown[1] = false;
 	io.MouseDown[2] = false;
+	event.setHandled( io.WantCaptureMouse );
 }
 static void ImGui_ImplCinder_MouseWheel( ci::app::MouseEvent& event )
 {


### PR DESCRIPTION
Current behavior prevents other parts of the app from using mouseUp events. When ImGui windows are interacted with, they shouldn't trigger mouseUp handlers elsewhere in the app.

This PR fixes that by handling the event using `io.WantCaptureMouse` in the `ImGui_ImplCinder_MouseUp` callback.