### PR TITLE
CanvasUi implementation

### DIFF
--- a/include/cinder/CanvasUi.h
+++ b/include/cinder/CanvasUi.h
@@ -1,6 +1,8 @@
 /*
- Copyright (c) 2024, The Cinder Authors
- All rights reserved.
+ Copyright (c) 2025, The Cinder Project, All rights reserved.
+ Portions copyright Paul Houx.
+
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
 
  Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  the following conditions are met:

--- a/include/cinder/CanvasUi.h
+++ b/include/cinder/CanvasUi.h
@@ -1,0 +1,333 @@
+/*
+ Copyright (c) 2024, The Cinder Authors
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+//! CanvasUi provides smooth pan and zoom interaction for 2D content, similar to image editors,
+//! drawing apps, or any application where users need to navigate around 2D content that may be
+//! larger than the screen or require detailed inspection.
+//!
+//! CanvasUi manages transformations between three coordinate spaces:
+//! - **Content space**: Your content's coordinate system (arbitrary units)
+//! - **Viewport space**: Rectangular region within window where content is displayed
+//! - **Window space**: Full application window coordinates (pixels from top-left)
+//!
+//! Content can be bounded (defined limits) or unbounded (infinite space). Default interactions
+//! include mouse drag panning, mouse wheel zooming, and keyboard shortcuts.
+
+#pragma once
+
+#include "cinder/Matrix.h"
+#include "cinder/Rect.h"
+#include "cinder/Signals.h"
+#include "cinder/app/KeyEvent.h"
+#include "cinder/app/MouseEvent.h"
+#include "cinder/app/Window.h"
+#include <optional>
+
+namespace cinder {
+
+//! 2D canvas with pan/zoom interaction controls
+//!
+//! Provides a complete 2D navigation system with smooth animations, configurable
+//! mouse/keyboard controls, and support for both bounded and unbounded content.
+class CI_API CanvasUi {
+  public:
+	// Hotkey system (uses Cinder's KeyEvent system)
+	struct HotkeyBinding {
+		int			 key;		// KeyEvent key code (KEY_0, KEY_PLUS, etc.)
+		unsigned int modifiers; // KeyEvent modifier flags (CTRL_DOWN, SHIFT_DOWN, etc.)
+		HotkeyBinding( int k, unsigned int m )
+			: key( k )
+			, modifiers( m )
+		{
+		}
+	};
+
+	// Mouse interaction system (uses Cinder's MouseEvent system)
+	struct MouseButtonBinding {
+		unsigned int button;	// MouseEvent button flags (LEFT_DOWN, RIGHT_DOWN, MIDDLE_DOWN)
+		unsigned int modifiers; // MouseEvent modifier flags (CTRL_DOWN, SHIFT_DOWN, etc.)
+		MouseButtonBinding( unsigned int b, unsigned int m )
+			: button( b )
+			, modifiers( m )
+		{
+		}
+	};
+
+	//! Default constructor, unbounded canvas, no signal connections
+	CanvasUi();
+	//! Initiates connections to \a window, unbounded canvas
+	CanvasUi( const app::WindowRef& window, int signalPriority = -1 );
+	//! Initiates connections to \a window, sets content bounds to \a bounds
+	CanvasUi( const app::WindowRef& window, const Rectf& bounds, int signalPriority = -1 );
+	~CanvasUi();
+
+	// Non-movable, non-copyable
+	CanvasUi( CanvasUi&& ) = delete;
+	CanvasUi& operator=( CanvasUi&& ) = delete;
+	CanvasUi( const CanvasUi& ) = delete;
+	CanvasUi& operator=( const CanvasUi& ) = delete;
+
+	//! Set content bounds \a bounds for bounded mode
+	void setContentBounds( const Rectf& bounds );
+	//! Enable unbounded mode (infinite content space)
+	void setUnbounded() { mCanvasBounds = std::nullopt; }
+	//! Get current content bounds (nullopt if unbounded)
+	const std::optional<Rectf>& getContentBounds() const { return mCanvasBounds; }
+	//! Check if content is bounded
+	bool isBounded() const { return mCanvasBounds.has_value(); }
+
+
+	//! Get current model matrix (content to window transform)
+	const mat4& getModelMatrix() const;
+	//! Get inverse model matrix (window to content transform)
+	const mat4& getInverseModelMatrix() const;
+	//! Get current position offset in viewport coordinates
+	vec2 getPosition() const { return mPosition; }
+	//! Get current zoom factor
+	float getZoom() const { return mZoom; }
+
+	//! Convert window coordinates to content coordinates
+	vec2 toContent( const vec2& posWindow ) const;
+	//! Convert content coordinates to window coordinates
+	vec2 toWindow( const vec2& posContent ) const;
+
+	//! Get visible content area of current viewport
+	Rectf getVisibleRect() const;
+	//! Get visible content area for specific viewport rectangle \a rectViewport
+	Rectf getVisibleRect( const Rectf& rectViewport ) const;
+
+	//! Pan by \a deltaViewport pixels in viewport coordinates (useful for keyboard navigation)
+	void panBy( const vec2& deltaViewport );
+	//! Pan to \a posViewport position in viewport coordinates
+	void panToViewportPos( const vec2& posViewport, bool disableAnimation = false );
+	//! Pan to center \a posContent in the viewport
+	void panToContentPos( const vec2& posContent, bool disableAnimation = false );
+	//! Zoom by \a factor around viewport center
+	void zoomBy( float factor, bool disableAnimation = false );
+	//! Zoom by \a factor around \a anchorWindow point (window coordinates)
+	void zoomBy( float factor, const vec2& anchorWindow, bool disableAnimation = false );
+	//! Zoom to specific \a zoom level around viewport center
+	void zoomTo( float zoom, bool disableAnimation = false );
+	//! Zoom to specific \a zoom level around \a anchorWindow point (window coordinates)
+	void zoomTo( float zoom, const vec2& anchorWindow, bool disableAnimation = false );
+
+	//! Fit all content in viewport (requires bounded content)
+	void fitAll( bool disableAnimation = false );
+	//! Fit content width to viewport width (requires bounded content)
+	void fitWidth( bool disableAnimation = false );
+	//! Fit content height to viewport height (requires bounded content)
+	void fitHeight( bool disableAnimation = false );
+	//! Fit and center rectangle \a contentRect in the viewport
+	void fitRect( const Rectf& contentRect, bool disableAnimation = false );
+	//! Zoom in by one step
+	void zoomIn( bool disableAnimation = false );
+	//! Zoom out by one step
+	void zoomOut( bool disableAnimation = false );
+
+	//! Set custom viewport \a viewport rectangle in window coordinates
+	void setCustomViewport( const Rectf& viewport );
+	//! Disable custom viewport (use full window)
+	void disableCustomViewport();
+	//! Check if custom viewport is active
+	bool hasCustomViewport() const { return mHasCustomViewport; }
+	//! Get current viewport rectangle
+	const Rectf& getViewport() const { return mViewport; }
+
+	//! Connect to \a window for automatic event handling
+	void connect( const app::WindowRef& window, int signalPriority = 0 );
+	//! Disconnect from window events
+	void disconnect();
+	//! Check if connected to a window
+	bool isConnected() const { return mWindow != nullptr; }
+
+	//! Enable or disable all interactions
+	void enable( bool enabled = true ) { mEnabled = enabled; }
+	//! Disable all interactions
+	void disable() { mEnabled = false; }
+	//! Check if interactions are enabled
+	bool isEnabled() const { return mEnabled; }
+	//! Enable or disable keyboard shortcuts
+	void setKeyboardEnabled( bool enabled ) { mKeyboardEnabled = enabled; }
+	//! Check if keyboard shortcuts are enabled
+	bool isKeyboardEnabled() const { return mKeyboardEnabled; }
+	//! Enable or disable mouse wheel zooming
+	void setMouseWheelEnabled( bool enabled ) { mMouseWheelEnabled = enabled; }
+	//! Check if mouse wheel zooming is enabled
+	bool isMouseWheelEnabled() const { return mMouseWheelEnabled; }
+
+	//! Set mouse \a buttons for panning
+	void setPanMouseButtons( const std::vector<MouseButtonBinding>& buttons );
+
+	//! Set mouse wheel zoom \a multiplier (relative to zoom factor)
+	void setMouseWheelMultiplier( float multiplier ) { mWheelMultiplier = multiplier; }
+	//! Get mouse wheel zoom multiplier
+	float getMouseWheelMultiplier() const { return mWheelMultiplier; }
+	//! Set mouse wheel direction inverted
+	void setMouseWheelInverted( bool inverted ) { mWheelInverted = inverted; }
+	//! Check if mouse wheel is inverted
+	bool isMouseWheelInverted() const { return mWheelInverted; }
+	//! Enable zoom-to-cursor behavior
+	void setZoomToCursor( bool enabled ) { mZoomToCursor = enabled; }
+	//! Check if zoom-to-cursor is enabled
+	bool isZoomToCursor() const { return mZoomToCursor; }
+	//! Enable or disable animations (when disabled, overrides all other animation settings)
+	void setAnimationEnabled( bool enabled ) { mAnimationEnabled = enabled; }
+	//! Check if animations are enabled
+	bool isAnimationEnabled() const { return mAnimationEnabled; }
+	//! Enable animations for mouse pan operations (only effective when animations are enabled)
+	void setAnimateMousePan( bool enabled ) { mAnimateMousePan = enabled; }
+	//! Check if mouse pan animations are enabled (returns false if animations are disabled)
+	bool hasAnimateMousePan() const { return mAnimationEnabled && mAnimateMousePan; }
+
+	//! Set animation \a duration in seconds
+	void setAnimationDuration( float duration ) { mAnimationDuration = glm::clamp( duration, 0.1f, 2.0f ); }
+	//! Get animation duration
+	float getAnimationDuration() const { return mAnimationDuration; }
+	//! Set animation \a easing curve power
+	void setAnimationEasing( float easing ) { mAnimationEasing = glm::clamp( easing, 1.0f, 5.0f ); }
+	//! Get animation easing curve power
+	float getAnimationEasing() const { return mAnimationEasing; }
+
+	//! Set zoom limits between \a minZoom and \a maxZoom
+	void setZoomLimits( float minZoom, float maxZoom )
+	{
+		mMinZoom = minZoom;
+		mMaxZoom = maxZoom;
+	}
+	//! Get minimum zoom limit
+	float getMinZoom() const { return mMinZoom; }
+	//! Get maximum zoom limit
+	float getMaxZoom() const { return mMaxZoom; }
+	//! Set zoom \a factor for zoom in/out (0.1 = 10% change per step). Default is 0.2.
+	void setZoomFactor( float factor ) { mZoomFactor = factor; }
+	//! Get zoom factor
+	float getZoomFactor() const { return mZoomFactor; }
+
+	//! Set \a hotkeys for zoom in
+	void setHotkeysZoomIn( const std::vector<HotkeyBinding>& hotkeys );
+	//! Set \a hotkeys for zoom out
+	void setHotkeysZoomOut( const std::vector<HotkeyBinding>& hotkeys );
+	//! Set \a hotkeys for reset zoom
+	void setHotkeysReset( const std::vector<HotkeyBinding>& hotkeys );
+
+	//! Allow panning content outside viewport bounds (auto-disables constrainZoomToContent when enabled). Default is \c false.
+	void setAllowPanOutside( bool allow );
+	//! Check if content can be panned outside viewport bounds. Default is \c false
+	bool getAllowPanOutside() const { return mAllowPanOutside; }
+	//! Prevent zooming out beyond fitAll() level (auto-disables allowPanOutside when enabled, ignored for unbounded content). Default is \c false.
+	void setConstrainZoomToContent( bool constrain );
+	//! Return if zoom is constrained to content. Default is \c false.
+	bool getConstrainZoomToContent() const { return mConstrainZoomToContent; }
+
+	//! Manual event handling (alternative to connect())
+	void mouseDown( app::MouseEvent& event );
+	void mouseUp( app::MouseEvent& event );
+	void mouseDrag( app::MouseEvent& event );
+	void mouseWheel( app::MouseEvent& event );
+	void keyDown( app::KeyEvent& event );
+	void resize( const ivec2& newSize );
+
+  private:
+	// Transform state
+	vec2				 mPosition{ 0, 0 }; // Position offset in viewport-local coordinates (relative to viewport origin)
+	float				 mZoom{ 1.0f };		// Current zoom scale factor
+	std::optional<Rectf> mCanvasBounds;		// Optional content bounds for constrained panning
+
+	// Viewport state
+	Rectf mViewport{ 0, 0, 1, 1 };	   // Current viewport in window coordinates
+	bool  mHasCustomViewport{ false }; // Whether custom viewport is set, otherwise uses full Window
+	ivec2 mWindowSize{ 1, 1 };		   // Full window size
+
+	// Cached transform matrices
+	mutable mat4 mModelMatrix;
+	mutable mat4 mInverseModelMatrix;
+	mutable bool mIsDirty{ true };
+
+	// Configuration
+	bool mEnabled{ true };
+	bool mKeyboardEnabled{ true };
+	bool mMouseWheelEnabled{ true };
+	bool mAllowPanOutside{ false };
+	bool mConstrainZoomToContent{ false };
+
+	// Mouse wheel settings
+	float mWheelMultiplier{ 1.0f }; // Multiplier relative to zoom factor (1.0 = same as zoom factor)
+	bool  mWheelInverted{ false };
+	bool  mZoomToCursor{ true };
+	bool  mAnimationEnabled{ true }; // Animation enabled by default for buttons/hotkeys
+	bool  mAnimateMousePan{ false }; // Mouse pan animation disabled by default for responsiveness
+
+	// Zoom settings
+	float mMinZoom{ 0.01f };
+	float mMaxZoom{ 100.0f };
+	float mZoomFactor{ 0.2f }; // Default 20% zoom change per step
+
+	std::vector<HotkeyBinding>		mHotkeysZoomIn;
+	std::vector<HotkeyBinding>		mHotkeysZoomOut;
+	std::vector<HotkeyBinding>		mHotkeysReset;
+	std::vector<MouseButtonBinding> mPanMouseButtons;
+
+	// Animation state
+	bool   mAnimating{ false };
+	float  mAnimationDuration{ 0.3f };		   // Duration of animation in seconds
+	float  mAnimationEasing{ 3.0f };		   // Easing power for cubic ease-out (1.0 = linear, higher = more curved)
+	float  mZoomAnimationStart{ 1.0f };		   // Starting zoom level
+	float  mZoomAnimationTarget{ 1.0f };	   // Target zoom level
+	vec2   mPositionAnimationStart{ 0.0f };	   // Starting position
+	vec2   mPositionAnimationTarget{ 0.0f };   // Target position
+	vec2   mZoomAnimationAnchor{ 0.0f };	   // Anchor point for zoom animation
+	vec2   mZoomAnimationContentPoint{ 0.0f }; // Content point under anchor at start
+	double mAnimationStartTime{ 0.0 };		   // When animation started
+	bool   mAnimatingZoom{ false };			   // Whether zoom is being animated
+	bool   mAnimatingPosition{ false };		   // Whether position is being animated
+
+	// Interaction state
+	bool  mIsDragging{ false };
+	ivec2 mDragStartPosWindow;
+	vec2  mDragStartPosition;
+	int	  mDragInitiator{ 0 }; // Which button started the drag (LEFT_DOWN, RIGHT_DOWN, or MIDDLE_DOWN)
+
+	// Connection state
+	app::WindowRef					 mWindow;
+	std::vector<signals::Connection> mConnections;
+
+
+	// Internal methods
+	void  fitWithCentering( float newZoom, bool disableAnimation = false );
+	void  zoomByStep( float factor );											// Zoom from center with constraints
+	float getEffectiveMinZoom() const;											// Get minimum zoom considering content constraint
+	void  zoomByStep( float factor, const vec2& anchorViewport );				// Zoom from specified anchor in viewport-local coordinates
+	void  setZoomAndPosition( float newZoom, const vec2& newPositionViewport ); // Helper for zoom presets, position in viewport-local coordinates
+	void  updateMatrices() const;
+	void  constrainPosition();
+	vec2  calculateConstrainedPosition( const vec2& desiredPos ) const;
+	vec2  calculateConstrainedPosition( const vec2& desiredPos, float zoom ) const;
+	void  updateViewportSize();
+	void  updateAnimation();
+	void  startZoomAnimation( float zoomFactor, const vec2& anchorViewport );					 // Anchor in viewport-local coordinates
+	void  startPositionAnimation( const vec2& targetPositionViewport );							 // Target position in viewport-local coordinates
+	void  startZoomAndPositionAnimation( float targetZoom, const vec2& targetPositionViewport ); // Target position in viewport-local coordinates
+	bool  matchesHotkey( const app::KeyEvent& event, const std::vector<HotkeyBinding>& hotkeys ) const;
+	bool  matchesPanMouseButton( const app::MouseEvent& event, const std::vector<MouseButtonBinding>& buttons ) const;
+};
+
+} // namespace cinder

--- a/include/cinder/app/MouseEvent.h
+++ b/include/cinder/app/MouseEvent.h
@@ -46,6 +46,8 @@ class CI_API MouseEvent : public Event {
 	const ivec2&	getPos() const			{ return mPos; }
 	//! Sets the coordinates of the mouse event, measured in points
 	void		setPos( const ivec2 &pos )	{ mPos = pos; }
+	//! Returns the button that initiated this event. Value will be LEFT_DOWN, RIGHT_DOWN, or MIDDLE_DOWN
+	int			getInitiator() const		{ return mInitiator; }
 	//! Returns whether the initiator for the event was the left mouse button
 	bool		isLeft() const				{ return ( mInitiator & LEFT_DOWN ) ? true : false; }
 	//! Returns whether the initiator for the event was the right mouse button
@@ -71,6 +73,7 @@ class CI_API MouseEvent : public Event {
 	//! Returns the number of detents the user has wheeled through. Positive values correspond to wheel-up and negative to wheel-down.
 	float		getWheelIncrement() const	{ return mWheelIncrement; }
 	
+	unsigned int	getModifiers() const { return mModifiers; }
 	//! Returns the platform-native modifier mask
 	uint32_t	getNativeModifiers() const	{ return mNativeModifiers; }
 

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -14,6 +14,7 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/Buffer.cpp
 	${CINDER_SRC_DIR}/cinder/Camera.cpp
 	${CINDER_SRC_DIR}/cinder/CameraUi.cpp
+	${CINDER_SRC_DIR}/cinder/CanvasUi.cpp
 	${CINDER_SRC_DIR}/cinder/Channel.cpp
 	${CINDER_SRC_DIR}/cinder/CinderAssert.cpp
 	${CINDER_SRC_DIR}/cinder/CinderMath.cpp

--- a/proj/vc2019/cinder.vcxproj
+++ b/proj/vc2019/cinder.vcxproj
@@ -754,6 +754,7 @@
     <ClCompile Include="..\..\src\cinder\Buffer.cpp" />
     <ClCompile Include="..\..\src\cinder\Camera.cpp" />
     <ClCompile Include="..\..\src\cinder\CameraUi.cpp" />
+    <ClCompile Include="..\..\src\cinder\CanvasUi.cpp" />
     <ClCompile Include="..\..\src\cinder\Capture.cpp" />
     <ClCompile Include="..\..\src\cinder\CaptureImplDirectShow.cpp" />
     <ClCompile Include="..\..\src\cinder\Channel.cpp" />
@@ -1071,6 +1072,7 @@
     <ClInclude Include="..\..\include\cinder\Base64.h" />
     <ClInclude Include="..\..\include\cinder\Breakpoint.h" />
     <ClInclude Include="..\..\include\cinder\CameraUi.h" />
+    <ClInclude Include="..\..\include\cinder\CanvasUi.h" />
     <ClInclude Include="..\..\include\cinder\CaptureImplDirectShow.h" />
     <ClInclude Include="..\..\include\cinder\CinderAssert.h" />
     <ClInclude Include="..\..\include\cinder\CinderImGui.h" />

--- a/proj/xcode/cinder.xcodeproj/project.pbxproj
+++ b/proj/xcode/cinder.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		00B729E8115DAC2B00CD71B9 /* Timer.h in Headers */ = {isa = PBXBuildFile; fileRef = 00B729E7115DAC2B00CD71B9 /* Timer.h */; };
 		00B8C3931AD582400007ADAA /* Blur.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8C3921AD582400007ADAA /* Blur.cpp */; };
 		00B8C3981AEB4F240007ADAA /* CameraUi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00B8C3971AEB4F240007ADAA /* CameraUi.cpp */; };
