### PR TITLE
CMake C++17 Enforcement and Platform Parity Improvements

### DIFF
--- a/proj/cmake/libcinder_configure.cmake
+++ b/proj/cmake/libcinder_configure.cmake
@@ -7,6 +7,7 @@ set( CINDER_INC_DIR		"${CINDER_PATH}/include" )
 
 if( NOT CINDER_MSW )
 	add_definitions( -Wfatal-errors )
+	add_definitions( -DHAVE_UNISTD_H )
 endif()
 
 list( APPEND CMAKE_MODULE_PATH ${CINDER_CMAKE_DIR} ${CMAKE_CURRENT_LIST_DIR}/modules )

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -397,6 +397,7 @@ if( NOT CINDER_FREETYPE_USE_SYSTEM )
 		${CINDER_SRC_DIR}/freetype/base/fttype1.c
 		${CINDER_SRC_DIR}/freetype/base/ftwinfnt.c
 		${CINDER_SRC_DIR}/freetype/raster/raster.c
+		${CINDER_SRC_DIR}/freetype/raster/rastpic.c
 		${CINDER_SRC_DIR}/freetype/smooth/smooth.c
 		${CINDER_SRC_DIR}/freetype/autofit/autofit.c
 		${CINDER_SRC_DIR}/freetype/bzip2/ftbzip2.c

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -24,7 +24,6 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/DataTarget.cpp
 	${CINDER_SRC_DIR}/cinder/Display.cpp
 	${CINDER_SRC_DIR}/cinder/Exception.cpp
-	${CINDER_SRC_DIR}/cinder/Filesystem.cpp
 	${CINDER_SRC_DIR}/cinder/FileWatcher.cpp
 	${CINDER_SRC_DIR}/cinder/Font.cpp
 	${CINDER_SRC_DIR}/cinder/Frustum.cpp
@@ -284,13 +283,13 @@ source_group( "thirdparty\\libtess" FILES   ${SRC_SET_LIBTESS} )
 # libpng
 # ----------------------------------------------------------------------------------------------------------------------
 
