### PR TITLE
Fix keyboard event propagation when ImGui window has focus

### DIFF
--- a/src/cinder/CinderImGui.cpp
+++ b/src/cinder/CinderImGui.cpp
@@ -557,7 +557,10 @@ bool ImGui::Initialize( const ImGui::Options& options )
 	auto context = ImGui::CreateContext();
 	
 	ImGuiIO& io = ImGui::GetIO();
-	if( options.isKeyboardEnabled() ) io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard; // Enable Keyboard Controls
+	if( options.isKeyboardEnabled() ) {
+		io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard; // Enable Keyboard Controls
+		io.ConfigFlags |= ImGuiConfigFlags_NavNoCaptureKeyboard; // Don't capture keyboard when navigation is active
+	}
 	if( options.isGamepadEnabled() ) io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad; // Enable Gamepad Controls	
 	ci::app::WindowRef window = options.getWindow();
 	io.DisplaySize = ci::vec2( window->toPixels( window->getSize() ) );


### PR DESCRIPTION
When an ImGui window has focus, all keyboard events are blocked from reaching the application, preventing other keyboard shortcuts handled in the app `keyDown` from working. This occurs because keyboard navigation is enabled by default, causing ImGui to capture all keyboard input for navigation purposes.

The proposed fix with the `NavNoCaptureKeyboard` flag prevents ImGui from setting `WantCaptureKeyboard=true` when only navigation is active (not text input). This allows the event handlers to correctly propagate keyboard events to the application when ImGui doesn't actually need them for text input.