+		06CBD5FAE61F47CC8CB7C5A6 /* CanvasUi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 585C940D97494FD6B1641420 /* CanvasUi.cpp */; };
 		00BC898B10D2BE9400D6DC59 /* DataTarget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00BC898A10D2BE9400D6DC59 /* DataTarget.cpp */; };
 		00BC898D10D2BEA200D6DC59 /* DataTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 00BC898C10D2BEA200D6DC59 /* DataTarget.h */; };
 		00BC89F210D2EA2200D6DC59 /* ImageTargetFileQuartz.h in Headers */ = {isa = PBXBuildFile; fileRef = 00BC89F110D2EA2200D6DC59 /* ImageTargetFileQuartz.h */; };
@@ -283,6 +284,7 @@
 		00F601C819F6C9DD00C83781 /* Ubo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00F601C719F6C9DD00C83781 /* Ubo.cpp */; };
 		00F601CC19F6CA2D00C83781 /* Ubo.h in Headers */ = {isa = PBXBuildFile; fileRef = 00F601CB19F6CA2D00C83781 /* Ubo.h */; };
 		00FF554D1AEADF9C0085071E /* CameraUi.h in Headers */ = {isa = PBXBuildFile; fileRef = 00FF554C1AEADF9C0085071E /* CameraUi.h */; };
+		03B0993BC7DC49A18700235B /* CanvasUi.h in Headers */ = {isa = PBXBuildFile; fileRef = CCEA2460CD2F4C1C93972D5F /* CanvasUi.h */; };
 		00FFAED119DB5CFD0002CA8E /* ImageSourceFileRadiance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00FFAED019DB5CFD0002CA8E /* ImageSourceFileRadiance.cpp */; };
 		00FFAED519DB5D330002CA8E /* ImageSourceFileRadiance.h in Headers */ = {isa = PBXBuildFile; fileRef = 00FFAED419DB5D330002CA8E /* ImageSourceFileRadiance.h */; };
 		1116CC4D1A5F154000023856 /* Platform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1116CC4A1A5F154000023856 /* Platform.cpp */; };
@@ -1859,6 +1861,7 @@
 		00B8C3921AD582400007ADAA /* Blur.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Blur.cpp; path = ip/Blur.cpp; sourceTree = "<group>"; };
 		00B8C3961AD582DE0007ADAA /* Blur.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Blur.h; path = ip/Blur.h; sourceTree = "<group>"; };
 		00B8C3971AEB4F240007ADAA /* CameraUi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CameraUi.cpp; sourceTree = "<group>"; };
+		585C940D97494FD6B1641420 /* CanvasUi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CanvasUi.cpp; sourceTree = "<group>"; };
 		00BC898A10D2BE9400D6DC59 /* DataTarget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DataTarget.cpp; sourceTree = "<group>"; };
 		00BC898C10D2BEA200D6DC59 /* DataTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DataTarget.h; sourceTree = "<group>"; };
 		00BC89F110D2EA2200D6DC59 /* ImageTargetFileQuartz.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageTargetFileQuartz.h; sourceTree = "<group>"; };
@@ -1889,6 +1892,7 @@
 		00F601C719F6C9DD00C83781 /* Ubo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Ubo.cpp; path = gl/Ubo.cpp; sourceTree = "<group>"; };
 		00F601CB19F6CA2D00C83781 /* Ubo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Ubo.h; path = gl/Ubo.h; sourceTree = "<group>"; };
 		00FF554C1AEADF9C0085071E /* CameraUi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CameraUi.h; sourceTree = "<group>"; };
+		CCEA2460CD2F4C1C93972D5F /* CanvasUi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CanvasUi.h; sourceTree = "<group>"; };
 		00FFAED019DB5CFD0002CA8E /* ImageSourceFileRadiance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageSourceFileRadiance.cpp; sourceTree = "<group>"; };
 		00FFAED419DB5D330002CA8E /* ImageSourceFileRadiance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageSourceFileRadiance.h; sourceTree = "<group>"; };
 		0867D69BFE84028FC02AAC07 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
@@ -2684,6 +2688,7 @@
 				277C2CEE1366632B00178A29 /* Matrix44.h */,
 				003CE482242A983C007BE072 /* MediaTime.h */,
 				00FF554C1AEADF9C0085071E /* CameraUi.h */,
+				CCEA2460CD2F4C1C93972D5F /* CanvasUi.h */,
 				002DFD530FA5602900E45AE0 /* ObjLoader.h */,
 				00CFE37B113B85F60091E310 /* Path2d.h */,
 				00D2F1150F8D825C00A7189A /* Perlin.h */,
@@ -2741,6 +2746,7 @@
 				C70E1A01106AA39D00E63577 /* Buffer.cpp */,
 				00241ABC0E830DD5004D34EB /* Camera.cpp */,
 				00B8C3971AEB4F240007ADAA /* CameraUi.cpp */,
+				585C940D97494FD6B1641420 /* CanvasUi.cpp */,
 				007438400EA7924F005DD3E6 /* Capture.cpp */,
 				008CE83C0E94672E00644A05 /* Channel.cpp */,
 				111A5EF0191F722E005C3166 /* CinderAssert.cpp */,
@@ -4016,6 +4022,7 @@
 				B322C4A11DC7DC7100D2E661 /* zutil.h in Headers */,
 				27C1FE781BD0AE3400AF387F /* QuickTimeImplLegacy.h in Headers */,
 				27C1FE791BD0AE3400AF387F /* CameraUi.h in Headers */,
+				03B0993BC7DC49A18700235B /* CanvasUi.h in Headers */,
 				27C1FE7A1BD0AE3400AF387F /* Threshold.h in Headers */,
 				27C1FE7B1BD0AE3400AF387F /* Vbo.h in Headers */,
 				B322C48C1DC7DC7100D2E661 /* inftrees.h in Headers */,
@@ -4327,6 +4334,7 @@
 				B3EA40051DD0EEA900E34348 /* svmm.h in Headers */,
 				B3EA3F7E1DD0EEA900E34348 /* ftimage.h in Headers */,
 				27C1FFF41BD16D4800AF387F /* CameraUi.h in Headers */,
+				03B0993BC7DC49A18700235B /* CanvasUi.h in Headers */,
 				27C1FFF51BD16D4800AF387F /* Plane.h in Headers */,
 				27C1FFF61BD16D4800AF387F /* QuickTime.h in Headers */,
 				27C1FFF71BD16D4800AF387F /* Json.h in Headers */,
@@ -4641,6 +4649,7 @@
 				B3EA3FDF1DD0EEA900E34348 /* ftstream.h in Headers */,
 				277C2CF21366632B00178A29 /* Matrix44.h in Headers */,
 				00FF554D1AEADF9C0085071E /* CameraUi.h in Headers */,
+				03B0993BC7DC49A18700235B /* CanvasUi.h in Headers */,
 				111A5EF3191F7251005C3166 /* CinderAssert.h in Headers */,
 				B3EA3FBB1DD0EEA900E34348 /* ftwinfnt.h in Headers */,
 				005C0CE914CBB3DB00A12CD2 /* Base64.h in Headers */,
@@ -4805,6 +4814,7 @@
 				27C1001E1BD16D4800AF387F /* Ubo.cpp in Sources */,
 				27C1001F1BD16D4800AF387F /* Rand.cpp in Sources */,
 				27C100201BD16D4800AF387F /* CameraUi.cpp in Sources */,
+				06CBD5FAE61F47CC8CB7C5A6 /* CanvasUi.cpp in Sources */,
 				27C100211BD16D4800AF387F /* DelayNode.cpp in Sources */,
 				27C100221BD16D4800AF387F /* KeyEvent.cpp in Sources */,
 				27C100231BD16D4800AF387F /* Stream.cpp in Sources */,
@@ -5058,6 +5068,7 @@
 				27C1FEC81BD0AE3400AF387F /* Ubo.cpp in Sources */,
 				27C1FEC91BD0AE3400AF387F /* Rand.cpp in Sources */,
 				27C1FECA1BD0AE3400AF387F /* CameraUi.cpp in Sources */,
+				06CBD5FAE61F47CC8CB7C5A6 /* CanvasUi.cpp in Sources */,
 				27C1FECB1BD0AE3400AF387F /* DelayNode.cpp in Sources */,
 				27C1FECC1BD0AE3400AF387F /* KeyEvent.cpp in Sources */,
 				27C1FECD1BD0AE3400AF387F /* Stream.cpp in Sources */,
@@ -5487,6 +5498,7 @@
 				0003F4141992D64100647C8B /* Vao.cpp in Sources */,
 				11FD37E41A8EDB9E002B6EA9 /* Signals.cpp in Sources */,
 				00B8C3981AEB4F240007ADAA /* CameraUi.cpp in Sources */,
+				06CBD5FAE61F47CC8CB7C5A6 /* CanvasUi.cpp in Sources */,
 				B3EA40C81DD0F04700E34348 /* autofit.c in Sources */,
 				0055BE991AD099DE00813C09 /* Checkerboard.cpp in Sources */,
 				00A1140D1355369A00081873 /* priorityq.c in Sources */,

--- a/samples/CanvasUi/include/Resources.h
+++ b/samples/CanvasUi/include/Resources.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "cinder/CinderResources.h"
+
+//#define RES_MY_RES			CINDER_RESOURCE( ../resources/, image_name.png, 128, IMAGE )
+
+
+

--- a/samples/CanvasUi/proj/cmake/CMakeLists.txt
+++ b/samples/CanvasUi/proj/cmake/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required( VERSION 3.10 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE ON )
+
+project( CanvasUi )
+
+get_filename_component( CINDER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE )
+get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
+
+include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
+
+ci_make_app(
+	SOURCES     ${APP_PATH}/src/CanvasUiApp.cpp
+	CINDER_PATH ${CINDER_PATH}
+)

--- a/samples/CanvasUi/proj/vc2019/CanvasUi.sln
+++ b/samples/CanvasUi/proj/vc2019/CanvasUi.sln
@@ -1,0 +1,19 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CanvasUi", "CanvasUi.vcxproj", "{6361A52F-2C16-4CD5-8760-0CC1F632B54B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6361A52F-2C16-4CD5-8760-0CC1F632B54B}.Debug|x64.ActiveCfg = Debug|x64
+		{6361A52F-2C16-4CD5-8760-0CC1F632B54B}.Debug|x64.Build.0 = Debug|x64
+		{6361A52F-2C16-4CD5-8760-0CC1F632B54B}.Release|x64.ActiveCfg = Release|x64
+		{6361A52F-2C16-4CD5-8760-0CC1F632B54B}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/CanvasUi/proj/vc2019/CanvasUi.vcxproj
+++ b/samples/CanvasUi/proj/vc2019/CanvasUi.vcxproj
@@ -45,7 +45,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\..\include"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\include"</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -56,11 +56,11 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
-      <AdditionalIncludeDirectories>"..\..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>"..\..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\msw\$(PlatformTarget);..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -70,7 +70,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\..\include"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\include"</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader />
@@ -83,11 +83,11 @@
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
     </ProjectReference>
     <ResourceCompile>
-      <AdditionalIncludeDirectories>"..\..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\include;..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>"..\..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\lib\msw\$(PlatformTarget);..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
       <SubSystem>Windows</SubSystem>

--- a/samples/CanvasUi/proj/vc2019/CanvasUi.vcxproj
+++ b/samples/CanvasUi/proj/vc2019/CanvasUi.vcxproj
@@ -1,0 +1,113 @@
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6361A52F-2C16-4CD5-8760-0CC1F632B54B}</ProjectGuid>
+    <RootNamespace>CanvasUi</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\..\include"</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>"..\..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>"..\..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <IgnoreSpecificDefaultLibraries>LIBCMT;LIBCPMT</IgnoreSpecificDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\..\include"</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>"..\..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>"..\..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateMapFile>true</GenerateMapFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding />
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Resources.rc" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup>
+    <ClCompile Include="..\..\src\CanvasUiApp.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\Resources.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/samples/CanvasUi/proj/vc2019/CanvasUi.vcxproj.filters
+++ b/samples/CanvasUi/proj/vc2019/CanvasUi.vcxproj.filters
@@ -17,15 +17,15 @@
     <ClCompile Include="..\src\CanvasUiApp.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\CanvasUiApp.cpp">
+    <ClCompile Include="..\..\src\CanvasUiApp.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClInclude Include="..\include\Resources.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\Resources.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\Resources.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/samples/CanvasUi/proj/vc2019/CanvasUi.vcxproj.filters
+++ b/samples/CanvasUi/proj/vc2019/CanvasUi.vcxproj.filters
@@ -1,0 +1,37 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\CanvasUiApp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\CanvasUiApp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClInclude Include="..\include\Resources.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\Resources.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Resources.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/samples/CanvasUi/proj/vc2019/Resources.rc
+++ b/samples/CanvasUi/proj/vc2019/Resources.rc
@@ -1,0 +1,3 @@
+#include "../include/Resources.h"
+
+1	ICON	"..\\..\\data\\cinder_app_icon.ico"