-if( PNG_FOUND )
-	list( APPEND SRC_SET_TINYEXR
+# ImageSourcePng: always included on Windows (user must link against libpng to use it)
+# On other platforms, only include if PNG_FOUND
+if( CINDER_MSW OR PNG_FOUND )
+	list( APPEND CINDER_SRC_FILES
 		${CINDER_SRC_DIR}/cinder/ImageSourcePng.cpp
 	)
-
-	list( APPEND CINDER_SRC_FILES ${SRC_SET_TINYEXR} )
-	source_group( "cinder" FILES ${SRC_SET_CINDER_APP} )
+	source_group( "cinder" FILES ${CINDER_SRC_DIR}/cinder/ImageSourcePng.cpp )
 endif()
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -72,57 +72,15 @@ elseif( CINDER_COCOA_TOUCH )
 elseif( CINDER_LINUX )
 endif()
 
-# Check compiler support for enabling c++11 or c++14 or c++17.
+# Enforce the minimum C++ standard Cinder requires.
 if( CINDER_MSW AND MSVC )
-    if( MSVC_VERSION LESS 1800 ) # Older version of Visual Studio
-        message( FATAL_ERROR "Unsupported MSVC version: ${MSVC_VERSION}" )
-    elseif( MSVC_VERSION LESS 1900 ) # Visual Studio 2013
-        set( COMPILER_SUPPORTS_CXX11 true )
-    elseif( MSVC_VERSION LESS 1920 ) # Visual Studio 2015
-        set( COMPILER_SUPPORTS_CXX14 true )
-        set( COMPILER_SUPPORTS_CXX11 true )
-    else() # Visual Studio 2019
-        set( COMPILER_SUPPORTS_CXX17 true )
-        set( COMPILER_SUPPORTS_CXX14 true )
-        set( COMPILER_SUPPORTS_CXX11 true )
+    if( MSVC_VERSION LESS 1920 )
+        message( FATAL_ERROR "Cinder requires Visual Studio 2019 (MSVC 19.20) or newer." )
     endif()
-elseif( CINDER_ANDROID )
-	# Assume true for Android since compiler is Clang 3.8 at minimum
-   	set( COMPILER_SUPPORTS_CXX14 true )
-    set( COMPILER_SUPPORTS_CXX11 true )
-else()
-    include( CheckCXXCompilerFlag )
-    CHECK_CXX_COMPILER_FLAG( "-std=c++17" COMPILER_SUPPORTS_CXX17 )
-    CHECK_CXX_COMPILER_FLAG( "-std=c++14" COMPILER_SUPPORTS_CXX14 )
-    CHECK_CXX_COMPILER_FLAG( "-std=c++11" COMPILER_SUPPORTS_CXX11 )
 endif()
 
-if( COMPILER_SUPPORTS_CXX17 )
-    if( NOT MSVC )
-        set( CINDER_CXX_FLAGS "-std=c++17" )
-    else()
-        set( CINDER_CXX_FLAGS "/std:c++17" )
-    endif()
-elseif( COMPILER_SUPPORTS_CXX14 )
-    if( NOT MSVC )
-        set( CINDER_CXX_FLAGS "-std=c++14" )
-    else()
-        set( CINDER_CXX_FLAGS "/std:c++14")
-    endif()
-elseif( COMPILER_SUPPORTS_CXX11 )
-    if( NOT MSVC )
-        set( CINDER_CXX_FLAGS "-std=c++11" )
-    else()
-        set( CINDER_CXX_FLAGS "/std:c++11")
-    endif()
-else()
-	message( FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has neither C++11 or C++14 or C++17 support. Please use a different C++ compiler." )
-endif()
-
-# TODO: it would be nice to the following, but we can't until min required cmake is 3.3
-#target_compile_options( cinder PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${CINDER_CXX_FLAGS}> )
-set( CMAKE_CXX_FLAGS "${CINDER_CXX_FLAGS} ${CMAKE_CXX_FLAGS}" )
-target_compile_options( cinder INTERFACE ${CINDER_CXX_FLAGS} )
+target_compile_features( cinder PUBLIC cxx_std_17 )
+set_property( TARGET cinder PROPERTY CXX_EXTENSIONS OFF )
 
 # This file will contain all dependencies, includes, definition, compiler flags and so on..
 export( TARGETS cinder FILE ${PROJECT_BINARY_DIR}/${CINDER_LIB_DIRECTORY}/cinderTargets.cmake )

--- a/proj/cmake/libcinder_target.cmake
+++ b/proj/cmake/libcinder_target.cmake
@@ -80,7 +80,11 @@ if( CINDER_MSW AND MSVC )
 endif()
 
 target_compile_features( cinder PUBLIC cxx_std_17 )
-set_property( TARGET cinder PROPERTY CXX_EXTENSIONS OFF )
+set_target_properties( cinder PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF
+)
 
 # This file will contain all dependencies, includes, definition, compiler flags and so on..
 export( TARGETS cinder FILE ${PROJECT_BINARY_DIR}/${CINDER_LIB_DIRECTORY}/cinderTargets.cmake )

--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -2,6 +2,11 @@ cmake_minimum_required( VERSION 3.10 FATAL_ERROR )
 
 set( CINDER_PLATFORM "Cocoa" )
 
+# Build universal binaries for macOS (arm64 + x86_64) to match Xcode default behavior
+if( NOT CMAKE_OSX_ARCHITECTURES )
+	set( CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "macOS architectures" FORCE )
+endif()
+
 # append mac specific source files
 list( APPEND SRC_SET_COCOA
 	${CINDER_SRC_DIR}/cinder/CaptureImplAvFoundation.mm

--- a/proj/cmake/platform_macosx.cmake
+++ b/proj/cmake/platform_macosx.cmake
@@ -10,6 +10,7 @@ endif()
 # append mac specific source files
 list( APPEND SRC_SET_COCOA
 	${CINDER_SRC_DIR}/cinder/CaptureImplAvFoundation.mm
+	${CINDER_SRC_DIR}/cinder/Filesystem.cpp
 	${CINDER_SRC_DIR}/cinder/ImageSourceFileQuartz.cpp
 	${CINDER_SRC_DIR}/cinder/ImageTargetFileQuartz.cpp
 	${CINDER_SRC_DIR}/cinder/UrlImplCocoa.mm

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -101,6 +101,7 @@ source_group( "cinder\\audio\\dsp"	FILES ${SRC_SET_CINDER_AUDIO_DSP} )
 source_group( "cinder\\video\\msw"	FILES ${SRC_SET_VIDEO_MSW} )
 
 list( APPEND CINDER_INCLUDE_SYSTEM_PRIVATE
+	${CINDER_INC_DIR}/msw/png
 	${CINDER_INC_DIR}/msw/zlib
 	${CINDER_INC_DIR}/msw
 )

--- a/proj/vc2019/cinder.vcxproj
+++ b/proj/vc2019/cinder.vcxproj
@@ -628,7 +628,14 @@
     <ClCompile Include="..\..\src\cinder\app\msw\AppMsw.cpp" />
     <ClCompile Include="..\..\src\cinder\app\msw\PlatformMsw.cpp" />
     <ClCompile Include="..\..\src\cinder\app\msw\RendererImpl2dGdi.cpp" />
-    <ClCompile Include="..\..\src\cinder\app\msw\RendererImplGlAngle.cpp" />
+    <ClCompile Include="..\..\src\cinder\app\msw\RendererImplGlAngle.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_ANGLE|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug_Shared|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_ANGLE|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Shared|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\cinder\app\msw\RendererImplGlMsw.cpp" />
     <ClCompile Include="..\..\src\cinder\app\Platform.cpp" />
     <ClCompile Include="..\..\src\cinder\app\RendererGl.cpp" />
@@ -823,7 +830,7 @@
     <ClCompile Include="..\..\src\cinder\Matrix.cpp" />
     <ClCompile Include="..\..\src\cinder\MediaTime.cpp" />
     <ClCompile Include="..\..\src\cinder\ObjLoader.cpp" />
-    <ClCompile Include="..\..\src\cinder\Path2D.cpp" />
+    <ClCompile Include="..\..\src\cinder\Path2d.cpp" />
     <ClCompile Include="..\..\src\cinder\Perlin.cpp" />
     <ClCompile Include="..\..\src\cinder\Plane.cpp" />
     <ClCompile Include="..\..\src\cinder\PolyLine.cpp" />

--- a/proj/vc2019/cinder.vcxproj.filters
+++ b/proj/vc2019/cinder.vcxproj.filters
@@ -1083,6 +1083,9 @@
     <ClCompile Include="..\..\src\imgui\imgui_tables.cpp">
       <Filter>Source Files\imgui</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\cinder\CanvasUi.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\AntTweakBar\AntPerfTimer.h">
@@ -2274,6 +2277,9 @@
       <Filter>Header Files\gl\nv</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\cinder\MediaTime.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\cinder\CanvasUi.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
  ## Modernize CMake C++17 Enforcement and Platform Parity Improvements
This PR updates the mechanism for C++17 standard enforcement with CMake, and brings parity on macOS and Windows to their respective platform-specific build files.

  ### C++17 Standard Enforcement (Addresses #2211, #2189)
  - Replaces manual compiler flag detection with `target_compile_features(cxx_std_17)`
  - Sets `CXX_STANDARD 17`, `CXX_STANDARD_REQUIRED ON`, and `CXX_EXTENSIONS OFF` via `set_target_properties()`
  - Removes brittle manual `-std=c++17` flag logic that broke downstream compilation with tools like nvcc
  - Ensures `-std=c++17` is applied instead of GNU extensions mode, preventing the `linux` macro from conflicting with `namespace linux` in system headers
  - Updates minimum MSVC requirement to Visual Studio 2019 (MSVC 19.20)

  ### Platform-Specific Adjustments
  - Adds `HAVE_UNISTD_H` definition for non-Windows platforms
  - Moves `Filesystem.cpp` to macOS-only builds (related to #2316)
  - Ensures PNG support (`ImageSourcePng.cpp`) is always built on Windows, conditionally on other platforms

  ### macOS Universal Binary Support
  - Builds universal binaries (arm64 + x86_64) by default to match Xcode project behavior
  - Respects `CMAKE_OSX_ARCHITECTURES` if explicitly set by users

  ### Visual Studio 2019 Project Updates
  - Excludes `RendererImplGlAngle.cpp` from non-ANGLE build configurations (Debug, Release, Release_Shared, Debug_Shared)
  - Corrects case of `Path2D.cpp` to `Path2d.cpp` to match actual filename
  - Adds `CanvasUi.cpp` and `CanvasUi.h` to project file
  - #2261 appears to be fixed