--- a/samples/CanvasUi/proj/xcode/CanvasUi.xcodeproj/project.pbxproj
+++ b/samples/CanvasUi/proj/xcode/CanvasUi.xcodeproj/project.pbxproj
@@ -1,0 +1,340 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 44;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995591B128DF400A5C623 /* IOSurface.framework */; };
+		00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995581B128DF400A5C623 /* IOKit.framework */; };
+		006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720219952D00008149E2 /* AVFoundation.framework */; };
+		006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720319952D00008149E2 /* CoreMedia.framework */; };
+		0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0091D8F80E81B9330029341E /* OpenGL.framework */; };
+		00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784AF0FF439BC000DE1D7 /* Accelerate.framework */; };
+		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
+		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
+		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
+		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
+		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		A1B6C1234567890123456789 /* CanvasUi_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = A1B6C1224567890123456788 /* CanvasUi_Prefix.pch */; };
+		A1B6C1254567890123456790 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = A1B6C1244567890123456789 /* CinderApp.icns */; };
+		A1B6C1274567890123456792 /* CanvasUiApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1B6C1264567890123456791 /* CanvasUiApp.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		00B995591B128DF400A5C623 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		00B995581B128DF400A5C623 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		006D720219952D00008149E2 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		006D720319952D00008149E2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		0091D8F80E81B9330029341E /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
+		00B784AF0FF439BC000DE1D7 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		00B784B10FF439BC000DE1D7 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
+		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
+		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
+		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
+		8D1107320486CEB800E47090 /* CanvasUi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanvasUi.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B6C1264567890123456791 /* CanvasUiApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../src/CanvasUiApp.cpp; sourceTree = "<group>"; name = CanvasUiApp.cpp; };
+		A1B6C1244567890123456789 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../../../data/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
+		A1B6C1284567890123456793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
+		A1B6C1224567890123456788 /* CanvasUi_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = CanvasUi_Prefix.pch; sourceTree = "<group>"; name = CanvasUi_Prefix.pch; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8D11072E0486CEB800E47090 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */,
+				00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */,
+				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
+				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
+				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
+				0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */,
+				5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */,
+				5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */,
+				00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */,
+				00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */,
+				00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */,
+				00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		080E96DDFE201D6D7F000001 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				A1B6C1264567890123456791 /* CanvasUiApp.cpp */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				00B995581B128DF400A5C623 /* IOKit.framework */,
+				00B995591B128DF400A5C623 /* IOSurface.framework */,
+				006D720219952D00008149E2 /* AVFoundation.framework */,
+				006D720319952D00008149E2 /* CoreMedia.framework */,
+				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
+				00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */,
+				00B784B10FF439BC000DE1D7 /* AudioUnit.framework */,
+				00B784B20FF439BC000DE1D7 /* CoreAudio.framework */,
+				5323E6B50EAFCA7E003A9687 /* QTKit.framework */,
+				5323E6B10EAFCA74003A9687 /* CoreVideo.framework */,
+				0091D8F80E81B9330029341E /* OpenGL.framework */,
+				1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */,
+			);
+			name = "Linked Frameworks";
+			sourceTree = "<group>";
+		};
+		1058C7A2FEA54F0111CA2CBB /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				29B97324FDCFA39411CA2CEA /* AppKit.framework */,
+				29B97325FDCFA39411CA2CEA /* Foundation.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		19C28FACFE9D520D11CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8D1107320486CEB800E47090 /* CanvasUi.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		29B97314FDCFA39411CA2CEA /* CanvasUi */ = {
+			isa = PBXGroup;
+			children = (
+				01B97315FEAEA392516A2CEA /* Blocks */,
+				29B97315FDCFA39411CA2CEA /* Headers */,
+				080E96DDFE201D6D7F000001 /* Source */,
+				29B97317FDCFA39411CA2CEA /* Resources */,
+				29B97323FDCFA39411CA2CEA /* Frameworks */,
+				19C28FACFE9D520D11CA2CBB /* Products */,
+			);
+			name = CanvasUi;
+			sourceTree = "<group>";
+		};
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
+		29B97315FDCFA39411CA2CEA /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				A1B6C1224567890123456788 /* CanvasUi_Prefix.pch */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		29B97317FDCFA39411CA2CEA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				A1B6C1244567890123456789 /* CinderApp.icns */,
+				A1B6C1284567890123456793 /* Info.plist */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
+				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8D1107260486CEB800E47090 /* CanvasUi */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "CanvasUi" */;
+			buildPhases = (
+				8D1107290486CEB800E47090 /* Resources */,
+				8D11072C0486CEB800E47090 /* Sources */,
+				8D11072E0486CEB800E47090 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CanvasUi;
+			productInstallPath = "$(HOME)/Applications";
+			productName = CanvasUi;
+			productReference = 8D1107320486CEB800E47090 /* CanvasUi.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		29B97313FDCFA39411CA2CEA /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "CanvasUi" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CanvasUi */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8D1107260486CEB800E47090 /* CanvasUi */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8D1107290486CEB800E47090 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B6C1254567890123456790 /* CinderApp.icns in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8D11072C0486CEB800E47090 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B6C1274567890123456792 /* CanvasUiApp.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C01FCF4B08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = CanvasUi_Prefix.pch;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
+				PRODUCT_NAME = CanvasUi;
+				WRAPPER_EXTENSION = app;
+				SYMROOT = ./build;
+			};
+			name = Debug;
+		};
+		C01FCF4C08A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_FAST_MATH = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"NDEBUG=1",
+					"$(inherited)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = CanvasUi_Prefix.pch;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
+				PRODUCT_NAME = CanvasUi;
+				STRIP_INSTALLED_PRODUCT = YES;
+				WRAPPER_EXTENSION = app;
+				SYMROOT = ./build;
+			};
+			name = Release;
+		};
+		C01FCF4F08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				CINDER_PATH = "../../../..";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				SDKROOT = macosx;
+				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../../include";
+			};
+			name = Debug;
+		};
+		C01FCF5008A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				CINDER_PATH = "../../../..";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				SDKROOT = macosx;
+				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../../include";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "CanvasUi" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4B08A954540054247B /* Debug */,
+				C01FCF4C08A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "CanvasUi" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4F08A954540054247B /* Debug */,
+				C01FCF5008A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
+}

--- a/samples/CanvasUi/proj/xcode/CanvasUi.xcodeproj/project.pbxproj
+++ b/samples/CanvasUi/proj/xcode/CanvasUi.xcodeproj/project.pbxproj
@@ -3,12 +3,10 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995591B128DF400A5C623 /* IOSurface.framework */; };
-		00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995581B128DF400A5C623 /* IOKit.framework */; };
 		006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720219952D00008149E2 /* AVFoundation.framework */; };
 		006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720319952D00008149E2 /* CoreMedia.framework */; };
 		0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0091D8F80E81B9330029341E /* OpenGL.framework */; };
@@ -16,17 +14,16 @@
 		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995581B128DF400A5C623 /* IOKit.framework */; };
+		00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995591B128DF400A5C623 /* IOSurface.framework */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-		A1B6C1234567890123456789 /* CanvasUi_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = A1B6C1224567890123456788 /* CanvasUi_Prefix.pch */; };
 		A1B6C1254567890123456790 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = A1B6C1244567890123456789 /* CinderApp.icns */; };
 		A1B6C1274567890123456792 /* CanvasUiApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1B6C1264567890123456791 /* CanvasUiApp.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		00B995591B128DF400A5C623 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
-		00B995581B128DF400A5C623 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		006D720219952D00008149E2 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		006D720319952D00008149E2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		0091D8F80E81B9330029341E /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
@@ -34,16 +31,18 @@
 		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		00B784B10FF439BC000DE1D7 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		00B995581B128DF400A5C623 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		00B995591B128DF400A5C623 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
 		8D1107320486CEB800E47090 /* CanvasUi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanvasUi.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		A1B6C1264567890123456791 /* CanvasUiApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../src/CanvasUiApp.cpp; sourceTree = "<group>"; name = CanvasUiApp.cpp; };
-		A1B6C1244567890123456789 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../../../data/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
-		A1B6C1284567890123456793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		A1B6C1224567890123456788 /* CanvasUi_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = CanvasUi_Prefix.pch; sourceTree = "<group>"; name = CanvasUi_Prefix.pch; };
+		A1B6C1224567890123456788 /* CanvasUi_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = CanvasUi_Prefix.pch; sourceTree = "<group>"; };
+		A1B6C1244567890123456789 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../../../data/CinderApp.icns; sourceTree = "<group>"; };
+		A1B6C1264567890123456791 /* CanvasUiApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = CanvasUiApp.cpp; path = ../../src/CanvasUiApp.cpp; sourceTree = "<group>"; };
+		A1B6C1284567890123456793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +68,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
 		080E96DDFE201D6D7F000001 /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -126,13 +132,6 @@
 			name = CanvasUi;
 			sourceTree = "<group>";
 		};
-		01B97315FEAEA392516A2CEA /* Blocks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Blocks;
-			sourceTree = "<group>";
-		};
 		29B97315FDCFA39411CA2CEA /* Headers */ = {
 			isa = PBXGroup;
 			children = (
@@ -185,6 +184,8 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "CanvasUi" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -230,31 +231,33 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = CanvasUi_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = CanvasUi_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_NAME = CanvasUi;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -262,31 +265,31 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = CanvasUi_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = CanvasUi_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_NAME = CanvasUi;
 				STRIP_INSTALLED_PRODUCT = YES;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../..";
+				CINDER_PATH = ../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
@@ -299,11 +302,11 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../..";
+				CINDER_PATH = ../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";

--- a/samples/CanvasUi/proj/xcode/CanvasUi_Prefix.pch
+++ b/samples/CanvasUi/proj/xcode/CanvasUi_Prefix.pch
@@ -1,0 +1,12 @@
+#if defined( __cplusplus )
+	#include "cinder/Cinder.h"
+	
+	#include "cinder/app/App.h"
+	
+	#include "cinder/gl/gl.h"
+	
+	#include "cinder/CinderMath.h"
+	#include "cinder/Matrix.h"
+	#include "cinder/Vector.h"
+	#include "cinder/Quaternion.h"
+#endif

--- a/samples/CanvasUi/proj/xcode/Info.plist
+++ b/samples/CanvasUi/proj/xcode/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string>CinderApp.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.libcinder.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2024 __MyCompanyName__. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/samples/CanvasUi/proj/xcode/Info.plist
+++ b/samples/CanvasUi/proj/xcode/Info.plist
@@ -30,5 +30,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>

--- a/samples/CanvasUi/src/CanvasUiApp.cpp
+++ b/samples/CanvasUi/src/CanvasUiApp.cpp
@@ -1,0 +1,544 @@
+/*
+CanvasUi Sample
+
+Comprehensive demonstration of CanvasUi features including:
+- Basic pan and zoom interaction
+- Bounded vs unbounded content modes
+- Custom viewport support (restricting canvas to window regions)
+- Animation controls and settings
+- Zoom constraints and pan limitations
+- Mouse and keyboard input customization
+
+Content: 10 circles with varying polygon complexity, useful for observing 
+zoom behavior as detail changes with scale.
+
+Controls: See the ImGui panel for interactive settings and examples.
+*/
+
+#include "cinder/CanvasUi.h"
+#include "cinder/CinderImGui.h"
+#include "cinder/CinderMath.h"
+#include "cinder/app/App.h"
+#include "cinder/app/RendererGl.h"
+#include "cinder/gl/gl.h"
+
+using namespace ci;
+using namespace ci::app;
+using namespace std;
+
+class CanvasUiSampleApp : public App {
+  public:
+	void setup() override;
+	void update() override;
+	void draw() override;
+	void keyDown( KeyEvent event ) override;
+	void mouseMove( MouseEvent event ) override;
+	void resize() override;
+
+  private:
+	CanvasUi mCanvas;
+
+	// Content
+	vector<vec2> mCircleCenters;
+	vector<int>	 mCircleSides;
+	Rectf		 mContentBounds;
+
+	// UI state
+	bool				   mShowImGui{ true };
+
+	bool				   mSplitScreenMode{ false };
+
+	// Hover state
+	int mHoveredCircle{ -1 }; // Index of currently hovered circle, -1 for none
+
+	static constexpr int   NUM_CIRCLES = 10;
+	static constexpr float CIRCLE_RADIUS = 40.0f;
+
+	void generateCircles();
+	void drawContent();
+	void drawGui();
+	void updateCanvasSettings( bool bounded );
+	void updateViewportSettings();
+};
+
+void CanvasUiSampleApp::setup()
+{
+	setWindowSize( 1280, 800 );
+
+	// Setup ImGui
+	ImGui::Initialize();
+
+	// Generate circle content
+	generateCircles();
+
+	// Setup canvas, default bounded
+	mCanvas.setContentBounds( mContentBounds );
+
+	// Connect to window
+	mCanvas.connect( getWindow() );
+
+	// Setup viewport
+	updateViewportSettings();
+
+	// Initial fit
+	mCanvas.fitAll();
+}
+
+void CanvasUiSampleApp::generateCircles()
+{
+	mCircleCenters.clear();
+	mCircleSides.clear();
+
+	const float spacing = 120.0f;
+
+	for( int i = 0; i < NUM_CIRCLES; ++i ) {
+		float x = i * spacing;
+		float y = 0;
+		mCircleCenters.push_back( vec2( x, y ) );
+
+		// Simple power function: 3 to 40 sides
+		float t = i / (float)( NUM_CIRCLES - 1 );			   // 0 to 1
+		int	  sides = (int)( 3.0f + 37.0f * powf( t, 1.5f ) ); // 3 to 40
+		mCircleSides.push_back( sides );
+	}
+
+	// Calculate content bounds with padding
+	if( ! mCircleCenters.empty() ) {
+		vec2 minPos = mCircleCenters.front();
+		vec2 maxPos = mCircleCenters.back();
+
+		float padding = CIRCLE_RADIUS + 20;
+		mContentBounds = Rectf( minPos.x - padding, minPos.y - padding, maxPos.x + padding, maxPos.y + padding );
+	}
+}
+
+void CanvasUiSampleApp::update()
+{
+	// Update title with current state
+	string title = "CanvasUi Sample - ";
+	title += "Zoom: " + to_string( (int)( mCanvas.getZoom() * 100 ) ) + "% | ";
+	title += mCanvas.isBounded() ? "Bounded" : "Unbounded";
+	if( mSplitScreenMode )
+		title += " | Viewport R";
+	title += " | Press H for help";
+	getWindow()->setTitle( title );
+}
+
+void CanvasUiSampleApp::draw()
+{
+	gl::clear( Color( 0.2f, 0.2f, 0.25f ) );
+
+	// In split-screen mode, draw different content on left half
+	if( mSplitScreenMode ) {
+		// Draw solid color background on left half
+		Rectf			leftHalf( 0, 0, getWindowWidth() * 0.5f, (float)getWindowHeight() );
+		gl::ScopedColor leftColor( Color( 0.3f, 0.4f, 0.6f ) );
+		gl::drawSolidRect( leftHalf );
+	}
+
+	// Apply canvas transform and draw content with scissor test for viewport
+	if( mCanvas.hasCustomViewport() ) {
+		Rectf viewport = mCanvas.getViewport();
+		// Convert from Cinder coordinates (top-left origin) to OpenGL coordinates (bottom-left origin)
+		int					  glY = getWindowHeight() - (int)viewport.y2;
+		gl::ScopedScissor	  scissor( (int)viewport.x1, glY, (int)viewport.getWidth(), (int)viewport.getHeight() );
+		gl::ScopedModelMatrix scpMatrix( mCanvas.getModelMatrix() );
+		drawContent();
+	}
+	else {
+		gl::ScopedModelMatrix scpMatrix( mCanvas.getModelMatrix() );
+		drawContent();
+	}
+
+	// Draw ImGui panel
+	if( mShowImGui )
+		drawGui();
+}
+
+void CanvasUiSampleApp::drawContent()
+{
+	// Draw content bounds if bounded (shows the defined canvas area)
+	if( mCanvas.isBounded() ) {
+		gl::ScopedColor scopedBg( ColorA( 0.1f, 0.1f, 0.1f, 0.3f ) );
+		gl::drawSolidRect( mContentBounds );
+
+		gl::ScopedColor scopedBorder( Color( 0.5f, 0.5f, 0.6f ) );
+		gl::drawStrokedRect( mContentBounds, 2.0f );
+	}
+
+	// Draw grid for reference (helps visualize coordinate system and zoom level)
+	gl::ScopedColor scopedGrid( ColorA( 0.4f, 0.4f, 0.4f, 0.3f ) );
+	const float		gridSpacing = 50.0f; // Grid lines every 50 content units
+
+	// Only draw grid within reasonable bounds to avoid performance issues
+	Rectf drawBounds = mCanvas.isBounded() ? mContentBounds : Rectf( -500, -300, 1500, 300 );
+
+	// Vertical grid lines
+	for( float x = floor( drawBounds.x1 / gridSpacing ) * gridSpacing; x <= drawBounds.x2; x += gridSpacing ) {
+		gl::drawLine( vec2( x, drawBounds.y1 ), vec2( x, drawBounds.y2 ) );
+	}
+
+	// Horizontal grid lines
+	for( float y = floor( drawBounds.y1 / gridSpacing ) * gridSpacing; y <= drawBounds.y2; y += gridSpacing ) {
+		gl::drawLine( vec2( drawBounds.x1, y ), vec2( drawBounds.x2, y ) );
+	}
+
+	// Draw the main demo: circles with increasing subdivision
+	// This demonstrates how geometric detail becomes visible/invisible at different zoom levels
+	for( int i = 0; i < mCircleCenters.size(); ++i ) {
+		vec2 center = mCircleCenters[i];
+		int	 sides = mCircleSides[i];
+
+		// Color based on polygon complexity (3 sides = red, 200 sides = purple)
+		float hue = i / (float)mCircleCenters.size();
+		Color fillColor = Color( CM_HSV, hue, 0.8f, 0.9f );
+
+		// Each circle rotates slowly - rotation speed varies by complexity
+		float rotationSpeed = 0.1f + ( i * 0.05f ); // Faster rotation for more complex shapes
+		float rotation = (float)getElapsedSeconds() * rotationSpeed;
+
+		// Apply rotation transform for this circle
+		gl::ScopedModelMatrix scpMatrix;
+		gl::translate( center );
+		gl::rotate( rotation );
+
+		// Draw filled circle using simple Cinder functions
+		{
+			gl::ScopedColor scopedColor( fillColor );
+			gl::drawSolidCircle( vec2( 0 ), CIRCLE_RADIUS, sides ); // Use sides parameter for subdivision
+		}
+
+		// Draw outline - brighter version of fill color for normal circles, special for hovered
+		{
+			Color outlineColor;
+			float strokeWidth = 2.0f;
+
+			if( i == mHoveredCircle ) {
+				// Highlighted circle gets bright white outline and thicker stroke
+				outlineColor = Color::white();
+				strokeWidth = 4.0f;
+			}
+			else {
+				// Normal circles get brighter version of their fill color
+				outlineColor = Color( CM_HSV, hue, 0.6f, 1.0f ); // Same hue, less saturation, full brightness
+			}
+
+			gl::ScopedColor scopedOutline( outlineColor );
+			gl::drawStrokedCircle( vec2( 0 ), CIRCLE_RADIUS, strokeWidth, sides ); // Same subdivision for outline
+		}
+	}
+
+	// Draw coordinate axes at origin (helps understand the coordinate system)
+	gl::ScopedColor scopedAxes( Color( 0.7f, 0.7f, 0.7f ) );
+	gl::drawLine( vec2( -30, 0 ), vec2( 30, 0 ) ); // X axis (horizontal)
+	gl::drawLine( vec2( 0, -30 ), vec2( 0, 30 ) ); // Y axis (vertical)
+}
+
+void CanvasUiSampleApp::drawGui()
+{
+	ImGui::ScopedWindow window( "CanvasUi Controls" );
+
+	// === STATUS (Always Visible) ===
+	ImGui::Text( "Current Zoom: %.1f%%", mCanvas.getZoom() * 100.0f );
+	Rectf visibleRect = mCanvas.getVisibleRect();
+	ImGui::Text( "Visible: (%.0f,%.0f) to (%.0f,%.0f)", visibleRect.x1, visibleRect.y1, visibleRect.x2, visibleRect.y2 );
+	if( mHoveredCircle >= 0 ) {
+		ImGui::Text( "Hovered: Circle #%d (%d sides)", (mHoveredCircle+1), mCircleSides[mHoveredCircle] );
+	}
+	else {
+		ImGui::Text( "Hovered: None" );
+	}
+	ImGui::Separator();
+
+	// === CONTENT MODE ===
+	if( ImGui::CollapsingHeader( "Content Mode" ) ) {
+		bool isBounded = mCanvas.isBounded();
+		if( ImGui::Checkbox( "Bounded Canvas", &isBounded ) )
+			updateCanvasSettings( isBounded );
+		if( ImGui::IsItemHovered() )
+			ImGui::SetTooltip( "Bounded: Content has defined limits\nUnbounded: Infinite scrollable canvas" );
+		
+		ImGui::SameLine();
+		ImGui::Text( mCanvas.isBounded() ? "(Content has limits)" : "(Infinite canvas)" );
+
+		// Viewport demo
+		bool wasSplitScreen = mSplitScreenMode;
+		ImGui::Checkbox( "Viewport Right Half Only", &mSplitScreenMode );
+		if( mSplitScreenMode != wasSplitScreen ) {
+			updateViewportSettings();
+		}
+		if( ImGui::IsItemHovered() ) {
+			ImGui::SetTooltip( "Demonstrates that CanvasUi can work\nwith a custom viewport area" );
+		}
+	}
+
+	// === NAVIGATION ===
+	if( ImGui::CollapsingHeader( "Navigation", ImGuiTreeNodeFlags_DefaultOpen ) ) {
+		// Fit operations (bounded content only)
+		if( mCanvas.isBounded() ) {
+			if( ImGui::Button( "Fit All" ) ) mCanvas.fitAll();
+			ImGui::SameLine();
+			if( ImGui::Button( "Fit Width" ) ) mCanvas.fitWidth(); 
+			ImGui::SameLine();
+			if( ImGui::Button( "Fit Height" ) ) mCanvas.fitHeight();
+		}
+		else {
+			ImGui::TextDisabled( "Fit operations require bounded content" );
+		}
+		
+		// Always available operations
+		ImGui::SameLine();
+		if( ImGui::Button( "Zoom In" ) ) mCanvas.zoomIn();
+		ImGui::SameLine();
+		if( ImGui::Button( "Zoom Out" ) ) mCanvas.zoomOut();
+		ImGui::SameLine();
+		
+		// Demo operations
+		if( mCircleCenters.size() > 3 ) {
+			if( ImGui::Button( "Frame Circle #4" ) ) {
+				vec2 center = mCircleCenters[3];
+				Rectf circleRect( center - vec2( CIRCLE_RADIUS ), center + vec2( CIRCLE_RADIUS ) );
+				mCanvas.fitRect( circleRect );
+			}
+			ImGui::SameLine();
+			if( ImGui::Button( "Pan to Circle #5" ) && mCircleCenters.size() > 4 ) {
+				mCanvas.panToContentPos( mCircleCenters[4] );
+			}
+		}
+	}
+
+	// === INPUT SETTINGS ===
+	if( ImGui::CollapsingHeader( "Input Settings" ) ) {
+		bool enabled = mCanvas.isEnabled();
+		if( ImGui::Checkbox( "Canvas Enabled", &enabled ) )
+			mCanvas.enable( enabled );
+
+		bool keyboardEnabled = mCanvas.isKeyboardEnabled();
+		if( ImGui::Checkbox( "Keyboard Shortcuts", &keyboardEnabled ) )
+			mCanvas.setKeyboardEnabled( keyboardEnabled );
+
+		bool mouseWheelEnabled = mCanvas.isMouseWheelEnabled();
+		if( ImGui::Checkbox( "Mouse Wheel Zoom", &mouseWheelEnabled ) )
+			mCanvas.setMouseWheelEnabled( mouseWheelEnabled );
+			
+		ImGui::Separator();
+		ImGui::Text( "Mouse: Left/Middle drag = pan, Wheel = zoom" );
+		ImGui::Text( "Keys: Ctrl+ (0=reset, +/- =zoom)" );
+	}
+
+	// === BEHAVIOR SETTINGS ===
+	if( ImGui::CollapsingHeader( "Behavior Settings" ) ) {
+		// Animation settings
+		bool animationEnabled = mCanvas.isAnimationEnabled();
+		if( ImGui::Checkbox( "Enable Animations", &animationEnabled ) ) {
+			mCanvas.setAnimationEnabled( animationEnabled );
+			mCanvas.connect( getWindow() );
+		}
+		if( ImGui::IsItemHovered() ) {
+			ImGui::SetTooltip( "Master animation toggle - when disabled, overrides all other animation settings" );
+		}
+		
+		if( animationEnabled ) {
+			ImGui::SameLine();
+			bool animateMousePan = mCanvas.hasAnimateMousePan();
+			if( ImGui::Checkbox( "Animate Mouse Pan", &animateMousePan ) ) {
+				mCanvas.setAnimateMousePan( animateMousePan );
+			}
+			if( ImGui::IsItemHovered() ) {
+				ImGui::SetTooltip( "Animate mouse drag operations (only effective when animations are enabled)" );
+			}
+			
+			float duration = mCanvas.getAnimationDuration();
+			if( ImGui::SliderFloat( "Animation Duration", &duration, 0.1f, 2.0f, "%.1fs" ) ) {
+				mCanvas.setAnimationDuration( duration );
+			}
+			if( ImGui::IsItemHovered() ) {
+				ImGui::SetTooltip( "How long animations take to complete" );
+			}
+			
+			float easing = mCanvas.getAnimationEasing();
+			if( ImGui::SliderFloat( "Animation Easing", &easing, 1.0f, 5.0f, "%.1f" ) ) {
+				mCanvas.setAnimationEasing( easing );
+			}
+			if( ImGui::IsItemHovered() ) {
+				ImGui::SetTooltip( "Animation curve steepness\n1.0 = linear, higher = more curved ease-out" );
+			}
+		}
+		else {
+			ImGui::TextDisabled( "Animation settings disabled" );
+		}
+		
+		ImGui::Separator();
+		
+		// Zoom settings
+		float zoomFactor = mCanvas.getZoomFactor();
+		if( ImGui::SliderFloat( "Zoom Factor", &zoomFactor, 0.05f, 2.0f, "%.2f" ) ) {
+			mCanvas.setZoomFactor( zoomFactor );
+		}
+		if( ImGui::IsItemHovered() ) {
+			ImGui::SetTooltip( "Controls zoom in/out step size (default: 0.1)" );
+		}
+		
+		float minZoom = mCanvas.getMinZoom();
+		float maxZoom = mCanvas.getMaxZoom();
+		if( ImGui::SliderFloat( "Min Zoom", &minZoom, 0.01f, 1.0f, "%.2f" ) ) {
+			mCanvas.setZoomLimits( minZoom, maxZoom );
+		}
+		if( ImGui::SliderFloat( "Max Zoom", &maxZoom, 1.0f, 50.0f, "%.1f" ) ) {
+			mCanvas.setZoomLimits( minZoom, maxZoom );
+		}
+		
+		ImGui::Separator();
+		
+		// Mouse wheel settings
+		bool zoomToCursor = mCanvas.isZoomToCursor();
+		if( ImGui::Checkbox( "Zoom to Cursor", &zoomToCursor ) ) {
+			mCanvas.setZoomToCursor( zoomToCursor );
+		}
+		
+		ImGui::SameLine();
+		bool inverted = mCanvas.isMouseWheelInverted();
+		if( ImGui::Checkbox( "Invert Wheel", &inverted ) ) {
+			mCanvas.setMouseWheelInverted( inverted );
+		}
+		
+		float multiplier = mCanvas.getMouseWheelMultiplier();
+		if( ImGui::SliderFloat( "Wheel Speed", &multiplier, 0.1f, 5.0f, "%.1f" ) ) {
+			mCanvas.setMouseWheelMultiplier( multiplier );
+		}
+		if( ImGui::IsItemHovered() ) {
+			ImGui::SetTooltip( "Multiplier on zoom factor for mouse wheel" );
+		}
+		
+		// Bounded canvas behavior (only show if bounded)
+		if( mCanvas.isBounded() ) {
+			ImGui::Separator();
+			ImGui::Text( "Bounded Canvas:" );
+			
+			bool allowPanOutside = mCanvas.getAllowPanOutside();
+			if( ImGui::Checkbox( "Allow Pan Outside", &allowPanOutside ) ) {
+				mCanvas.setAllowPanOutside( allowPanOutside );
+			}
+			if( ImGui::IsItemHovered() ) {
+				ImGui::SetTooltip( "Whether user can pan content outside viewport bounds" );
+			}
+			
+			bool constrainZoomToContent = mCanvas.getConstrainZoomToContent();
+			if( ImGui::Checkbox( "Constrain Zoom to Content", &constrainZoomToContent ) ) {
+				mCanvas.setConstrainZoomToContent( constrainZoomToContent );
+			}
+			if( ImGui::IsItemHovered() ) {
+				ImGui::SetTooltip( "Prevent zooming out beyond the point where content fits entirely in viewport" );
+			}
+			
+		}
+	}
+
+	// === HELP & EXAMPLES ===
+	if( ImGui::CollapsingHeader( "Help & Examples" ) ) {
+		ImGui::Text( "Application Keys:" );
+		ImGui::Text( "• Ctrl+G: Toggle this GUI panel" );
+		ImGui::Text( "• Ctrl+Q: Quit" );
+		
+		ImGui::Separator();
+		
+		ImGui::Text( "Input Customization Examples:" );
+		if( ImGui::Button( "Right-Only Pan" ) ) {
+			mCanvas.setPanMouseButtons( { { app::MouseEvent::RIGHT_DOWN, 0 } } );
+		}
+		ImGui::SameLine();
+		if( ImGui::Button( "Left+Shift Pan" ) ) {
+			mCanvas.setPanMouseButtons( { { app::MouseEvent::LEFT_DOWN, app::MouseEvent::SHIFT_DOWN } } );
+		}
+		ImGui::SameLine();
+		if( ImGui::Button( "Reset Mouse" ) ) {
+			mCanvas.setPanMouseButtons( { { app::MouseEvent::LEFT_DOWN, app::MouseEvent::ALT_DOWN }, { app::MouseEvent::MIDDLE_DOWN, 0 }, { app::MouseEvent::RIGHT_DOWN, 0 } } );
+		}
+
+		if( ImGui::Button( "F1=Zoom In" ) ) {
+			mCanvas.setHotkeysZoomIn( { { app::KeyEvent::KEY_F1, 0 } } );
+		}
+		ImGui::SameLine();
+		if( ImGui::Button( "Space=Reset" ) ) {
+			mCanvas.setHotkeysReset( { { app::KeyEvent::KEY_SPACE, 0 } } );
+		}
+		ImGui::SameLine();
+		if( ImGui::Button( "Reset Keys" ) ) {
+			mCanvas.setHotkeysZoomIn( { { app::KeyEvent::KEY_PLUS, app::KeyEvent::ACCEL_DOWN }, { app::KeyEvent::KEY_EQUALS, app::KeyEvent::ACCEL_DOWN } } );
+			mCanvas.setHotkeysZoomOut( { { app::KeyEvent::KEY_MINUS, app::KeyEvent::ACCEL_DOWN } } );
+			mCanvas.setHotkeysReset( { { app::KeyEvent::KEY_0, app::KeyEvent::ACCEL_DOWN } } );
+		}
+	}
+}
+
+void CanvasUiSampleApp::keyDown( KeyEvent event )
+{
+	switch( event.getCode() ) {
+		case KeyEvent::KEY_g:
+			mShowImGui = ! mShowImGui;
+			event.setHandled();
+			break;
+		case KeyEvent::KEY_q:
+			quit();
+			break;
+	}
+}
+
+void CanvasUiSampleApp::updateCanvasSettings( bool bounded )
+{
+	if( bounded )
+		mCanvas.setContentBounds( mContentBounds );
+	else
+		mCanvas.setUnbounded();
+
+	updateViewportSettings();
+}
+
+void CanvasUiSampleApp::updateViewportSettings()
+{
+	if( mSplitScreenMode ) {
+		// Set CanvasUi to operate only in right half of window
+		float windowWidth = (float)getWindowWidth();
+		float windowHeight = (float)getWindowHeight();
+		Rectf rightHalf( windowWidth * 0.5f, 0, windowWidth, windowHeight );
+		mCanvas.setCustomViewport( rightHalf );
+	}
+	else {
+		// Use full window
+		mCanvas.disableCustomViewport();
+	}
+}
+
+void CanvasUiSampleApp::mouseMove( MouseEvent event )
+{
+	// Check if mouse is within CanvasUi viewport
+	vec2 mousePos = vec2( event.getPos() );
+	if( ! mCanvas.getViewport().contains( mousePos ) ) {
+		mHoveredCircle = -1; // Clear hover when outside viewport
+		return;
+	}
+
+	vec2 contentPos = mCanvas.toContent( event.getPos() );
+
+	// Hit-test against all circles
+	mHoveredCircle = -1;
+
+	for( int i = 0; i < mCircleCenters.size(); ++i ) {
+		vec2  center = mCircleCenters[i];
+		float distance = glm::distance( contentPos, center );
+
+		// Perfect circle hit test
+		if( distance <= CIRCLE_RADIUS ) {
+			mHoveredCircle = i;
+			break; // Take the first hit (could prioritize by z-order if needed)
+		}
+	}
+}
+
+void CanvasUiSampleApp::resize()
+{
+	// Update viewport settings when window is resized
+	updateViewportSettings();
+}
+
+CINDER_APP( CanvasUiSampleApp, RendererGl( RendererGl::Options().msaa( 16 ) ) )

--- a/samples/CanvasUiMinimap/include/Resources.h
+++ b/samples/CanvasUiMinimap/include/Resources.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "cinder/CinderResources.h"
+
+//#define RES_MY_RES			CINDER_RESOURCE( ../resources/, image_name.png, 128, IMAGE )
+
+

--- a/samples/CanvasUiMinimap/proj/cmake/CMakeLists.txt
+++ b/samples/CanvasUiMinimap/proj/cmake/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required( VERSION 3.10 FATAL_ERROR )
+set( CMAKE_VERBOSE_MAKEFILE ON )
+
+project( CanvasUiMinimap )
+
+get_filename_component( CINDER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE )
+get_filename_component( APP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../" ABSOLUTE )
+
+include( "${CINDER_PATH}/proj/cmake/modules/cinderMakeApp.cmake" )
+
+ci_make_app(
+	SOURCES     ${APP_PATH}/src/CanvasUiMinimapApp.cpp
+	CINDER_PATH ${CINDER_PATH}
+)

--- a/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.sln
+++ b/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.sln
@@ -1,0 +1,19 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CanvasUiMinimap", "CanvasUiMinimap.vcxproj", "{6361A52F-2C16-4CD5-8760-0CC1F632B54B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6361A52F-2C16-4CD5-8760-0CC1F632B54B}.Debug|x64.ActiveCfg = Debug|x64
+		{6361A52F-2C16-4CD5-8760-0CC1F632B54B}.Debug|x64.Build.0 = Debug|x64
+		{6361A52F-2C16-4CD5-8760-0CC1F632B54B}.Release|x64.ActiveCfg = Release|x64
+		{6361A52F-2C16-4CD5-8760-0CC1F632B54B}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.vcxproj
+++ b/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.vcxproj
@@ -1,0 +1,113 @@
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6361A52F-2C16-4CD5-8760-0CC1F632B54B}</ProjectGuid>
+    <RootNamespace>CanvasUiMinimap</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\..\include"</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>"..\..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>"..\..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+      <IgnoreSpecificDefaultLibraries>LIBCMT;LIBCPMT</IgnoreSpecificDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\..\include"</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>"..\..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>"..\..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateMapFile>true</GenerateMapFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding />
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention />
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Resources.rc" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup />
+  <ItemGroup>
+    <ClCompile Include="..\..\src\CanvasUiMinimapApp.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\Resources.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.vcxproj
+++ b/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.vcxproj
@@ -45,7 +45,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\..\include"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\include"</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -56,11 +56,11 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
-      <AdditionalIncludeDirectories>"..\..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>"..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>"..\..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>"..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -70,7 +70,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\..\include"</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;"..\..\..\..\include"</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_WINDOWS;NOMINMAX;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader />
@@ -83,11 +83,11 @@
       <LinkLibraryDependencies>true</LinkLibraryDependencies>
     </ProjectReference>
     <ResourceCompile>
-      <AdditionalIncludeDirectories>"..\..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>"..\..\..\..\include";..\..\include</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>cinder.lib;OpenGL32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>"..\..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>"..\..\..\..\lib\msw\$(PlatformTarget)";"..\..\..\..\lib\msw\$(PlatformTarget)\$(Configuration)\$(PlatformToolset)"</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
       <SubSystem>Windows</SubSystem>

--- a/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.vcxproj.filters
+++ b/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.vcxproj.filters
@@ -1,0 +1,31 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\CanvasUiMinimapApp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\Resources.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Resources.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
+  </ItemGroup>
+</Project>

--- a/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.vcxproj.filters
+++ b/samples/CanvasUiMinimap/proj/vc2019/CanvasUiMinimap.vcxproj.filters
@@ -14,12 +14,12 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\src\CanvasUiMinimapApp.cpp">
+    <ClCompile Include="..\..\src\CanvasUiMinimapApp.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\include\Resources.h">
+    <ClInclude Include="..\..\include\Resources.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/samples/CanvasUiMinimap/proj/vc2019/Resources.rc
+++ b/samples/CanvasUiMinimap/proj/vc2019/Resources.rc
@@ -1,0 +1,3 @@
+#include "../include/Resources.h"
+
+1	ICON	"..\\..\\data\\cinder_app_icon.ico"

--- a/samples/CanvasUiMinimap/proj/xcode/CanvasUiMinimap.xcodeproj/project.pbxproj
+++ b/samples/CanvasUiMinimap/proj/xcode/CanvasUiMinimap.xcodeproj/project.pbxproj
@@ -3,12 +3,10 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995591B128DF400A5C623 /* IOSurface.framework */; };
-		00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995581B128DF400A5C623 /* IOKit.framework */; };
 		006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720219952D00008149E2 /* AVFoundation.framework */; };
 		006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720319952D00008149E2 /* CoreMedia.framework */; };
 		0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0091D8F80E81B9330029341E /* OpenGL.framework */; };
@@ -16,17 +14,16 @@
 		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995581B128DF400A5C623 /* IOKit.framework */; };
+		00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995591B128DF400A5C623 /* IOSurface.framework */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-		B2C7D1234567890123456789 /* CanvasUiMinimap_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = B2C7D1224567890123456788 /* CanvasUiMinimap_Prefix.pch */; };
 		B2C7D1254567890123456790 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = B2C7D1244567890123456789 /* CinderApp.icns */; };
 		B2C7D1274567890123456792 /* CanvasUiMinimapApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B2C7D1264567890123456791 /* CanvasUiMinimapApp.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		00B995591B128DF400A5C623 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
-		00B995581B128DF400A5C623 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		006D720219952D00008149E2 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		006D720319952D00008149E2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		0091D8F80E81B9330029341E /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
@@ -34,16 +31,18 @@
 		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		00B784B10FF439BC000DE1D7 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		00B995581B128DF400A5C623 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		00B995591B128DF400A5C623 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
 		8D1107320486CEB800E47090 /* CanvasUiMinimap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanvasUiMinimap.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		B2C7D1264567890123456791 /* CanvasUiMinimapApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../src/CanvasUiMinimapApp.cpp; sourceTree = "<group>"; name = CanvasUiMinimapApp.cpp; };
-		B2C7D1244567890123456789 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../../../data/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
-		B2C7D1284567890123456793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		B2C7D1224567890123456788 /* CanvasUiMinimap_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = CanvasUiMinimap_Prefix.pch; sourceTree = "<group>"; name = CanvasUiMinimap_Prefix.pch; };
+		B2C7D1224567890123456788 /* CanvasUiMinimap_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = CanvasUiMinimap_Prefix.pch; sourceTree = "<group>"; };
+		B2C7D1244567890123456789 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../../../data/CinderApp.icns; sourceTree = "<group>"; };
+		B2C7D1264567890123456791 /* CanvasUiMinimapApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = CanvasUiMinimapApp.cpp; path = ../../src/CanvasUiMinimapApp.cpp; sourceTree = "<group>"; };
+		B2C7D1284567890123456793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +68,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
 		080E96DDFE201D6D7F000001 /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -126,13 +132,6 @@
 			name = CanvasUiMinimap;
 			sourceTree = "<group>";
 		};
-		01B97315FEAEA392516A2CEA /* Blocks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Blocks;
-			sourceTree = "<group>";
-		};
 		29B97315FDCFA39411CA2CEA /* Headers */ = {
 			isa = PBXGroup;
 			children = (
@@ -185,6 +184,8 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "CanvasUiMinimap" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -230,31 +231,33 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = CanvasUiMinimap_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = CanvasUiMinimap_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_NAME = CanvasUiMinimap;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -262,31 +265,31 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = CanvasUiMinimap_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = CanvasUiMinimap_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
 				PRODUCT_NAME = CanvasUiMinimap;
 				STRIP_INSTALLED_PRODUCT = YES;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../..";
+				CINDER_PATH = ../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
@@ -299,11 +302,11 @@
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../..";
+				CINDER_PATH = ../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";

--- a/samples/CanvasUiMinimap/proj/xcode/CanvasUiMinimap.xcodeproj/project.pbxproj
+++ b/samples/CanvasUiMinimap/proj/xcode/CanvasUiMinimap.xcodeproj/project.pbxproj
@@ -1,0 +1,340 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 44;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995591B128DF400A5C623 /* IOSurface.framework */; };
+		00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B995581B128DF400A5C623 /* IOKit.framework */; };
+		006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720219952D00008149E2 /* AVFoundation.framework */; };
+		006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 006D720319952D00008149E2 /* CoreMedia.framework */; };
+		0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0091D8F80E81B9330029341E /* OpenGL.framework */; };
+		00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784AF0FF439BC000DE1D7 /* Accelerate.framework */; };
+		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
+		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
+		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
+		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
+		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		B2C7D1234567890123456789 /* CanvasUiMinimap_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = B2C7D1224567890123456788 /* CanvasUiMinimap_Prefix.pch */; };
+		B2C7D1254567890123456790 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = B2C7D1244567890123456789 /* CinderApp.icns */; };
+		B2C7D1274567890123456792 /* CanvasUiMinimapApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B2C7D1264567890123456791 /* CanvasUiMinimapApp.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		00B995591B128DF400A5C623 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		00B995581B128DF400A5C623 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		006D720219952D00008149E2 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		006D720319952D00008149E2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		0091D8F80E81B9330029341E /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
+		00B784AF0FF439BC000DE1D7 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		00B784B10FF439BC000DE1D7 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
+		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
+		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
+		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
+		8D1107320486CEB800E47090 /* CanvasUiMinimap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CanvasUiMinimap.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B2C7D1264567890123456791 /* CanvasUiMinimapApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../src/CanvasUiMinimapApp.cpp; sourceTree = "<group>"; name = CanvasUiMinimapApp.cpp; };
+		B2C7D1244567890123456789 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../../../data/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
+		B2C7D1284567890123456793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
+		B2C7D1224567890123456788 /* CanvasUiMinimap_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = CanvasUiMinimap_Prefix.pch; sourceTree = "<group>"; name = CanvasUiMinimap_Prefix.pch; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8D11072E0486CEB800E47090 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				00B9955B1B128DF400A5C623 /* IOSurface.framework in Frameworks */,
+				00B9955A1B128DF400A5C623 /* IOKit.framework in Frameworks */,
+				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
+				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
+				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
+				0091D8F90E81B9330029341E /* OpenGL.framework in Frameworks */,
+				5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */,
+				5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */,
+				00B784B30FF439BC000DE1D7 /* Accelerate.framework in Frameworks */,
+				00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */,
+				00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */,
+				00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		080E96DDFE201D6D7F000001 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				B2C7D1264567890123456791 /* CanvasUiMinimapApp.cpp */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				00B995581B128DF400A5C623 /* IOKit.framework */,
+				00B995591B128DF400A5C623 /* IOSurface.framework */,
+				006D720219952D00008149E2 /* AVFoundation.framework */,
+				006D720319952D00008149E2 /* CoreMedia.framework */,
+				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
+				00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */,
+				00B784B10FF439BC000DE1D7 /* AudioUnit.framework */,
+				00B784B20FF439BC000DE1D7 /* CoreAudio.framework */,
+				5323E6B50EAFCA7E003A9687 /* QTKit.framework */,
+				5323E6B10EAFCA74003A9687 /* CoreVideo.framework */,
+				0091D8F80E81B9330029341E /* OpenGL.framework */,
+				1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */,
+			);
+			name = "Linked Frameworks";
+			sourceTree = "<group>";
+		};
+		1058C7A2FEA54F0111CA2CBB /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				29B97324FDCFA39411CA2CEA /* AppKit.framework */,
+				29B97325FDCFA39411CA2CEA /* Foundation.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		19C28FACFE9D520D11CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8D1107320486CEB800E47090 /* CanvasUiMinimap.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		29B97314FDCFA39411CA2CEA /* CanvasUiMinimap */ = {
+			isa = PBXGroup;
+			children = (
+				01B97315FEAEA392516A2CEA /* Blocks */,
+				29B97315FDCFA39411CA2CEA /* Headers */,
+				080E96DDFE201D6D7F000001 /* Source */,
+				29B97317FDCFA39411CA2CEA /* Resources */,
+				29B97323FDCFA39411CA2CEA /* Frameworks */,
+				19C28FACFE9D520D11CA2CBB /* Products */,
+			);
+			name = CanvasUiMinimap;
+			sourceTree = "<group>";
+		};
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
+		29B97315FDCFA39411CA2CEA /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				B2C7D1224567890123456788 /* CanvasUiMinimap_Prefix.pch */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		29B97317FDCFA39411CA2CEA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B2C7D1244567890123456789 /* CinderApp.icns */,
+				B2C7D1284567890123456793 /* Info.plist */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
+				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8D1107260486CEB800E47090 /* CanvasUiMinimap */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "CanvasUiMinimap" */;
+			buildPhases = (
+				8D1107290486CEB800E47090 /* Resources */,
+				8D11072C0486CEB800E47090 /* Sources */,
+				8D11072E0486CEB800E47090 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CanvasUiMinimap;
+			productInstallPath = "$(HOME)/Applications";
+			productName = CanvasUiMinimap;
+			productReference = 8D1107320486CEB800E47090 /* CanvasUiMinimap.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		29B97313FDCFA39411CA2CEA /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "CanvasUiMinimap" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CanvasUiMinimap */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8D1107260486CEB800E47090 /* CanvasUiMinimap */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8D1107290486CEB800E47090 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B2C7D1254567890123456790 /* CinderApp.icns in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8D11072C0486CEB800E47090 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B2C7D1274567890123456792 /* CanvasUiMinimapApp.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		C01FCF4B08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = CanvasUiMinimap_Prefix.pch;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
+				PRODUCT_NAME = CanvasUiMinimap;
+				WRAPPER_EXTENSION = app;
+				SYMROOT = ./build;
+			};
+			name = Debug;
+		};
+		C01FCF4C08A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_FAST_MATH = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"NDEBUG=1",
+					"$(inherited)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = CanvasUiMinimap_Prefix.pch;
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INFOPLIST_FILE = Info.plist;
+				INSTALL_PATH = "$(HOME)/Applications";
+				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/macosx/$(CONFIGURATION)/libcinder.a\"";
+				PRODUCT_NAME = CanvasUiMinimap;
+				STRIP_INSTALLED_PRODUCT = YES;
+				WRAPPER_EXTENSION = app;
+				SYMROOT = ./build;
+			};
+			name = Release;
+		};
+		C01FCF4F08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				CINDER_PATH = "../../../..";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				SDKROOT = macosx;
+				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../../include";
+			};
+			name = Debug;
+		};
+		C01FCF5008A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				CINDER_PATH = "../../../..";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				SDKROOT = macosx;
+				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../../include";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "CanvasUiMinimap" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4B08A954540054247B /* Debug */,
+				C01FCF4C08A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "CanvasUiMinimap" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4F08A954540054247B /* Debug */,
+				C01FCF5008A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
+}

--- a/samples/CanvasUiMinimap/proj/xcode/CanvasUiMinimap_Prefix.pch
+++ b/samples/CanvasUiMinimap/proj/xcode/CanvasUiMinimap_Prefix.pch
@@ -1,0 +1,12 @@
+#if defined( __cplusplus )
+	#include "cinder/Cinder.h"
+	
+	#include "cinder/app/App.h"
+	
+	#include "cinder/gl/gl.h"
+	
+	#include "cinder/CinderMath.h"
+	#include "cinder/Matrix.h"
+	#include "cinder/Vector.h"
+	#include "cinder/Quaternion.h"
+#endif

--- a/samples/CanvasUiMinimap/proj/xcode/Info.plist
+++ b/samples/CanvasUiMinimap/proj/xcode/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string>CinderApp.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.libcinder.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2024 __MyCompanyName__. All rights reserved.</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/samples/CanvasUiMinimap/proj/xcode/Info.plist
+++ b/samples/CanvasUiMinimap/proj/xcode/Info.plist
@@ -30,5 +30,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>

--- a/samples/CanvasUiMinimap/src/CanvasUiMinimapApp.cpp
+++ b/samples/CanvasUiMinimap/src/CanvasUiMinimapApp.cpp
@@ -27,11 +27,11 @@ class CanvasUiMinimapApp : public App {
 
 	gl::FboRef mSceneFbo;
 
-	static constexpr int GRID_X = 32;
-	static constexpr int GRID_Y = 18;
+	static constexpr int GRID_X = 16;
+	static constexpr int GRID_Y = 9;
 	static constexpr int SCENE_WIDTH = 1920;
 	static constexpr int SCENE_HEIGHT = 1080;
-	static constexpr float CUBE_SIZE = 30;
+	static constexpr float CUBE_SIZE = 60;
 	static constexpr int MINIMAP_WIDTH = 192;
 	static constexpr int MINIMAP_HEIGHT = 108;
 	static constexpr int MINIMAP_MARGIN = 20;

--- a/samples/CanvasUiMinimap/src/CanvasUiMinimapApp.cpp
+++ b/samples/CanvasUiMinimap/src/CanvasUiMinimapApp.cpp
@@ -1,0 +1,261 @@
+#include "cinder/CanvasUi.h"
+#include "cinder/CinderImGui.h"
+#include "cinder/CinderMath.h"
+#include "cinder/app/App.h"
+#include "cinder/app/RendererGl.h"
+#include "cinder/gl/gl.h"
+#include "cinder/Camera.h"
+#include "cinder/Rand.h"
+
+using namespace ci;
+using namespace ci::app;
+using namespace std;
+
+class CanvasUiMinimapApp : public App {
+  public:
+	void setup() override;
+	void draw() override;
+
+	// Input
+	void mouseDown( MouseEvent event ) override;
+	void mouseDrag( MouseEvent event ) override;
+	void mouseUp( MouseEvent event ) override;
+	void keyDown( KeyEvent event ) override;
+	void resize() override;
+
+	CanvasUi mCanvasUi;
+
+	gl::FboRef mSceneFbo;
+
+	static constexpr int GRID_X = 32;
+	static constexpr int GRID_Y = 18;
+	static constexpr int SCENE_WIDTH = 1920;
+	static constexpr int SCENE_HEIGHT = 1080;
+	static constexpr float CUBE_SIZE = 30;
+	static constexpr int MINIMAP_WIDTH = 192;
+	static constexpr int MINIMAP_HEIGHT = 108;
+	static constexpr int MINIMAP_MARGIN = 20;
+
+	bool mMinimapDragging = false;
+
+	// Minimap
+	Rectf mMinimapRect;
+
+	// Helpers
+	void setupFbo();
+	// Removed setupCubes - now stateless
+	void setupCanvasUi();
+	void renderSceneToFbo();
+	void drawMainView();
+	void drawMinimap();
+	void drawGui();
+
+	// Minimap mapping helpers (window px <-> minimap-local px <-> content)
+	inline vec2 windowToMinimap( vec2 win ) const { return win - mMinimapRect.getUpperLeft(); }
+	inline vec2 minimapToContent( vec2 mini ) const {
+		const float sx = mMinimapRect.getWidth() / SCENE_WIDTH;
+		const float sy = mMinimapRect.getHeight() / SCENE_HEIGHT;
+		return vec2( mini.x / sx, mini.y / sy );
+	}
+	inline Rectf contentToMinimap( const Rectf& content ) {
+		const float sx = mMinimapRect.getWidth()  / SCENE_WIDTH;
+		const float sy = mMinimapRect.getHeight() / SCENE_HEIGHT;
+
+		vec2 tl = mMinimapRect.getUpperLeft() + vec2( content.x1 * sx, content.y1 * sy );
+		vec2 br = mMinimapRect.getUpperLeft() + vec2( content.x2 * sx, content.y2 * sy );
+
+		tl = glm::max( tl, mMinimapRect.getUpperLeft() );
+		br = glm::min( br, mMinimapRect.getLowerRight() );
+		return Rectf{ tl, br };
+	}
+	inline bool inMinimap( vec2 win ) const { return mMinimapRect.contains( win ); }
+};
+
+void CanvasUiMinimapApp::setup()
+{
+	setWindowSize( 1280, 720 );
+	resize(); // force minimap rect calculation
+	
+	ImGui::Initialize();
+
+	setupFbo();
+	setupCanvasUi();
+}
+
+void CanvasUiMinimapApp::setupFbo()
+{
+	gl::Fbo::Format fmt;
+	fmt.setSamples( 16 );
+	fmt.colorTexture( gl::Texture2d::Format()
+		.minFilter( GL_LINEAR )
+		.magFilter( GL_NEAREST )
+		.wrap( GL_CLAMP_TO_EDGE ) );
+	mSceneFbo = gl::Fbo::create( SCENE_WIDTH, SCENE_HEIGHT, fmt );
+}
+
+void CanvasUiMinimapApp::setupCanvasUi()
+{
+	// Bounded canvas matching scene
+	mCanvasUi.setContentBounds( Rectf( 0, 0, (float)SCENE_WIDTH, (float)SCENE_HEIGHT ) );
+	// Lower signal priority so our App handlers can swallow events first if needed
+	mCanvasUi.connect( getWindow(), /*signalPriority*/ -1 );
+	
+	// Start with 720p height centered in the scene
+	mCanvasUi.fitRect( Rectf( 320, 180, 1600, 900 ), true /*disableAnimation*/ );
+}
+
+void CanvasUiMinimapApp::renderSceneToFbo()
+{
+	gl::ScopedFramebuffer fb( mSceneFbo );
+	gl::ScopedViewport vp( mSceneFbo->getSize() );
+	gl::ScopedMatrices mx;
+	gl::clear( Color( 0.1f, 0.1f, 0.15f ) );
+	gl::setMatricesWindowPersp( mSceneFbo->getSize(), 40.0f, 1.0f, 2000.0f );
+	gl::ScopedDepth depth( true );
+
+	const float t = (float)getElapsedSeconds();
+	
+	for( int y = 0; y < GRID_Y; ++y ) {
+		for( int x = 0; x < GRID_X; ++x ) {
+			vec3 pos( ( x + 0.5f ) * (float)SCENE_WIDTH / (float)GRID_X, ( y + 0.5f ) * (float)SCENE_HEIGHT / (float)GRID_Y, 0.0f  );
+			
+			// Calculate color based on grid position
+			Color col = Color( CM_HSV, x / (float)(GRID_X - 1), 0.2f + 0.8f * (y / (float)(GRID_Y - 1)), 0.9f );
+			
+			// Calculate rotation (deterministic based on position)
+			float rotSpeed = 0.5f + 1.5f * (float)(x + y) / (float)(GRID_X + GRID_Y - 2);
+			vec3 rotAxis = normalize( vec3( sin( x * 0.7f + y * 0.3f ), cos( x * 0.3f + y * 0.7f ), sin( x * 0.5f - y * 0.5f ) ));
+			
+			gl::ScopedModelMatrix mm;
+			gl::translate( pos );
+			gl::rotate( t * rotSpeed, rotAxis );
+			
+			// Draw cube (80% of cell size)
+			gl::ScopedColor cubeCol( col );
+			gl::drawCube( vec3( 0 ), vec3( CUBE_SIZE ) );
+			
+			// Draw wireframe
+			gl::ScopedColor wireCol( Color::white() * 0.3f );
+			gl::drawStrokedCube( vec3( 0 ), vec3( CUBE_SIZE ) );
+		}
+	}
+}
+
+void CanvasUiMinimapApp::mouseDown( MouseEvent e )
+{
+	if( e.isLeft() && inMinimap( e.getPos() ) ) {
+		mMinimapDragging = true;
+		mCanvasUi.panToContentPos( minimapToContent( windowToMinimap( e.getPos() ) ), true );
+		e.setHandled();
+	}
+}
+
+void CanvasUiMinimapApp::mouseDrag( MouseEvent e )
+{
+	if( mMinimapDragging && e.isLeftDown() && inMinimap( e.getPos() ) ) {
+		mCanvasUi.panToContentPos( minimapToContent( windowToMinimap( e.getPos() ) ), true );
+		e.setHandled();
+	}
+}
+
+void CanvasUiMinimapApp::mouseUp( MouseEvent )
+{
+	mMinimapDragging = false;
+}
+
+void CanvasUiMinimapApp::keyDown( KeyEvent event )
+{
+	const float panStep = 30.0f; // pixels to pan per keypress
+	
+	switch( event.getCode() ) {
+		case KeyEvent::KEY_UP:
+			mCanvasUi.panBy( vec2( 0, panStep ) );
+			event.setHandled();
+			break;
+			
+		case KeyEvent::KEY_DOWN:
+			mCanvasUi.panBy( vec2( 0, -panStep ) );
+			event.setHandled();
+			break;
+			
+		case KeyEvent::KEY_LEFT:
+			mCanvasUi.panBy( vec2( panStep, 0 ) );
+			event.setHandled();
+			break;
+			
+		case KeyEvent::KEY_RIGHT:
+			mCanvasUi.panBy( vec2( -panStep, 0 ) );
+			event.setHandled();
+			break;
+
+		case KeyEvent::KEY_q:
+			if( event.isControlDown() )
+				quit();
+			break;
+	}
+}
+
+void CanvasUiMinimapApp::resize()
+{
+	// recalculate bounds of minimap
+	const float l = (float)getWindowWidth()  - MINIMAP_WIDTH - MINIMAP_MARGIN;
+	const float t = (float)getWindowHeight() - MINIMAP_HEIGHT - MINIMAP_MARGIN;
+	mMinimapRect = Rectf( l, t, l + MINIMAP_WIDTH, t + MINIMAP_HEIGHT );
+}
+
+void CanvasUiMinimapApp::drawMainView()
+{
+	gl::ScopedMatrices m;
+	gl::setMatricesWindow( getWindowSize() );			// 2D, window coords (y down)
+	gl::multModelMatrix( mCanvasUi.getModelMatrix() );	// canvas content -> window
+	gl::ScopedColor white( Color::white() );
+	gl::draw( mSceneFbo->getColorTexture(), Rectf( 0, 0, (float)SCENE_WIDTH, (float)SCENE_HEIGHT ) );
+}
+
+void CanvasUiMinimapApp::drawMinimap()
+{
+	// FBO contents
+	gl::ScopedColor dim( Color::white() * 0.7f );
+	gl::draw( mSceneFbo->getColorTexture(), mMinimapRect );
+
+	// visible rect outline
+	gl::ScopedColor y( Color( 1, 1, 0 ) );
+	gl::drawStrokedRect( contentToMinimap( mCanvasUi.getVisibleRect() ), 2.0f );
+
+	// border
+	gl::ScopedColor border( Color( 0.5f, 0.5f, 0.6f ) );
+	gl::drawStrokedRect( mMinimapRect, 2.0f );
+}
+
+void CanvasUiMinimapApp::drawGui()
+{
+	ImGui::ScopedWindow w( "CanvasUi Minimap" );
+	ImGui::Text( "Scene: %dx%d", SCENE_WIDTH, SCENE_HEIGHT );
+	ImGui::Text( "Zoom: %.1f%%", (float)(mCanvasUi.getZoom() * 100) );
+	
+	if( ImGui::Button( "Fit All" ) ) mCanvasUi.fitAll();
+	ImGui::SameLine();
+	if( ImGui::Button( "Zoom In" ) ) mCanvasUi.zoomIn();
+	ImGui::SameLine();
+	if( ImGui::Button( "Zoom Out" ) ) mCanvasUi.zoomOut();
+	
+	ImGui::Separator();
+	ImGui::Text( "Navigation:" );
+	ImGui::Text( "• Arrow keys: Pan view" );
+	ImGui::Text( "• Mouse drag: Pan view" );
+	ImGui::Text( "• Mouse wheel: Zoom" );
+	ImGui::Text( "• Click minimap: Jump to location" );
+}
+
+void CanvasUiMinimapApp::draw()
+{
+	gl::clear( Color( 0.2f, 0.2f, 0.25f ) );
+
+	renderSceneToFbo();
+
+	drawMainView();
+	drawMinimap();
+	drawGui();
+}
+
+CINDER_APP( CanvasUiMinimapApp, RendererGl( RendererGl::Options().msaa( 16 ) ) )

--- a/src/cinder/CanvasUi.cpp
+++ b/src/cinder/CanvasUi.cpp
@@ -1,25 +1,25 @@
 /*
-Copyright (c) 2024, The Cinder Project - All rights reserved.
-Simple 2D Canvas UI with web browser-like controls and bounded/unbounded modes.
+ Copyright (c) 2025, The Cinder Project, All rights reserved.
+ Portions copyright Paul Houx.
 
-This code is intended for use with the Cinder C++ library: http://libcinder.org
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that
-the following conditions are met:
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
 
-   * Redistributions of source code must retain the above copyright notice, this list of conditions and
-   the following disclaimer.
-   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
-   the following disclaimer in the documentation and/or other materials provided with the distribution.
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "cinder/CanvasUi.h"
@@ -27,7 +27,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "cinder/Log.h"
 #include "cinder/app/App.h"
 #include "cinder/gl/gl.h"
-#include <cstdio>
 
 namespace cinder {
 
@@ -51,10 +50,6 @@ CanvasUi::CanvasUi()
 
 	mHotkeysReset.emplace_back( KeyEvent::KEY_0, modifier );
 	mHotkeysReset.emplace_back( KeyEvent::KEY_KP0, modifier );
-	
-	// Debug output to show what hotkeys are registered
-	std::printf("CanvasUi initialized with modifier: 0x%x (CTRL_DOWN=0x%x, ACCEL_DOWN=0x%x)\n", 
-	           modifier, KeyEvent::CTRL_DOWN, KeyEvent::ACCEL_DOWN);
 
 	// Set default pan mouse buttons: Alt+Left, Middle, or Right mouse
 	mPanMouseButtons.emplace_back( app::MouseEvent::LEFT_DOWN, app::MouseEvent::ALT_DOWN );
@@ -174,7 +169,7 @@ void CanvasUi::panToViewportPos( const vec2& posViewport, bool disableAnimation 
 void CanvasUi::panToContentPos( const vec2& posContent, bool disableAnimation )
 {
 	// Convert content coordinates to the position needed to center that content in the viewport
-	vec2 viewportCenter = mViewport.getSize() * 0.5f; 
+	vec2 viewportCenter = mViewport.getSize() * 0.5f;
 	vec2 newPositionViewport = viewportCenter - posContent * mZoom;
 
 	panToViewportPos( newPositionViewport, disableAnimation );
@@ -199,7 +194,7 @@ void CanvasUi::zoomBy( float factor, const vec2& anchorWindow, bool disableAnima
 	// Convert provided window anchor to viewport-local coordinates
 	vec2 anchorViewport = anchorWindow - mViewport.getUpperLeft();
 
-	if( mAnimationEnabled && !disableAnimation ) {
+	if( mAnimationEnabled && ! disableAnimation ) {
 		// Use animation system
 		startZoomAnimation( factor, anchorViewport );
 	}
@@ -518,7 +513,6 @@ void CanvasUi::updateViewportSize()
 			if( ! mHasCustomViewport ) {
 				Rectf oldViewport = mViewport;
 				mViewport = Rectf( 0, 0, (float)newSize.x, (float)newSize.y );
-
 			}
 
 			// Enforce zoom constraint after viewport change
@@ -627,24 +621,16 @@ void CanvasUi::keyDown( app::KeyEvent& event )
 	if( ! mKeyboardEnabled )
 		return;
 
-	// Debug output to see what keys are being pressed
-	std::printf("CanvasUi::keyDown - Key: %d, Modifiers: 0x%x, CTRL_DOWN=0x%x, ACCEL_DOWN=0x%x\n", 
-	           event.getCode(), event.getModifiers(), 
-	           app::KeyEvent::CTRL_DOWN, app::KeyEvent::ACCEL_DOWN);
-
 	// Check hotkeys using the new system
 	if( matchesHotkey( event, mHotkeysZoomIn ) ) {
-		std::printf("Zoom in hotkey matched!\n");
 		zoomIn();
 		event.setHandled();
 	}
 	else if( matchesHotkey( event, mHotkeysZoomOut ) ) {
-		std::printf("Zoom out hotkey matched!\n");
 		zoomOut();
 		event.setHandled();
 	}
 	else if( matchesHotkey( event, mHotkeysReset ) ) {
-		std::printf("Reset hotkey matched!\n");
 		if( isBounded() )
 			fitAll();
 		event.setHandled();

--- a/src/cinder/CanvasUi.cpp
+++ b/src/cinder/CanvasUi.cpp
@@ -1,0 +1,925 @@
+/*
+Copyright (c) 2024, The Cinder Project - All rights reserved.
+Simple 2D Canvas UI with web browser-like controls and bounded/unbounded modes.
+
+This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright notice, this list of conditions and
+   the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+   the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "cinder/CanvasUi.h"
+#include "cinder/CinderAssert.h"
+#include "cinder/Log.h"
+#include "cinder/app/App.h"
+#include "cinder/gl/gl.h"
+#include <cstdio>
+
+namespace cinder {
+
+CanvasUi::CanvasUi()
+{
+	// Set default hotkeys
+	using namespace app;
+#if defined( CINDER_MSW )
+	// On Windows, use ACCEL_DOWN (which maps to CTRL_DOWN)
+	unsigned int modifier = KeyEvent::ACCEL_DOWN;
+#else
+	// On Linux/Mac, use CTRL_DOWN directly for consistency with Windows behavior
+	unsigned int modifier = KeyEvent::CTRL_DOWN;
+#endif
+	mHotkeysZoomIn.emplace_back( KeyEvent::KEY_PLUS, modifier );
+	mHotkeysZoomIn.emplace_back( KeyEvent::KEY_EQUALS, modifier );
+	mHotkeysZoomIn.emplace_back( KeyEvent::KEY_KP_PLUS, modifier );
+
+	mHotkeysZoomOut.emplace_back( KeyEvent::KEY_MINUS, modifier );
+	mHotkeysZoomOut.emplace_back( KeyEvent::KEY_KP_MINUS, modifier );
+
+	mHotkeysReset.emplace_back( KeyEvent::KEY_0, modifier );
+	mHotkeysReset.emplace_back( KeyEvent::KEY_KP0, modifier );
+	
+	// Debug output to show what hotkeys are registered
+	std::printf("CanvasUi initialized with modifier: 0x%x (CTRL_DOWN=0x%x, ACCEL_DOWN=0x%x)\n", 
+	           modifier, KeyEvent::CTRL_DOWN, KeyEvent::ACCEL_DOWN);
+
+	// Set default pan mouse buttons: Alt+Left, Middle, or Right mouse
+	mPanMouseButtons.emplace_back( app::MouseEvent::LEFT_DOWN, app::MouseEvent::ALT_DOWN );
+	mPanMouseButtons.emplace_back( app::MouseEvent::MIDDLE_DOWN, 0 );
+	mPanMouseButtons.emplace_back( app::MouseEvent::RIGHT_DOWN, 0 );
+}
+
+CanvasUi::CanvasUi( const ci::app::WindowRef& window, int signalPriority )
+	: CanvasUi()
+{
+	connect( window, signalPriority );
+}
+
+CanvasUi::CanvasUi( const app::WindowRef& window, const Rectf& bounds, int signalPriority )
+	: CanvasUi( window, signalPriority )
+{
+	setContentBounds( bounds );
+}
+
+CanvasUi::~CanvasUi()
+{
+	disconnect();
+}
+
+void CanvasUi::setContentBounds( const Rectf& bounds )
+{
+	mCanvasBounds = bounds;
+	if( isBounded() )
+		constrainPosition();
+}
+
+const mat4& CanvasUi::getModelMatrix() const
+{
+	if( mIsDirty ) {
+		updateMatrices();
+		mIsDirty = false;
+	}
+	return mModelMatrix;
+}
+
+const mat4& CanvasUi::getInverseModelMatrix() const
+{
+	if( mIsDirty ) {
+		updateMatrices();
+		mIsDirty = false;
+	}
+	return mInverseModelMatrix;
+}
+
+void CanvasUi::updateMatrices() const
+{
+	// Transform: Window = Translate(viewport_offset + position) * Scale(zoom) * Canvas
+	vec2 viewportOffset = mViewport.getUpperLeft();
+	mModelMatrix = translate( vec3( viewportOffset + mPosition, 0 ) );
+	mModelMatrix *= scale( vec3( mZoom ) );
+
+	mInverseModelMatrix = inverse( mModelMatrix );
+}
+
+vec2 CanvasUi::toContent( const vec2& posWindow ) const
+{
+	// Inverse model matrix now handles full window-to-content transformation (includes viewport offset)
+	return vec2( getInverseModelMatrix() * vec4( posWindow, 0, 1 ) );
+}
+
+vec2 CanvasUi::toWindow( const vec2& posContent ) const
+{
+	// Convert from content directly to window coordinates (model matrix now includes viewport offset)
+	return vec2( getModelMatrix() * vec4( posContent, 0, 1 ) );
+}
+
+Rectf CanvasUi::getVisibleRect() const
+{
+	// Return the visible area of the viewport
+	return getVisibleRect( Rectf( vec2( 0 ), mViewport.getSize() ) );
+}
+
+Rectf CanvasUi::getVisibleRect( const Rectf& rectViewport ) const
+{
+	// Convert viewport rect to window coordinates first
+	Rectf windowRect = rectViewport + mViewport.getUpperLeft();
+	// Convert the corners to content coordinates
+	return Rectf{ toContent( windowRect.getUpperLeft() ), toContent( windowRect.getLowerRight() ) };
+}
+
+void CanvasUi::panBy( const vec2& deltaViewport )
+{
+	vec2 newPosition = mPosition + deltaViewport;
+	if( isBounded() && ! mAllowPanOutside ) {
+		newPosition = calculateConstrainedPosition( newPosition );
+	}
+
+	if( newPosition != mPosition ) {
+		mPosition = newPosition;
+		mIsDirty = true;
+	}
+}
+
+void CanvasUi::panToViewportPos( const vec2& posViewport, bool disableAnimation )
+{
+	vec2 newPosition = posViewport;
+	if( isBounded() && ! mAllowPanOutside ) {
+		newPosition = calculateConstrainedPosition( newPosition );
+	}
+
+	if( newPosition != mPosition ) {
+		if( mAnimationEnabled && ! disableAnimation ) {
+			startPositionAnimation( newPosition );
+		}
+		else {
+			mPosition = newPosition;
+			mIsDirty = true;
+		}
+	}
+}
+
+void CanvasUi::panToContentPos( const vec2& posContent, bool disableAnimation )
+{
+	// Convert content coordinates to the position needed to center that content in the viewport
+	vec2 viewportCenter = mViewport.getSize() * 0.5f; 
+	vec2 newPositionViewport = viewportCenter - posContent * mZoom;
+
+	panToViewportPos( newPositionViewport, disableAnimation );
+}
+
+void CanvasUi::zoomBy( float factor, bool disableAnimation )
+{
+	// Zoom around viewport center
+	vec2 viewportCenter = mViewport.getUpperLeft() + mViewport.getSize() * 0.5f;
+	zoomBy( factor, viewportCenter, disableAnimation );
+}
+
+void CanvasUi::zoomBy( float factor, const vec2& anchorWindow, bool disableAnimation )
+{
+	if( factor <= 0.0f )
+		return;
+
+	float newZoom = glm::clamp( mZoom * factor, getEffectiveMinZoom(), mMaxZoom );
+	if( newZoom == mZoom )
+		return;
+
+	// Convert provided window anchor to viewport-local coordinates
+	vec2 anchorViewport = anchorWindow - mViewport.getUpperLeft();
+
+	if( mAnimationEnabled && !disableAnimation ) {
+		// Use animation system
+		startZoomAnimation( factor, anchorViewport );
+	}
+	else {
+		// Immediate zoom using existing step function
+		zoomByStep( factor, anchorViewport );
+	}
+}
+
+void CanvasUi::zoomTo( float zoom, bool disableAnimation )
+{
+	// Zoom around viewport center
+	vec2 viewportCenter = mViewport.getUpperLeft() + mViewport.getSize() * 0.5f;
+	zoomTo( zoom, viewportCenter, disableAnimation );
+}
+
+void CanvasUi::zoomTo( float zoom, const vec2& anchorWindow, bool disableAnimation )
+{
+	if( zoom <= 0.0f )
+		return;
+	zoomBy( zoom / mZoom, anchorWindow, disableAnimation );
+}
+
+void CanvasUi::constrainPosition()
+{
+	if( ! isBounded() || mAllowPanOutside )
+		return;
+
+	vec2 constrainedPos = calculateConstrainedPosition( mPosition );
+	if( constrainedPos != mPosition ) {
+		mPosition = constrainedPos;
+		mIsDirty = true;
+	}
+}
+
+vec2 CanvasUi::calculateConstrainedPosition( const vec2& desiredPos ) const
+{
+	return calculateConstrainedPosition( desiredPos, mZoom );
+}
+
+vec2 CanvasUi::calculateConstrainedPosition( const vec2& desiredPos, float zoom ) const
+{
+	if( ! isBounded() || mAllowPanOutside ) {
+		return desiredPos;
+	}
+
+	// Calculate canvas bounds in viewport space
+	vec2 canvasMin = mCanvasBounds->getUpperLeft() * zoom + desiredPos;
+	vec2 canvasMax = mCanvasBounds->getLowerRight() * zoom + desiredPos;
+	vec2 viewportSize = mViewport.getSize();
+
+	vec2 constrainedPos = desiredPos;
+
+	// If canvas is smaller than viewport, center it
+	if( canvasMax.x - canvasMin.x < viewportSize.x ) {
+		constrainedPos.x = ( viewportSize.x - ( canvasMax.x - canvasMin.x ) ) * 0.5f - mCanvasBounds->getUpperLeft().x * zoom;
+	}
+	else {
+		// Canvas is larger than viewport, constrain edges
+		if( canvasMin.x > 0 ) {
+			constrainedPos.x = -mCanvasBounds->getUpperLeft().x * zoom;
+		}
+		if( canvasMax.x < viewportSize.x ) {
+			constrainedPos.x = viewportSize.x - mCanvasBounds->getLowerRight().x * zoom;
+		}
+	}
+
+	// Same logic for Y
+	if( canvasMax.y - canvasMin.y < viewportSize.y ) {
+		constrainedPos.y = ( viewportSize.y - ( canvasMax.y - canvasMin.y ) ) * 0.5f - mCanvasBounds->getUpperLeft().y * zoom;
+	}
+	else {
+		if( canvasMin.y > 0 ) {
+			constrainedPos.y = -mCanvasBounds->getUpperLeft().y * zoom;
+		}
+		if( canvasMax.y < viewportSize.y ) {
+			constrainedPos.y = viewportSize.y - mCanvasBounds->getLowerRight().y * zoom;
+		}
+	}
+
+	return constrainedPos;
+}
+
+
+void CanvasUi::zoomIn( bool disableAnimation )
+{
+	vec2 centerViewport = mViewport.getSize() * 0.5f; // Center of viewport in viewport-local coordinates
+
+	if( mAnimationEnabled && ! disableAnimation ) {
+		// Start smooth animation from center (expects viewport-local coordinates)
+		startZoomAnimation( 1.0f + mZoomFactor, centerViewport );
+	}
+	else {
+		// Immediate zoom (expects viewport-local coordinates)
+		zoomByStep( 1.0f + mZoomFactor, centerViewport );
+	}
+}
+
+void CanvasUi::zoomOut( bool disableAnimation )
+{
+	vec2 centerViewport = mViewport.getSize() * 0.5f; // Center of viewport in viewport-local coordinates
+
+	if( mAnimationEnabled && ! disableAnimation ) {
+		// Start smooth animation from center (expects viewport-local coordinates)
+		startZoomAnimation( 1.0f / ( 1.0f + mZoomFactor ), centerViewport );
+	}
+	else {
+		// Immediate zoom (expects viewport-local coordinates)
+		zoomByStep( 1.0f / ( 1.0f + mZoomFactor ), centerViewport );
+	}
+}
+
+// Helper to set zoom and position with proper constraints
+void CanvasUi::setZoomAndPosition( float newZoom, const vec2& newPositionViewport )
+{
+	mZoom = glm::clamp( newZoom, getEffectiveMinZoom(), mMaxZoom );
+
+	if( isBounded() && ! mAllowPanOutside ) {
+		mPosition = calculateConstrainedPosition( newPositionViewport, mZoom );
+	}
+	else {
+		mPosition = newPositionViewport;
+	}
+	mIsDirty = true;
+}
+
+// Helper for fit operations that center the canvas
+void CanvasUi::fitWithCentering( float newZoom, bool disableAnimation )
+{
+	CI_ASSERT( isBounded() && "CanvasUi: Fit operations require bounded content. Use setContentBounds() first." );
+
+	vec2 canvasCenter = mCanvasBounds->getCenter();
+	vec2 viewportCenter = mViewport.getSize() * 0.5f;
+	vec2 newPosition = viewportCenter - canvasCenter * newZoom;
+
+	if( mAnimationEnabled && ! disableAnimation ) {
+		startZoomAndPositionAnimation( newZoom, newPosition );
+	}
+	else {
+		setZoomAndPosition( newZoom, newPosition );
+	}
+}
+
+// Dedicated zoom preset functions
+void CanvasUi::fitAll( bool disableAnimation )
+{
+	CI_ASSERT( isBounded() && "CanvasUi: fitAll() requires bounded content. Use setContentBounds() first." );
+
+	vec2 canvasSize = mCanvasBounds->getSize();
+	vec2 viewportSize = mViewport.getSize();
+
+	if( canvasSize.x <= 0 || canvasSize.y <= 0 || viewportSize.x <= 0 || viewportSize.y <= 0 ) {
+		return;
+	}
+
+	float scaleX = viewportSize.x / canvasSize.x;
+	float scaleY = viewportSize.y / canvasSize.y;
+
+	// fitAll() always shows all content (uses min scale)
+	fitWithCentering( glm::min( scaleX, scaleY ) );
+}
+
+void CanvasUi::fitWidth( bool disableAnimation )
+{
+	CI_ASSERT( isBounded() && "CanvasUi: fitWidth() requires bounded content. Use setContentBounds() first." );
+
+	vec2  canvasSize = mCanvasBounds->getSize();
+	float viewportWidth = mViewport.getWidth();
+
+	if( canvasSize.x <= 0 || viewportWidth <= 0 ) {
+		return;
+	}
+
+	fitWithCentering( viewportWidth / canvasSize.x );
+}
+
+void CanvasUi::fitHeight( bool disableAnimation )
+{
+	CI_ASSERT( isBounded() && "CanvasUi: fitHeight() requires bounded content. Use setContentBounds() first." );
+
+	vec2  canvasSize = mCanvasBounds->getSize();
+	float viewportHeight = mViewport.getHeight();
+
+	if( canvasSize.y <= 0 || viewportHeight <= 0 ) {
+		return;
+	}
+
+	fitWithCentering( viewportHeight / canvasSize.y );
+}
+
+void CanvasUi::fitRect( const Rectf& contentRect, bool disableAnimation )
+{
+	vec2 rectSize = contentRect.getSize();
+	vec2 viewportSize = mViewport.getSize();
+
+	if( rectSize.x <= 0 || rectSize.y <= 0 || viewportSize.x <= 0 || viewportSize.y <= 0 ) {
+		return;
+	}
+
+	// Calculate zoom to fit the rectangle in the viewport (with aspect ratio preservation)
+	float scaleX = viewportSize.x / rectSize.x;
+	float scaleY = viewportSize.y / rectSize.y;
+	float newZoom = glm::min( scaleX, scaleY );
+
+	// Center the rectangle in the viewport
+	vec2 rectCenter = contentRect.getCenter();
+	vec2 viewportCenter = mViewport.getSize() * 0.5f;
+	vec2 newPosition = viewportCenter - rectCenter * newZoom;
+
+	if( mAnimationEnabled && ! disableAnimation ) {
+		startZoomAndPositionAnimation( newZoom, newPosition );
+	}
+	else {
+		setZoomAndPosition( newZoom, newPosition );
+	}
+}
+
+
+void CanvasUi::zoomByStep( float factor, const vec2& anchorViewport )
+{
+	if( factor <= 0.0f )
+		return;
+
+	// Calculate new zoom target
+	float newZoomTarget = mZoom * factor;
+	newZoomTarget = glm::clamp( newZoomTarget, getEffectiveMinZoom(), mMaxZoom );
+
+	if( newZoomTarget == mZoom )
+		return;
+
+	// Convert anchor from viewport coordinates to window coordinates for toContent()
+	vec2 anchorWindow = anchorViewport + mViewport.getUpperLeft();
+	vec2 contentPoint = toContent( anchorWindow );
+
+	// Calculate new position to keep content point at anchor (anchorViewport is in viewport coordinates)
+	// Formula: viewportPoint = position + contentPoint * zoom
+	// Solving for position: position = viewportPoint - contentPoint * zoom
+	vec2 newPosition = anchorViewport - contentPoint * newZoomTarget;
+
+	// Apply constraints after zoom using the target zoom value
+	if( isBounded() && ! mAllowPanOutside ) {
+		newPosition = calculateConstrainedPosition( newPosition, newZoomTarget );
+	}
+
+	// Set new values
+	mZoom = newZoomTarget;
+	mPosition = newPosition;
+	mIsDirty = true;
+}
+
+void CanvasUi::connect( const app::WindowRef& window, int signalPriority )
+{
+	disconnect(); // Clean up existing connections
+
+	mWindow = window;
+	updateViewportSize();
+
+	if( window ) {
+		// Connect to window events
+		mConnections.push_back( window->getSignalMouseDown().connect( signalPriority, [this]( app::MouseEvent& event ) {
+			if( mEnabled )
+				mouseDown( event );
+		} ) );
+
+		mConnections.push_back( window->getSignalMouseUp().connect( signalPriority, [this]( app::MouseEvent& event ) {
+			if( mEnabled )
+				mouseUp( event );
+		} ) );
+
+		mConnections.push_back( window->getSignalMouseDrag().connect( signalPriority, [this]( app::MouseEvent& event ) {
+			if( mEnabled )
+				mouseDrag( event );
+		} ) );
+
+		mConnections.push_back( window->getSignalMouseWheel().connect( signalPriority, [this]( app::MouseEvent& event ) {
+			if( mEnabled && mMouseWheelEnabled )
+				mouseWheel( event );
+		} ) );
+
+		mConnections.push_back( window->getSignalKeyDown().connect( signalPriority, [this]( app::KeyEvent& event ) {
+			if( mEnabled && mKeyboardEnabled )
+				keyDown( event );
+		} ) );
+
+		mConnections.push_back( window->getSignalResize().connect( signalPriority, [this]() {
+			if( mEnabled )
+				resize( mWindow->getSize() );
+		} ) );
+
+		// Update loop for animation
+		mConnections.push_back( window->getSignalDraw().connect( signalPriority, [this]() {
+			if( mEnabled && mAnimationEnabled ) {
+				updateAnimation();
+			}
+		} ) );
+	}
+}
+
+void CanvasUi::disconnect()
+{
+	for( auto& connection : mConnections ) {
+		connection.disconnect();
+	}
+	mConnections.clear();
+	mWindow.reset();
+}
+
+void CanvasUi::updateViewportSize()
+{
+	if( mWindow ) {
+		ivec2 newSize = mWindow->getSize();
+		if( newSize != mWindowSize ) {
+			mWindowSize = newSize;
+
+			// Update viewport if not using custom viewport
+			if( ! mHasCustomViewport ) {
+				Rectf oldViewport = mViewport;
+				mViewport = Rectf( 0, 0, (float)newSize.x, (float)newSize.y );
+
+			}
+
+			// Enforce zoom constraint after viewport change
+			if( mConstrainZoomToContent && isBounded() ) {
+				float effectiveMinZoom = getEffectiveMinZoom();
+				if( mZoom < effectiveMinZoom ) {
+					mZoom = effectiveMinZoom;
+				}
+			}
+
+			// Always constrain position after resize
+			constrainPosition();
+			mIsDirty = true;
+		}
+	}
+}
+
+void CanvasUi::mouseDown( app::MouseEvent& event )
+{
+	// Check if mouse is within viewport
+	vec2 mousePos = vec2( event.getPos() );
+	if( ! mViewport.contains( mousePos ) ) {
+		return; // Event outside viewport, don't handle
+	}
+
+	if( matchesPanMouseButton( event, mPanMouseButtons ) ) {
+		// Only start new drag if not already dragging
+		if( ! mIsDragging ) {
+			// Stop any animation to prevent conflicts during drag
+			if( mAnimating ) {
+				mAnimating = false;
+				mAnimatingZoom = false;
+				mAnimatingPosition = false;
+			}
+
+			mIsDragging = true;
+			mDragStartPosWindow = event.getPos();
+			mDragStartPosition = mPosition;
+			mDragInitiator = event.getInitiator();
+		}
+		event.setHandled();
+	}
+}
+
+void CanvasUi::mouseUp( app::MouseEvent& event )
+{
+	// End drag if the button that started it was released
+	if( mIsDragging && event.getInitiator() == mDragInitiator ) {
+		mIsDragging = false;
+		mDragInitiator = 0;
+		event.setHandled();
+	}
+}
+
+void CanvasUi::mouseDrag( app::MouseEvent& event )
+{
+	if( mIsDragging ) {
+		// Both mouse positions are in window coordinates, so delta is also window coordinates
+		vec2 windowDragDelta = vec2( event.getPos() - mDragStartPosWindow );
+		// Since mPosition is stored in viewport coordinates, the delta should be the same
+		// (viewport is just translated window coordinates, so deltas are identical)
+
+		// For mouse dragging, use the mouse pan animation setting (only if animations enabled)
+		panToViewportPos( mDragStartPosition + windowDragDelta, ! ( mAnimationEnabled && mAnimateMousePan ) );
+		event.setHandled();
+	}
+}
+
+void CanvasUi::mouseWheel( app::MouseEvent& event )
+{
+	// Check if mouse is within viewport
+	vec2 mousePos = vec2( event.getPos() );
+	if( ! mViewport.contains( mousePos ) ) {
+		return; // Event outside viewport, don't handle
+	}
+
+	float inc = event.getWheelIncrement();
+	if( mWheelInverted )
+		inc = -inc;
+
+	// Calculate zoom factor relative to zoom factor setting
+	float effectiveZoomFactor = mZoomFactor * mWheelMultiplier;
+	float zoomMultiplier;
+	if( inc > 0 ) {
+		zoomMultiplier = 1.0f + effectiveZoomFactor; // Zoom in
+	}
+	else {
+		zoomMultiplier = 1.0f / ( 1.0f + effectiveZoomFactor ); // Zoom out (reciprocal)
+	}
+	// Determine anchor point in viewport-local coordinates
+	vec2 anchorViewport = mZoomToCursor ? ( vec2( event.getPos() ) - mViewport.getUpperLeft() ) : ( mViewport.getSize() * 0.5f );
+
+	if( mAnimationEnabled ) {
+		// Start smooth animation to target (expects viewport-local coordinates)
+		startZoomAnimation( zoomMultiplier, anchorViewport );
+	}
+	else {
+		// Immediate zoom (expects viewport-local coordinates)
+		zoomByStep( zoomMultiplier, anchorViewport );
+	}
+	event.setHandled();
+}
+
+void CanvasUi::keyDown( app::KeyEvent& event )
+{
+	if( ! mKeyboardEnabled )
+		return;
+
+	// Debug output to see what keys are being pressed
+	std::printf("CanvasUi::keyDown - Key: %d, Modifiers: 0x%x, CTRL_DOWN=0x%x, ACCEL_DOWN=0x%x\n", 
+	           event.getCode(), event.getModifiers(), 
+	           app::KeyEvent::CTRL_DOWN, app::KeyEvent::ACCEL_DOWN);
+
+	// Check hotkeys using the new system
+	if( matchesHotkey( event, mHotkeysZoomIn ) ) {
+		std::printf("Zoom in hotkey matched!\n");
+		zoomIn();
+		event.setHandled();
+	}
+	else if( matchesHotkey( event, mHotkeysZoomOut ) ) {
+		std::printf("Zoom out hotkey matched!\n");
+		zoomOut();
+		event.setHandled();
+	}
+	else if( matchesHotkey( event, mHotkeysReset ) ) {
+		std::printf("Reset hotkey matched!\n");
+		if( isBounded() )
+			fitAll();
+		event.setHandled();
+	}
+}
+
+void CanvasUi::resize( const ivec2& newSize )
+{
+	updateViewportSize();
+}
+
+void CanvasUi::zoomByStep( float factor )
+{
+	// Zoom from viewport center
+	vec2 centerViewport = mViewport.getSize() * 0.5f;
+	zoomByStep( factor, centerViewport );
+}
+
+
+void CanvasUi::startZoomAnimation( float zoomFactor, const vec2& anchorViewport )
+{
+	// Calculate final zoom target - if already animating, use the target, not current interpolated zoom
+	float baseZoom = mAnimating ? mZoomAnimationTarget : mZoom;
+	float newZoomTarget = baseZoom * zoomFactor;
+	newZoomTarget = glm::clamp( newZoomTarget, getEffectiveMinZoom(), mMaxZoom );
+
+	if( newZoomTarget == baseZoom )
+		return; // No change needed
+
+	// Capture the content point under the anchor at the START of animation
+	// anchorViewport is in viewport-local coordinates, convert to window coordinates for toContent()
+	vec2 anchorWindow = anchorViewport + mViewport.getUpperLeft();
+	vec2 contentPoint = toContent( anchorWindow );
+
+	// Start animation
+	mAnimating = true;
+	mAnimatingZoom = true;
+	mAnimatingPosition = false;
+	mZoomAnimationStart = mZoom;
+	mZoomAnimationTarget = newZoomTarget;
+	mZoomAnimationAnchor = anchorViewport; // Store viewport-local coordinates
+	mZoomAnimationContentPoint = contentPoint;
+	mAnimationStartTime = app::getElapsedSeconds();
+}
+
+void CanvasUi::updateAnimation()
+{
+	if( ! mAnimating )
+		return;
+
+	double currentTime = app::getElapsedSeconds();
+	float  elapsed = (float)( currentTime - mAnimationStartTime );
+	float  progress = elapsed / mAnimationDuration;
+
+	if( progress >= 1.0f ) {
+		// Animation complete
+		progress = 1.0f;
+		mAnimating = false;
+		mAnimatingZoom = false;
+		mAnimatingPosition = false;
+	}
+
+	// Smooth easing (configurable ease-out)
+	float easedProgress = 1.0f - pow( 1.0f - progress, mAnimationEasing );
+
+	if( mAnimatingZoom && mAnimatingPosition ) {
+		// Animate both zoom and position
+		float currentZoom = mZoomAnimationStart + ( mZoomAnimationTarget - mZoomAnimationStart ) * easedProgress;
+		vec2  currentPosition = mPositionAnimationStart + ( mPositionAnimationTarget - mPositionAnimationStart ) * easedProgress;
+
+		// Apply constraints
+		if( isBounded() && ! mAllowPanOutside ) {
+			currentPosition = calculateConstrainedPosition( currentPosition, currentZoom );
+		}
+
+		mZoom = currentZoom;
+		mPosition = currentPosition;
+	}
+	else if( mAnimatingZoom ) {
+		// Animate zoom with anchor point
+		float currentZoom = mZoomAnimationStart + ( mZoomAnimationTarget - mZoomAnimationStart ) * easedProgress;
+		vec2  newPosition = mZoomAnimationAnchor - mZoomAnimationContentPoint * currentZoom;
+
+		// Apply constraints
+		if( isBounded() && ! mAllowPanOutside ) {
+			newPosition = calculateConstrainedPosition( newPosition, currentZoom );
+		}
+
+		mZoom = currentZoom;
+		mPosition = newPosition;
+	}
+	else if( mAnimatingPosition ) {
+		// Animate position only
+		vec2 currentPosition = mPositionAnimationStart + ( mPositionAnimationTarget - mPositionAnimationStart ) * easedProgress;
+
+		// Apply constraints
+		if( isBounded() && ! mAllowPanOutside ) {
+			currentPosition = calculateConstrainedPosition( currentPosition );
+		}
+
+		mPosition = currentPosition;
+	}
+
+	mIsDirty = true;
+}
+
+void CanvasUi::startPositionAnimation( const vec2& targetPositionViewport )
+{
+	mAnimating = true;
+	mAnimatingZoom = false;
+	mAnimatingPosition = true;
+	mPositionAnimationStart = mPosition;
+	mPositionAnimationTarget = targetPositionViewport;
+	mAnimationStartTime = app::getElapsedSeconds();
+}
+
+void CanvasUi::startZoomAndPositionAnimation( float targetZoom, const vec2& targetPositionViewport )
+{
+	targetZoom = glm::clamp( targetZoom, getEffectiveMinZoom(), mMaxZoom );
+
+	mAnimating = true;
+	mAnimatingZoom = true;
+	mAnimatingPosition = true;
+	mZoomAnimationStart = mZoom;
+	mZoomAnimationTarget = targetZoom;
+	mPositionAnimationStart = mPosition;
+	mPositionAnimationTarget = targetPositionViewport;
+	mAnimationStartTime = app::getElapsedSeconds();
+}
+
+// Hotkey system implementation
+void CanvasUi::setHotkeysZoomIn( const std::vector<HotkeyBinding>& hotkeys )
+{
+	mHotkeysZoomIn = hotkeys;
+}
+
+void CanvasUi::setHotkeysZoomOut( const std::vector<HotkeyBinding>& hotkeys )
+{
+	mHotkeysZoomOut = hotkeys;
+}
+
+void CanvasUi::setHotkeysReset( const std::vector<HotkeyBinding>& hotkeys )
+{
+	mHotkeysReset = hotkeys;
+}
+
+
+bool CanvasUi::matchesHotkey( const app::KeyEvent& event, const std::vector<HotkeyBinding>& hotkeys ) const
+{
+	int			 keyCode = event.getCode();
+	unsigned int modifiers = event.getModifiers();
+
+	for( const auto& binding : hotkeys ) {
+		if( keyCode == binding.key && modifiers == binding.modifiers ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+// Mouse button system implementation
+void CanvasUi::setPanMouseButtons( const std::vector<MouseButtonBinding>& buttons )
+{
+	mPanMouseButtons = buttons;
+}
+
+bool CanvasUi::matchesPanMouseButton( const app::MouseEvent& event, const std::vector<MouseButtonBinding>& buttons ) const
+{
+	// If no buttons configured, don't allow panning
+	if( buttons.empty() )
+		return false;
+
+	unsigned int eventButtons = 0;
+	unsigned int eventModifiers = event.getModifiers();
+
+	// Build button mask from what's currently down
+	if( event.isLeftDown() )
+		eventButtons |= app::MouseEvent::LEFT_DOWN;
+	if( event.isMiddleDown() )
+		eventButtons |= app::MouseEvent::MIDDLE_DOWN;
+	if( event.isRightDown() )
+		eventButtons |= app::MouseEvent::RIGHT_DOWN;
+
+	// Mask out mouse button flags from modifiers to avoid double-counting
+	eventModifiers &= ~( app::MouseEvent::LEFT_DOWN | app::MouseEvent::MIDDLE_DOWN | app::MouseEvent::RIGHT_DOWN );
+
+	for( const auto& binding : buttons )
+		if( ( eventButtons == binding.button ) && ( eventModifiers == binding.modifiers ) )
+			return true;
+
+	return false;
+}
+
+// Viewport management
+void CanvasUi::setCustomViewport( const Rectf& viewport )
+{
+	mViewport = viewport;
+	mHasCustomViewport = true;
+	mIsDirty = true;
+
+	// Constrain position for new viewport
+	if( isBounded() ) {
+		constrainPosition();
+	}
+}
+
+void CanvasUi::disableCustomViewport()
+{
+	mHasCustomViewport = false;
+	// Update viewport to match window
+	mViewport = Rectf( 0, 0, (float)mWindowSize.x, (float)mWindowSize.y );
+	mIsDirty = true;
+
+	// Constrain position for new viewport
+	if( isBounded() ) {
+		constrainPosition();
+	}
+}
+
+float CanvasUi::getEffectiveMinZoom() const
+{
+	// Always respect the absolute minimum zoom
+	float effectiveMin = mMinZoom;
+
+	// If content constraint is enabled and content is bounded, calculate content-based minimum
+	// NOTE: Only applies when allowPanOutside=false, since allowPanOutside=true makes this
+	// constraint meaningless (you can create gaps by panning anyway)
+	if( mConstrainZoomToContent && isBounded() && ! mAllowPanOutside ) {
+		vec2 canvasSize = mCanvasBounds->getSize();
+		vec2 viewportSize = mViewport.getSize();
+
+		if( canvasSize.x > 0 && canvasSize.y > 0 && viewportSize.x > 0 && viewportSize.y > 0 ) {
+			// Calculate zoom needed so the larger axis fits (prevents both axes from being loose)
+			// This is the fitAll() level - content fits entirely but may have gaps on one axis
+			float scaleX = viewportSize.x / canvasSize.x;
+			float scaleY = viewportSize.y / canvasSize.y;
+			float contentMinZoom = glm::min( scaleX, scaleY );
+
+			// Use the larger of absolute minimum and content-based minimum
+			effectiveMin = glm::max( effectiveMin, contentMinZoom );
+		}
+	}
+
+	return effectiveMin;
+}
+
+void CanvasUi::setConstrainZoomToContent( bool constrain )
+{
+	bool wasConstrained = mConstrainZoomToContent;
+	mConstrainZoomToContent = constrain;
+
+	// Auto-disable pan outside when enabling zoom constraint (need controlled positioning)
+	if( constrain )
+		mAllowPanOutside = false;
+
+	// If enabling constraint, fix zoom and position immediately
+	// Only applies when allowPanOutside=false (when true, constraint is meaningless)
+	if( constrain && ! wasConstrained && isBounded() && ! mAllowPanOutside ) {
+		float effectiveMinZoom = getEffectiveMinZoom();
+		if( mZoom < effectiveMinZoom ) {
+			mZoom = effectiveMinZoom;
+			mIsDirty = true;
+		}
+		// Always constrain position when enabling - this handles off-center content from previous allowPanOutside
+		constrainPosition();
+	}
+}
+
+void CanvasUi::setAllowPanOutside( bool allow )
+{
+	mAllowPanOutside = allow;
+
+	// Auto-disable zoom constraint when enabling pan outside (makes constraint meaningless)
+	if( allow )
+		mConstrainZoomToContent = false;
+}
+
+} // namespace cinder


### PR DESCRIPTION
This is a continuation of work @paulhoux started with PR #2326, implementing a `CanvasUi` class, similar to `CameraUi` but for 2D canvas manipulation.

This PR includes two samples, one exercising most of the functionality, _CanvasUi_, and another showing how to implement a mini-map paired with `CanvasUi` called _CanvasUiMinimap_.

The implementation allows customization of hotkeys and mouse interactions, but by default uses middle, right, or alt-left clicking for panning, leaving left click for selecting. It also supports several hotkeys for zoom by default.

One key concept is the notion of a bounded vs. unbounded canvas. The former is required for "fitting" functionality, which allows automatic zoom to fit height, width, etc to the window. An unbounded canvas cannot be fit to a window but allows an infinite canvas.

It's challenging for a class like this to be "all things to all men" but I believe this addresses most of the common features typically needed and should simplify samples at the very least.
<img width="1402" height="961" alt="Screenshot From 2025-09-17 19-16-31" src="https://github.com/user-attachments/assets/de96147d-8984-41f5-8c58-07f842bdfb81" />
<img width="1402" height="881" alt="Screenshot From 2025-09-17 19-40-27" src="https://github.com/user-attachments/assets/6f04193a-9c6d-41e4-afad-8d8f47cb531d" />

Tested on macOS, MSW and Linux.
