### PR TITLE
QOI Image format

### DIFF
--- a/include/cinder/ImageSourceFileQoi.h
+++ b/include/cinder/ImageSourceFileQoi.h
@@ -1,0 +1,51 @@
+/*
+ Copyright (c) 2025, The Cinder Project, All rights reserved.
+
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "cinder/Cinder.h"
+#include "cinder/ImageIo.h"
+#include "cinder/Exception.h"
+
+namespace cinder {
+
+typedef std::shared_ptr<class ImageSourceFileQoi>	ImageSourceFileQoiRef;
+
+class ImageSourceFileQoi : public ImageSource {
+  public:
+	~ImageSourceFileQoi();
+
+	static ImageSourceRef	create( DataSourceRef dataSourceRef, ImageSource::Options options ) { return ImageSourceFileQoiRef( new ImageSourceFileQoi( dataSourceRef, options ) ); }
+
+	static void		registerSelf();
+
+	void	load( ImageTargetRef target ) override;
+
+  protected:
+	ImageSourceFileQoi( DataSourceRef dataSourceRef, ImageSource::Options options );
+
+	uint8_t		*mData;
+	size_t		mRowBytes;
+};
+
+} // namespace cinder

--- a/include/cinder/ImageTargetFileQoi.h
+++ b/include/cinder/ImageTargetFileQoi.h
@@ -1,0 +1,51 @@
+/*
+ Copyright (c) 2025, The Cinder Project, All rights reserved.
+
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "cinder/ImageIo.h"
+
+namespace cinder {
+
+typedef std::shared_ptr<class ImageTargetFileQoi> ImageTargetFileQoiRef;
+
+class ImageTargetFileQoi : public ImageTarget {
+  public:
+	static ImageTargetRef		create( DataTargetRef dataTarget, ImageSourceRef imageSource, ImageTarget::Options options, const std::string &extensionData );
+
+	void*	getRowPointer( int32_t row ) override;
+	void	finalize() override;
+
+	static void		registerSelf();
+
+  protected:
+	ImageTargetFileQoi( DataTargetRef dataTarget, ImageSourceRef imageSource, ImageTarget::Options options, const std::string &extensionData );
+
+	uint8_t						mNumComponents;
+	size_t						mRowBytes;
+	fs::path					mFilePath;
+	std::unique_ptr<uint8_t[]>	mData;
+	DataTargetRef				mDataTarget;
+};
+
+} // namespace cinder

--- a/include/qoi/qoi.h
+++ b/include/qoi/qoi.h
@@ -1,0 +1,649 @@
+/*
+
+Copyright (c) 2021, Dominic Szablewski - https://phoboslab.org
+SPDX-License-Identifier: MIT
+
+
+QOI - The "Quite OK Image" format for fast, lossless image compression
+
+-- About
+
+QOI encodes and decodes images in a lossless format. Compared to stb_image and
+stb_image_write QOI offers 20x-50x faster encoding, 3x-4x faster decoding and
+20% better compression.
+
+
+-- Synopsis
+
+// Define `QOI_IMPLEMENTATION` in *one* C/C++ file before including this
+// library to create the implementation.
+
+#define QOI_IMPLEMENTATION
+#include "qoi.h"
+
+// Encode and store an RGBA buffer to the file system. The qoi_desc describes
+// the input pixel data.
+qoi_write("image_new.qoi", rgba_pixels, &(qoi_desc){
+	.width = 1920,
+	.height = 1080,
+	.channels = 4,
+	.colorspace = QOI_SRGB
+});
+
+// Load and decode a QOI image from the file system into a 32bbp RGBA buffer.
+// The qoi_desc struct will be filled with the width, height, number of channels
+// and colorspace read from the file header.
+qoi_desc desc;
+void *rgba_pixels = qoi_read("image.qoi", &desc, 4);
+
+
+
+-- Documentation
+
+This library provides the following functions;
+- qoi_read    -- read and decode a QOI file
+- qoi_decode  -- decode the raw bytes of a QOI image from memory
+- qoi_write   -- encode and write a QOI file
+- qoi_encode  -- encode an rgba buffer into a QOI image in memory
+
+See the function declaration below for the signature and more information.
+
+If you don't want/need the qoi_read and qoi_write functions, you can define
+QOI_NO_STDIO before including this library.
+
+This library uses malloc() and free(). To supply your own malloc implementation
+you can define QOI_MALLOC and QOI_FREE before including this library.
+
+This library uses memset() to zero-initialize the index. To supply your own
+implementation you can define QOI_ZEROARR before including this library.
+
+
+-- Data Format
+
+A QOI file has a 14 byte header, followed by any number of data "chunks" and an
+8-byte end marker.
+
+struct qoi_header_t {
+	char     magic[4];   // magic bytes "qoif"
+	uint32_t width;      // image width in pixels (BE)
+	uint32_t height;     // image height in pixels (BE)
+	uint8_t  channels;   // 3 = RGB, 4 = RGBA
+	uint8_t  colorspace; // 0 = sRGB with linear alpha, 1 = all channels linear
+};
+
+Images are encoded row by row, left to right, top to bottom. The decoder and
+encoder start with {r: 0, g: 0, b: 0, a: 255} as the previous pixel value. An
+image is complete when all pixels specified by width * height have been covered.
+
+Pixels are encoded as
+ - a run of the previous pixel
+ - an index into an array of previously seen pixels
+ - a difference to the previous pixel value in r,g,b
+ - full r,g,b or r,g,b,a values
+
+The color channels are assumed to not be premultiplied with the alpha channel
+("un-premultiplied alpha").
+
+A running array[64] (zero-initialized) of previously seen pixel values is
+maintained by the encoder and decoder. Each pixel that is seen by the encoder
+and decoder is put into this array at the position formed by a hash function of
+the color value. In the encoder, if the pixel value at the index matches the
+current pixel, this index position is written to the stream as QOI_OP_INDEX.
+The hash function for the index is:
+
+	index_position = (r * 3 + g * 5 + b * 7 + a * 11) % 64
+
+Each chunk starts with a 2- or 8-bit tag, followed by a number of data bits. The
+bit length of chunks is divisible by 8 - i.e. all chunks are byte aligned. All
+values encoded in these data bits have the most significant bit on the left.
+
+The 8-bit tags have precedence over the 2-bit tags. A decoder must check for the
+presence of an 8-bit tag first.
+
+The byte stream's end is marked with 7 0x00 bytes followed a single 0x01 byte.
+
+
+The possible chunks are:
+
+
+.- QOI_OP_INDEX ----------.
+|         Byte[0]         |
+|  7  6  5  4  3  2  1  0 |
+|-------+-----------------|
+|  0  0 |     index       |
+`-------------------------`
+2-bit tag b00
+6-bit index into the color index array: 0..63
+
+A valid encoder must not issue 2 or more consecutive QOI_OP_INDEX chunks to the
+same index. QOI_OP_RUN should be used instead.
+
+
+.- QOI_OP_DIFF -----------.
+|         Byte[0]         |
+|  7  6  5  4  3  2  1  0 |
+|-------+-----+-----+-----|
+|  0  1 |  dr |  dg |  db |
+`-------------------------`
+2-bit tag b01
+2-bit   red channel difference from the previous pixel between -2..1
+2-bit green channel difference from the previous pixel between -2..1
+2-bit  blue channel difference from the previous pixel between -2..1
+
+The difference to the current channel values are using a wraparound operation,
+so "1 - 2" will result in 255, while "255 + 1" will result in 0.
+
+Values are stored as unsigned integers with a bias of 2. E.g. -2 is stored as
+0 (b00). 1 is stored as 3 (b11).
+
+The alpha value remains unchanged from the previous pixel.
+
+
+.- QOI_OP_LUMA -------------------------------------.
+|         Byte[0]         |         Byte[1]         |
+|  7  6  5  4  3  2  1  0 |  7  6  5  4  3  2  1  0 |
+|-------+-----------------+-------------+-----------|
+|  1  0 |  green diff     |   dr - dg   |  db - dg  |
+`---------------------------------------------------`
+2-bit tag b10
+6-bit green channel difference from the previous pixel -32..31
+4-bit   red channel difference minus green channel difference -8..7
+4-bit  blue channel difference minus green channel difference -8..7
+
+The green channel is used to indicate the general direction of change and is
+encoded in 6 bits. The red and blue channels (dr and db) base their diffs off
+of the green channel difference and are encoded in 4 bits. I.e.:
+	dr_dg = (cur_px.r - prev_px.r) - (cur_px.g - prev_px.g)
+	db_dg = (cur_px.b - prev_px.b) - (cur_px.g - prev_px.g)
+
+The difference to the current channel values are using a wraparound operation,
+so "10 - 13" will result in 253, while "250 + 7" will result in 1.
+
+Values are stored as unsigned integers with a bias of 32 for the green channel
+and a bias of 8 for the red and blue channel.
+
+The alpha value remains unchanged from the previous pixel.
+
+
+.- QOI_OP_RUN ------------.
+|         Byte[0]         |
+|  7  6  5  4  3  2  1  0 |
+|-------+-----------------|
+|  1  1 |       run       |
+`-------------------------`
+2-bit tag b11
+6-bit run-length repeating the previous pixel: 1..62
+
+The run-length is stored with a bias of -1. Note that the run-lengths 63 and 64
+(b111110 and b111111) are illegal as they are occupied by the QOI_OP_RGB and
+QOI_OP_RGBA tags.
+
+
+.- QOI_OP_RGB ------------------------------------------.
+|         Byte[0]         | Byte[1] | Byte[2] | Byte[3] |
+|  7  6  5  4  3  2  1  0 | 7 .. 0  | 7 .. 0  | 7 .. 0  |
+|-------------------------+---------+---------+---------|
+|  1  1  1  1  1  1  1  0 |   red   |  green  |  blue   |
+`-------------------------------------------------------`
+8-bit tag b11111110
+8-bit   red channel value
+8-bit green channel value
+8-bit  blue channel value
+
+The alpha value remains unchanged from the previous pixel.
+
+
+.- QOI_OP_RGBA ---------------------------------------------------.
+|         Byte[0]         | Byte[1] | Byte[2] | Byte[3] | Byte[4] |
+|  7  6  5  4  3  2  1  0 | 7 .. 0  | 7 .. 0  | 7 .. 0  | 7 .. 0  |
+|-------------------------+---------+---------+---------+---------|
+|  1  1  1  1  1  1  1  1 |   red   |  green  |  blue   |  alpha  |
+`-----------------------------------------------------------------`
+8-bit tag b11111111
+8-bit   red channel value
+8-bit green channel value
+8-bit  blue channel value
+8-bit alpha channel value
+
+*/
+
+
+/* -----------------------------------------------------------------------------
+Header - Public functions */
+
+#ifndef QOI_H
+#define QOI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* A pointer to a qoi_desc struct has to be supplied to all of qoi's functions.
+It describes either the input format (for qoi_write and qoi_encode), or is
+filled with the description read from the file header (for qoi_read and
+qoi_decode).
+
+The colorspace in this qoi_desc is an enum where
+	0 = sRGB, i.e. gamma scaled RGB channels and a linear alpha channel
+	1 = all channels are linear
+You may use the constants QOI_SRGB or QOI_LINEAR. The colorspace is purely
+informative. It will be saved to the file header, but does not affect
+how chunks are en-/decoded. */
+
+#define QOI_SRGB   0
+#define QOI_LINEAR 1
+
+typedef struct {
+	unsigned int width;
+	unsigned int height;
+	unsigned char channels;
+	unsigned char colorspace;
+} qoi_desc;
+
+#ifndef QOI_NO_STDIO
+
+/* Encode raw RGB or RGBA pixels into a QOI image and write it to the file
+system. The qoi_desc struct must be filled with the image width, height,
+number of channels (3 = RGB, 4 = RGBA) and the colorspace.
+
+The function returns 0 on failure (invalid parameters, or fopen or malloc
+failed) or the number of bytes written on success. */
+
+int qoi_write(const char *filename, const void *data, const qoi_desc *desc);
+
+
+/* Read and decode a QOI image from the file system. If channels is 0, the
+number of channels from the file header is used. If channels is 3 or 4 the
+output format will be forced into this number of channels.
+
+The function either returns NULL on failure (invalid data, or malloc or fopen
+failed) or a pointer to the decoded pixels. On success, the qoi_desc struct
+will be filled with the description from the file header.
+
+The returned pixel data should be free()d after use. */
+
+void *qoi_read(const char *filename, qoi_desc *desc, int channels);
+
+#endif /* QOI_NO_STDIO */
+
+
+/* Encode raw RGB or RGBA pixels into a QOI image in memory.
+
+The function either returns NULL on failure (invalid parameters or malloc
+failed) or a pointer to the encoded data on success. On success the out_len
+is set to the size in bytes of the encoded data.
+
+The returned qoi data should be free()d after use. */
+
+void *qoi_encode(const void *data, const qoi_desc *desc, int *out_len);
+
+
+/* Decode a QOI image from memory.
+
+The function either returns NULL on failure (invalid parameters or malloc
+failed) or a pointer to the decoded pixels. On success, the qoi_desc struct
+is filled with the description from the file header.
+
+The returned pixel data should be free()d after use. */
+
+void *qoi_decode(const void *data, int size, qoi_desc *desc, int channels);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* QOI_H */
+
+
+/* -----------------------------------------------------------------------------
+Implementation */
+
+#ifdef QOI_IMPLEMENTATION
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef QOI_MALLOC
+	#define QOI_MALLOC(sz) malloc(sz)
+	#define QOI_FREE(p)    free(p)
+#endif
+#ifndef QOI_ZEROARR
+	#define QOI_ZEROARR(a) memset((a),0,sizeof(a))
+#endif
+
+#define QOI_OP_INDEX  0x00 /* 00xxxxxx */
+#define QOI_OP_DIFF   0x40 /* 01xxxxxx */
+#define QOI_OP_LUMA   0x80 /* 10xxxxxx */
+#define QOI_OP_RUN    0xc0 /* 11xxxxxx */
+#define QOI_OP_RGB    0xfe /* 11111110 */
+#define QOI_OP_RGBA   0xff /* 11111111 */
+
+#define QOI_MASK_2    0xc0 /* 11000000 */
+
+#define QOI_COLOR_HASH(C) (C.rgba.r*3 + C.rgba.g*5 + C.rgba.b*7 + C.rgba.a*11)
+#define QOI_MAGIC \
+	(((unsigned int)'q') << 24 | ((unsigned int)'o') << 16 | \
+	 ((unsigned int)'i') <<  8 | ((unsigned int)'f'))
+#define QOI_HEADER_SIZE 14
+
+/* 2GB is the max file size that this implementation can safely handle. We guard
+against anything larger than that, assuming the worst case with 5 bytes per
+pixel, rounded down to a nice clean value. 400 million pixels ought to be
+enough for anybody. */
+#define QOI_PIXELS_MAX ((unsigned int)400000000)
+
+typedef union {
+	struct { unsigned char r, g, b, a; } rgba;
+	unsigned int v;
+} qoi_rgba_t;
+
+static const unsigned char qoi_padding[8] = {0,0,0,0,0,0,0,1};
+
+static void qoi_write_32(unsigned char *bytes, int *p, unsigned int v) {
+	bytes[(*p)++] = (0xff000000 & v) >> 24;
+	bytes[(*p)++] = (0x00ff0000 & v) >> 16;
+	bytes[(*p)++] = (0x0000ff00 & v) >> 8;
+	bytes[(*p)++] = (0x000000ff & v);
+}
+
+static unsigned int qoi_read_32(const unsigned char *bytes, int *p) {
+	unsigned int a = bytes[(*p)++];
+	unsigned int b = bytes[(*p)++];
+	unsigned int c = bytes[(*p)++];
+	unsigned int d = bytes[(*p)++];
+	return a << 24 | b << 16 | c << 8 | d;
+}
+
+void *qoi_encode(const void *data, const qoi_desc *desc, int *out_len) {
+	int i, max_size, p, run;
+	int px_len, px_end, px_pos, channels;
+	unsigned char *bytes;
+	const unsigned char *pixels;
+	qoi_rgba_t index[64];
+	qoi_rgba_t px, px_prev;
+
+	if (
+		data == NULL || out_len == NULL || desc == NULL ||
+		desc->width == 0 || desc->height == 0 ||
+		desc->channels < 3 || desc->channels > 4 ||
+		desc->colorspace > 1 ||
+		desc->height >= QOI_PIXELS_MAX / desc->width
+	) {
+		return NULL;
+	}
+
+	max_size =
+		desc->width * desc->height * (desc->channels + 1) +
+		QOI_HEADER_SIZE + sizeof(qoi_padding);
+
+	p = 0;
+	bytes = (unsigned char *) QOI_MALLOC(max_size);
+	if (!bytes) {
+		return NULL;
+	}
+
+	qoi_write_32(bytes, &p, QOI_MAGIC);
+	qoi_write_32(bytes, &p, desc->width);
+	qoi_write_32(bytes, &p, desc->height);
+	bytes[p++] = desc->channels;
+	bytes[p++] = desc->colorspace;
+
+
+	pixels = (const unsigned char *)data;
+
+	QOI_ZEROARR(index);
+
+	run = 0;
+	px_prev.rgba.r = 0;
+	px_prev.rgba.g = 0;
+	px_prev.rgba.b = 0;
+	px_prev.rgba.a = 255;
+	px = px_prev;
+
+	px_len = desc->width * desc->height * desc->channels;
+	px_end = px_len - desc->channels;
+	channels = desc->channels;
+
+	for (px_pos = 0; px_pos < px_len; px_pos += channels) {
+		px.rgba.r = pixels[px_pos + 0];
+		px.rgba.g = pixels[px_pos + 1];
+		px.rgba.b = pixels[px_pos + 2];
+
+		if (channels == 4) {
+			px.rgba.a = pixels[px_pos + 3];
+		}
+
+		if (px.v == px_prev.v) {
+			run++;
+			if (run == 62 || px_pos == px_end) {
+				bytes[p++] = QOI_OP_RUN | (run - 1);
+				run = 0;
+			}
+		}
+		else {
+			int index_pos;
+
+			if (run > 0) {
+				bytes[p++] = QOI_OP_RUN | (run - 1);
+				run = 0;
+			}
+
+			index_pos = QOI_COLOR_HASH(px) & (64 - 1);
+
+			if (index[index_pos].v == px.v) {
+				bytes[p++] = QOI_OP_INDEX | index_pos;
+			}
+			else {
+				index[index_pos] = px;
+
+				if (px.rgba.a == px_prev.rgba.a) {
+					signed char vr = px.rgba.r - px_prev.rgba.r;
+					signed char vg = px.rgba.g - px_prev.rgba.g;
+					signed char vb = px.rgba.b - px_prev.rgba.b;
+
+					signed char vg_r = vr - vg;
+					signed char vg_b = vb - vg;
+
+					if (
+						vr > -3 && vr < 2 &&
+						vg > -3 && vg < 2 &&
+						vb > -3 && vb < 2
+					) {
+						bytes[p++] = QOI_OP_DIFF | (vr + 2) << 4 | (vg + 2) << 2 | (vb + 2);
+					}
+					else if (
+						vg_r >  -9 && vg_r <  8 &&
+						vg   > -33 && vg   < 32 &&
+						vg_b >  -9 && vg_b <  8
+					) {
+						bytes[p++] = QOI_OP_LUMA     | (vg   + 32);
+						bytes[p++] = (vg_r + 8) << 4 | (vg_b +  8);
+					}
+					else {
+						bytes[p++] = QOI_OP_RGB;
+						bytes[p++] = px.rgba.r;
+						bytes[p++] = px.rgba.g;
+						bytes[p++] = px.rgba.b;
+					}
+				}
+				else {
+					bytes[p++] = QOI_OP_RGBA;
+					bytes[p++] = px.rgba.r;
+					bytes[p++] = px.rgba.g;
+					bytes[p++] = px.rgba.b;
+					bytes[p++] = px.rgba.a;
+				}
+			}
+		}
+		px_prev = px;
+	}
+
+	for (i = 0; i < (int)sizeof(qoi_padding); i++) {
+		bytes[p++] = qoi_padding[i];
+	}
+
+	*out_len = p;
+	return bytes;
+}
+
+void *qoi_decode(const void *data, int size, qoi_desc *desc, int channels) {
+	const unsigned char *bytes;
+	unsigned int header_magic;
+	unsigned char *pixels;
+	qoi_rgba_t index[64];
+	qoi_rgba_t px;
+	int px_len, chunks_len, px_pos;
+	int p = 0, run = 0;
+
+	if (
+		data == NULL || desc == NULL ||
+		(channels != 0 && channels != 3 && channels != 4) ||
+		size < QOI_HEADER_SIZE + (int)sizeof(qoi_padding)
+	) {
+		return NULL;
+	}
+
+	bytes = (const unsigned char *)data;
+
+	header_magic = qoi_read_32(bytes, &p);
+	desc->width = qoi_read_32(bytes, &p);
+	desc->height = qoi_read_32(bytes, &p);
+	desc->channels = bytes[p++];
+	desc->colorspace = bytes[p++];
+
+	if (
+		desc->width == 0 || desc->height == 0 ||
+		desc->channels < 3 || desc->channels > 4 ||
+		desc->colorspace > 1 ||
+		header_magic != QOI_MAGIC ||
+		desc->height >= QOI_PIXELS_MAX / desc->width
+	) {
+		return NULL;
+	}
+
+	if (channels == 0) {
+		channels = desc->channels;
+	}
+
+	px_len = desc->width * desc->height * channels;
+	pixels = (unsigned char *) QOI_MALLOC(px_len);
+	if (!pixels) {
+		return NULL;
+	}
+
+	QOI_ZEROARR(index);
+	px.rgba.r = 0;
+	px.rgba.g = 0;
+	px.rgba.b = 0;
+	px.rgba.a = 255;
+
+	chunks_len = size - (int)sizeof(qoi_padding);
+	for (px_pos = 0; px_pos < px_len; px_pos += channels) {
+		if (run > 0) {
+			run--;
+		}
+		else if (p < chunks_len) {
+			int b1 = bytes[p++];
+
+			if (b1 == QOI_OP_RGB) {
+				px.rgba.r = bytes[p++];
+				px.rgba.g = bytes[p++];
+				px.rgba.b = bytes[p++];
+			}
+			else if (b1 == QOI_OP_RGBA) {
+				px.rgba.r = bytes[p++];
+				px.rgba.g = bytes[p++];
+				px.rgba.b = bytes[p++];
+				px.rgba.a = bytes[p++];
+			}
+			else if ((b1 & QOI_MASK_2) == QOI_OP_INDEX) {
+				px = index[b1];
+			}
+			else if ((b1 & QOI_MASK_2) == QOI_OP_DIFF) {
+				px.rgba.r += ((b1 >> 4) & 0x03) - 2;
+				px.rgba.g += ((b1 >> 2) & 0x03) - 2;
+				px.rgba.b += ( b1       & 0x03) - 2;
+			}
+			else if ((b1 & QOI_MASK_2) == QOI_OP_LUMA) {
+				int b2 = bytes[p++];
+				int vg = (b1 & 0x3f) - 32;
+				px.rgba.r += vg - 8 + ((b2 >> 4) & 0x0f);
+				px.rgba.g += vg;
+				px.rgba.b += vg - 8 +  (b2       & 0x0f);
+			}
+			else if ((b1 & QOI_MASK_2) == QOI_OP_RUN) {
+				run = (b1 & 0x3f);
+			}
+
+			index[QOI_COLOR_HASH(px) & (64 - 1)] = px;
+		}
+
+		pixels[px_pos + 0] = px.rgba.r;
+		pixels[px_pos + 1] = px.rgba.g;
+		pixels[px_pos + 2] = px.rgba.b;
+		
+		if (channels == 4) {
+			pixels[px_pos + 3] = px.rgba.a;
+		}
+	}
+
+	return pixels;
+}
+
+#ifndef QOI_NO_STDIO
+#include <stdio.h>
+
+int qoi_write(const char *filename, const void *data, const qoi_desc *desc) {
+	FILE *f = fopen(filename, "wb");
+	int size, err;
+	void *encoded;
+
+	if (!f) {
+		return 0;
+	}
+
+	encoded = qoi_encode(data, desc, &size);
+	if (!encoded) {
+		fclose(f);
+		return 0;
+	}
+
+	fwrite(encoded, 1, size, f);
+	fflush(f);
+	err = ferror(f);
+	fclose(f);
+
+	QOI_FREE(encoded);
+	return err ? 0 : size;
+}
+
+void *qoi_read(const char *filename, qoi_desc *desc, int channels) {
+	FILE *f = fopen(filename, "rb");
+	int size, bytes_read;
+	void *pixels, *data;
+
+	if (!f) {
+		return NULL;
+	}
+
+	fseek(f, 0, SEEK_END);
+	size = ftell(f);
+	if (size <= 0 || fseek(f, 0, SEEK_SET) != 0) {
+		fclose(f);
+		return NULL;
+	}
+
+	data = QOI_MALLOC(size);
+	if (!data) {
+		fclose(f);
+		return NULL;
+	}
+
+	bytes_read = fread(data, 1, size, f);
+	fclose(f);
+	pixels = (bytes_read != size) ? NULL : qoi_decode(data, bytes_read, desc, channels);
+	QOI_FREE(data);
+	return pixels;
+}
+
+#endif /* QOI_NO_STDIO */
+#endif /* QOI_IMPLEMENTATION */

--- a/proj/android/CMakeLists.txt
+++ b/proj/android/CMakeLists.txt
@@ -663,6 +663,8 @@ set( CINDER_CXX_SRC_FILES
     ${CINDER_SRC_DIR}/cinder/ImageSourceFileRadiance.cpp
     ${CINDER_SRC_DIR}/cinder/ImageSourceFileStbImage.cpp
     ${CINDER_SRC_DIR}/cinder/ImageTargetFileStbImage.cpp
+    ${CINDER_SRC_DIR}/cinder/ImageSourceFileQoi.cpp
+    ${CINDER_SRC_DIR}/cinder/ImageTargetFileQoi.cpp
     ${CINDER_SRC_DIR}/cinder/ImageFileTinyExr.cpp
     ${CINDER_SRC_DIR}/cinder/Json.cpp
     ${CINDER_SRC_DIR}/cinder/Log.cpp

--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -33,6 +33,8 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/ImageSourceFileRadiance.cpp
 	${CINDER_SRC_DIR}/cinder/ImageSourceFileStbImage.cpp
 	${CINDER_SRC_DIR}/cinder/ImageTargetFileStbImage.cpp
+	${CINDER_SRC_DIR}/cinder/ImageSourceFileQoi.cpp
+	${CINDER_SRC_DIR}/cinder/ImageTargetFileQoi.cpp
 	${CINDER_SRC_DIR}/cinder/Json.cpp
 	${CINDER_SRC_DIR}/cinder/Log.cpp
 	${CINDER_SRC_DIR}/cinder/Matrix.cpp

--- a/proj/vc2019/cinder.vcxproj
+++ b/proj/vc2019/cinder.vcxproj
@@ -820,6 +820,8 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release_Shared|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\cinder\ImageTargetFileStbImage.cpp" />
+    <ClCompile Include="..\..\src\cinder\ImageSourceFileQoi.cpp" />
+    <ClCompile Include="..\..\src\cinder\ImageTargetFileQoi.cpp" />
     <ClCompile Include="..\..\src\cinder\ImageTargetFileWic.cpp" />
     <ClCompile Include="..\..\src\cinder\ip\Blend.cpp" />
     <ClCompile Include="..\..\src\cinder\CinderMath.cpp" />
@@ -1134,6 +1136,8 @@
     <ClInclude Include="..\..\include\cinder\ImageSourceFileRadiance.h" />
     <ClInclude Include="..\..\include\cinder\ImageSourceFileStbImage.h" />
     <ClInclude Include="..\..\include\cinder\ImageTargetFileStbImage.h" />
+    <ClInclude Include="..\..\include\cinder\ImageSourceFileQoi.h" />
+    <ClInclude Include="..\..\include\cinder\ImageTargetFileQoi.h" />
     <ClInclude Include="..\..\include\cinder\ip\Blend.h" />
     <ClInclude Include="..\..\include\cinder\ip\Blur.h" />
     <ClInclude Include="..\..\include\cinder\ip\Checkerboard.h" />

--- a/proj/xcode/cinder.xcodeproj/project.pbxproj
+++ b/proj/xcode/cinder.xcodeproj/project.pbxproj
@@ -430,6 +430,18 @@
 		27BE4DCF1DA9E4FC00DE84C8 /* ImageSourceFileStbImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA7E1B1C1B2000A23DDB /* ImageSourceFileStbImage.cpp */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
 		27BE4DD01DA9E4FC00DE84C8 /* ImageSourceFileStbImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA7E1B1C1B2000A23DDB /* ImageSourceFileStbImage.cpp */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
 		27BE4DD11DA9E4FD00DE84C8 /* ImageSourceFileStbImage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA7E1B1C1B2000A23DDB /* ImageSourceFileStbImage.cpp */; settings = {COMPILER_FLAGS = "-Wno-unused-function"; }; };
+		27BE4DD41DA9E4B900DE84C9 /* ImageSourceFileQoi.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BE4DD21DA9E4B900DE84C9 /* ImageSourceFileQoi.h */; };
+		27BE4DD51DA9E4B900DE84C9 /* ImageSourceFileQoi.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BE4DD21DA9E4B900DE84C9 /* ImageSourceFileQoi.h */; };
+		27BE4DD61DA9E4B900DE84C9 /* ImageSourceFileQoi.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BE4DD21DA9E4B900DE84C9 /* ImageSourceFileQoi.h */; };
+		27BE4DD71DA9E4B900DE84C9 /* ImageTargetFileQoi.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BE4DD31DA9E4B900DE84C9 /* ImageTargetFileQoi.h */; };
+		27BE4DD81DA9E4B900DE84C9 /* ImageTargetFileQoi.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BE4DD31DA9E4B900DE84C9 /* ImageTargetFileQoi.h */; };
+		27BE4DD91DA9E4B900DE84C9 /* ImageTargetFileQoi.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BE4DD31DA9E4B900DE84C9 /* ImageTargetFileQoi.h */; };
+		27BE4DDA1DA9E4DD00DE84C9 /* ImageTargetFileQoi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA851B1C1B2000A23DDD /* ImageTargetFileQoi.cpp */; };
+		27BE4DDB1DA9E4DE00DE84C9 /* ImageTargetFileQoi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA851B1C1B2000A23DDD /* ImageTargetFileQoi.cpp */; };
+		27BE4DDC1DA9E4DF00DE84C9 /* ImageTargetFileQoi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA851B1C1B2000A23DDD /* ImageTargetFileQoi.cpp */; };
+		27BE4DDD1DA9E4FC00DE84C9 /* ImageSourceFileQoi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA841B1C1B2000A23DDC /* ImageSourceFileQoi.cpp */; };
+		27BE4DDE1DA9E4FC00DE84C9 /* ImageSourceFileQoi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA841B1C1B2000A23DDC /* ImageSourceFileQoi.cpp */; };
+		27BE4DDF1DA9E4FD00DE84C9 /* ImageSourceFileQoi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 111FBA841B1C1B2000A23DDC /* ImageSourceFileQoi.cpp */; };
 		27C100001BD16D4800AF387F /* highlevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 111A5E67191F703D005C3166 /* highlevel.h */; };
 		27C100011BD16D4800AF387F /* SvgGl.h in Headers */ = {isa = PBXBuildFile; fileRef = 008B439C14F5F39100B55B07 /* SvgGl.h */; };
 		27C100021BD16D4800AF387F /* QuickTimeGlImplLegacy.h in Headers */ = {isa = PBXBuildFile; fileRef = 006D706519942C31008149E2 /* QuickTimeGlImplLegacy.h */; };
@@ -2059,6 +2071,8 @@
 		111A5FA6191F72AE005C3166 /* WaveTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WaveTable.cpp; sourceTree = "<group>"; };
 		111FBA7E1B1C1B2000A23DDB /* ImageSourceFileStbImage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageSourceFileStbImage.cpp; sourceTree = "<group>"; };
 		111FBA7F1B1C1B2000A23DDB /* ImageTargetFileStbImage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageTargetFileStbImage.cpp; sourceTree = "<group>"; };
+		111FBA841B1C1B2000A23DDC /* ImageSourceFileQoi.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageSourceFileQoi.cpp; sourceTree = "<group>"; };
+		111FBA851B1C1B2000A23DDD /* ImageTargetFileQoi.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageTargetFileQoi.cpp; sourceTree = "<group>"; };
 		111FBA811B1C1B2000A23DDB /* ImageSourcePng.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageSourcePng.cpp; sourceTree = "<group>"; };
 		111FBA821B1C1B2000A23DDB /* UrlImplCurl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UrlImplCurl.cpp; sourceTree = "<group>"; };
 		111FBA831B1C1B2000A23DDB /* UrlImplWinInet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UrlImplWinInet.cpp; sourceTree = "<group>"; };
@@ -2134,6 +2148,8 @@
 		277C2CEE1366632B00178A29 /* Matrix44.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = Matrix44.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		27BE4DC41DA9E4B900DE84C8 /* ImageSourceFileStbImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageSourceFileStbImage.h; sourceTree = "<group>"; };
 		27BE4DC51DA9E4B900DE84C8 /* ImageTargetFileStbImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageTargetFileStbImage.h; sourceTree = "<group>"; };
+		27BE4DD21DA9E4B900DE84C9 /* ImageSourceFileQoi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageSourceFileQoi.h; sourceTree = "<group>"; };
+		27BE4DD31DA9E4B900DE84C9 /* ImageTargetFileQoi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageTargetFileQoi.h; sourceTree = "<group>"; };
 		27C100CF1BD16D4800AF387F /* libcinder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libcinder.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		27C1FF771BD0AE3400AF387F /* libcinder.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libcinder.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		32DBCF5E0370ADEE00C91783 /* cinder_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cinder_Prefix.pch; sourceTree = "<group>"; };
@@ -2691,8 +2707,10 @@
 				009FD55410C9DB0600D63B1B /* ImageSourceFileQuartz.h */,
 				00FFAED419DB5D330002CA8E /* ImageSourceFileRadiance.h */,
 				27BE4DC41DA9E4B900DE84C8 /* ImageSourceFileStbImage.h */,
+				27BE4DD21DA9E4B900DE84C9 /* ImageSourceFileQoi.h */,
 				00BC89F110D2EA2200D6DC59 /* ImageTargetFileQuartz.h */,
 				27BE4DC51DA9E4B900DE84C8 /* ImageTargetFileStbImage.h */,
+				27BE4DD31DA9E4B900DE84C9 /* ImageTargetFileQoi.h */,
 				43F78EF51516DAE200EB63B5 /* Json.h */,
 				0003F47A1992DA7C00647C8B /* Log.h */,
 				00241AB00E830DBA004D34EB /* Matrix.h */,
@@ -2780,9 +2798,11 @@
 				009FD55610CAB8B700D63B1B /* ImageSourceFileQuartz.cpp */,
 				00FFAED019DB5CFD0002CA8E /* ImageSourceFileRadiance.cpp */,
 				111FBA7E1B1C1B2000A23DDB /* ImageSourceFileStbImage.cpp */,
+				111FBA841B1C1B2000A23DDC /* ImageSourceFileQoi.cpp */,
 				111FBA811B1C1B2000A23DDB /* ImageSourcePng.cpp */,
 				00BC8A0810D2EE2000D6DC59 /* ImageTargetFileQuartz.cpp */,
 				111FBA7F1B1C1B2000A23DDB /* ImageTargetFileStbImage.cpp */,
+				111FBA851B1C1B2000A23DDD /* ImageTargetFileQoi.cpp */,
 				43F78EF11516DAB700EB63B5 /* Json.cpp */,
 				0003F47E1992DA9A00647C8B /* Log.cpp */,
 				00241ABD0E830DD5004D34EB /* Matrix.cpp */,
@@ -3991,6 +4011,7 @@
 				B3EA3FD41DD0EEA900E34348 /* ftobjs.h in Headers */,
 				B322C4981DC7DC7100D2E661 /* zconf.h in Headers */,
 				27BE4DC71DA9E4B900DE84C8 /* ImageSourceFileStbImage.h in Headers */,
+				27BE4DD51DA9E4B900DE84C9 /* ImageSourceFileQoi.h in Headers */,
 				27C1FE661BD0AE3400AF387F /* DataSource.h in Headers */,
 				27C1FE671BD0AE3400AF387F /* QuickTime.h in Headers */,
 				B3EA3F7D1DD0EEA900E34348 /* ftimage.h in Headers */,
@@ -4051,6 +4072,7 @@
 				27C1FE8A1BD0AE3400AF387F /* Filesystem.h in Headers */,
 				27C1FE8B1BD0AE3400AF387F /* Function.h in Headers */,
 				27BE4DCA1DA9E4B900DE84C8 /* ImageTargetFileStbImage.h in Headers */,
+				27BE4DD81DA9E4B900DE84C9 /* ImageTargetFileQoi.h in Headers */,
 				27C1FE8C1BD0AE3400AF387F /* backends.h in Headers */,
 				27C1FE8D1BD0AE3400AF387F /* rapidxml_print.hpp in Headers */,
 				27C1FE8E1BD0AE3400AF387F /* rapidxml.hpp in Headers */,
@@ -4207,10 +4229,12 @@
 				27C1FFA71BD16D4800AF387F /* mdct.h in Headers */,
 				27C1FFA81BD16D4800AF387F /* Log.h in Headers */,
 				27BE4DC81DA9E4B900DE84C8 /* ImageSourceFileStbImage.h in Headers */,
+				27BE4DD61DA9E4B900DE84C9 /* ImageSourceFileQoi.h in Headers */,
 				27C1FFA91BD16D4800AF387F /* Arcball.h in Headers */,
 				27C1FFAA1BD16D4800AF387F /* TriMesh.h in Headers */,
 				27C1FFAB1BD16D4800AF387F /* ObjLoader.h in Headers */,
 				27BE4DCB1DA9E4B900DE84C8 /* ImageTargetFileStbImage.h in Headers */,
+				27BE4DD91DA9E4B900DE84C9 /* ImageTargetFileQoi.h in Headers */,
 				27C1FFAC1BD16D4800AF387F /* Display.h in Headers */,
 				27C1FFAD1BD16D4800AF387F /* envelope.h in Headers */,
 				B3EA3F361DD0EEA900E34348 /* ftconfig.h in Headers */,
@@ -4411,6 +4435,7 @@
 				003832DF0E9C03CB00ACB120 /* Stream.h in Headers */,
 				0003F43C1992D67300647C8B /* BufferObj.h in Headers */,
 				27BE4DC61DA9E4B900DE84C8 /* ImageSourceFileStbImage.h in Headers */,
+				27BE4DD41DA9E4B900DE84C9 /* ImageSourceFileQoi.h in Headers */,
 				84A3FFE624048D1B00932807 /* imgui_freetype.h in Headers */,
 				007438E00EA7975A005DD3E6 /* Capture.h in Headers */,
 				00D23A560EAEB4DE0002BF91 /* Color.h in Headers */,
@@ -4463,6 +4488,7 @@
 				00F601CC19F6CA2D00C83781 /* Ubo.h in Headers */,
 				B3EA3FA91DD0EEA900E34348 /* ftstroke.h in Headers */,
 				27BE4DC91DA9E4B900DE84C8 /* ImageTargetFileStbImage.h in Headers */,
+				27BE4DD71DA9E4B900DE84C9 /* ImageTargetFileQoi.h in Headers */,
 				006D708119942C31008149E2 /* QuickTimeUtils.h in Headers */,
 				111A5EBE191F703D005C3166 /* lsp.h in Headers */,
 				002DFC060FA50D0200E45AE0 /* TriMesh.h in Headers */,
@@ -5009,6 +5035,7 @@
 				27C100B01BD16D4800AF387F /* VaoImplCore.cpp in Sources */,
 				27C100B11BD16D4800AF387F /* linebreakdef.c in Sources */,
 				27BE4DCE1DA9E4DF00DE84C8 /* ImageTargetFileStbImage.cpp in Sources */,
+				27BE4DDC1DA9E4DF00DE84C9 /* ImageTargetFileQoi.cpp in Sources */,
 				27C100B21BD16D4800AF387F /* SampleRecorderNode.cpp in Sources */,
 				27C100B31BD16D4800AF387F /* TextureFormatParsers.cpp in Sources */,
 				B322C4901DC7DC7100D2E661 /* trees.c in Sources */,
@@ -5022,6 +5049,7 @@
 				27C100BA1BD16D4800AF387F /* Capture.cpp in Sources */,
 				27C100BB1BD16D4800AF387F /* CaptureImplCocoaDummy.mm in Sources */,
 				27BE4DD11DA9E4FD00DE84C8 /* ImageSourceFileStbImage.cpp in Sources */,
+				27BE4DDF1DA9E4FD00DE84C9 /* ImageSourceFileQoi.cpp in Sources */,
 				27C100BC1BD16D4800AF387F /* floor1.c in Sources */,
 				B3EA408D1DD0F00900E34348 /* ftbitmap.c in Sources */,
 				B3EA40611DD0EF5C00E34348 /* type1.c in Sources */,
@@ -5262,6 +5290,7 @@
 				27C1FF5A1BD0AE3400AF387F /* VaoImplCore.cpp in Sources */,
 				27C1FF5B1BD0AE3400AF387F /* linebreak.c in Sources */,
 				27BE4DCD1DA9E4DE00DE84C8 /* ImageTargetFileStbImage.cpp in Sources */,
+				27BE4DDB1DA9E4DE00DE84C9 /* ImageTargetFileQoi.cpp in Sources */,
 				27C1FF5C1BD0AE3400AF387F /* SampleRecorderNode.cpp in Sources */,
 				27C1FF5D1BD0AE3400AF387F /* linebreakdata.c in Sources */,
 				B322C48F1DC7DC7100D2E661 /* trees.c in Sources */,
@@ -5275,6 +5304,7 @@
 				27C1FF641BD0AE3400AF387F /* Window.cpp in Sources */,
 				27C1FF651BD0AE3400AF387F /* Display.cpp in Sources */,
 				27BE4DD01DA9E4FC00DE84C8 /* ImageSourceFileStbImage.cpp in Sources */,
+				27BE4DDE1DA9E4FC00DE84C9 /* ImageSourceFileQoi.cpp in Sources */,
 				27C1FF661BD0AE3400AF387F /* floor1.c in Sources */,
 				B3EA408C1DD0F00900E34348 /* ftbitmap.c in Sources */,
 				B3EA40601DD0EF5C00E34348 /* type1.c in Sources */,
@@ -5332,6 +5362,7 @@
 				00F3BD1D0EBF88AA00382AC1 /* Utilities.cpp in Sources */,
 				006D705019942BF5008149E2 /* QuickTimeGlImplAvf.cpp in Sources */,
 				27BE4DCC1DA9E4DD00DE84C8 /* ImageTargetFileStbImage.cpp in Sources */,
+				27BE4DDA1DA9E4DD00DE84C9 /* ImageTargetFileQoi.cpp in Sources */,
 				111A5FA7191F72AE005C3166 /* ChannelRouterNode.cpp in Sources */,
 				111A5EBD191F703D005C3166 /* lsp.c in Sources */,
 				B3EA40BB1DD0F00900E34348 /* fttype1.c in Sources */,
@@ -5473,6 +5504,7 @@
 				111A6010191F72AE005C3166 /* Voice.cpp in Sources */,
 				B322C4731DC7DC7100D2E661 /* gzwrite.c in Sources */,
 				27BE4DCF1DA9E4FC00DE84C8 /* ImageSourceFileStbImage.cpp in Sources */,
+				27BE4DDD1DA9E4FC00DE84C9 /* ImageSourceFileQoi.cpp in Sources */,
 				00A113D5135535C500081873 /* Triangulate.cpp in Sources */,
 				B3EA40EB1DD0F0EE00E34348 /* psaux.c in Sources */,
 				0003F3DE1992D64100647C8B /* BufferTexture.cpp in Sources */,

--- a/src/cinder/ImageSourceFileQoi.cpp
+++ b/src/cinder/ImageSourceFileQoi.cpp
@@ -1,0 +1,105 @@
+/*
+ Copyright (c) 2025, The Cinder Project, All rights reserved.
+
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "cinder/ImageSourceFileQoi.h"
+#define QOI_IMPLEMENTATION
+#include "qoi/qoi.h"
+
+namespace cinder {
+
+///////////////////////////////////////////////////////////////////////////////
+// Registrar
+void ImageSourceFileQoi::registerSelf()
+{
+	static bool alreadyRegistered = false;
+	static const int32_t SOURCE_PRIORITY = 2;
+
+	if( alreadyRegistered )
+		return;
+	alreadyRegistered = true;
+
+	ImageIoRegistrar::SourceCreationFunc sourceFunc = ImageSourceFileQoi::create;
+	ImageIoRegistrar::registerSourceType( "qoi", sourceFunc, SOURCE_PRIORITY );
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// ImageSourceFileQoi
+ImageSourceFileQoi::ImageSourceFileQoi( DataSourceRef dataSourceRef, ImageSource::Options /*options*/ )
+	: mData( nullptr ), mRowBytes( 0 )
+{
+	qoi_desc desc;
+	int channels = 0;
+
+	if( dataSourceRef->isFilePath() ) {
+		mData = (uint8_t*)qoi_read( dataSourceRef->getFilePath().string().c_str(), &desc, 0 );
+		if( ! mData )
+			throw ImageIoExceptionFailedLoad( "Failed to load QOI image" );
+
+		channels = desc.channels;
+		mRowBytes = desc.width * channels;
+	}
+	else { // we'll use a dataref from the buffer
+		BufferRef buffer = dataSourceRef->getBuffer();
+		mData = (uint8_t*)qoi_decode( buffer->getData(), (int)buffer->getSize(), &desc, 0 );
+		if( ! mData )
+			throw ImageIoExceptionFailedLoad( "Failed to decode QOI image" );
+
+		channels = desc.channels;
+		mRowBytes = desc.width * channels;
+	}
+
+	setDataType( ImageIo::UINT8 );
+	setSize( desc.width, desc.height );
+
+	switch( channels ) {
+		case 3:
+			setColorModel( ImageIo::CM_RGB );
+			setChannelOrder( ImageIo::ChannelOrder::RGB );
+		break;
+		case 4:
+			setColorModel( ImageIo::CM_RGB );
+			setChannelOrder( ImageIo::ChannelOrder::RGBA );
+		break;
+		default:
+			free( mData );
+			throw ImageIoException( "QOI: Unsupported number of channels" );
+	}
+}
+
+
+ImageSourceFileQoi::~ImageSourceFileQoi()
+{
+	if( mData )
+		free( mData );
+}
+
+void ImageSourceFileQoi::load( ImageTargetRef target )
+{
+	ImageSource::RowFunc func = setupRowFunc( target );
+	for( int32_t row = 0; row < mHeight; ++row ) {
+		((*this).*func)( target, row, mData + row * mRowBytes );
+	}
+}
+
+} // namespace cinder

--- a/src/cinder/ImageTargetFileQoi.cpp
+++ b/src/cinder/ImageTargetFileQoi.cpp
@@ -1,0 +1,114 @@
+/*
+ Copyright (c) 2025, The Cinder Project, All rights reserved.
+
+ This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "cinder/ImageTargetFileQoi.h"
+#include "cinder/Log.h"
+
+// Note: QOI_IMPLEMENTATION is defined in ImageSourceFileQoi.cpp
+// to avoid multiple definition errors
+#include "qoi/qoi.h"
+
+namespace cinder {
+
+void ImageTargetFileQoi::registerSelf()
+{
+	static bool alreadyRegistered = false;
+	const int32_t PRIORITY = 2;
+
+	if( alreadyRegistered )
+		return;
+	alreadyRegistered = true;
+
+	ImageIoRegistrar::TargetCreationFunc func = ImageTargetFileQoi::create;
+	ImageIoRegistrar::registerTargetType( "qoi", func, PRIORITY, "qoi" );
+}
+
+ImageTargetRef ImageTargetFileQoi::create( DataTargetRef dataTarget, ImageSourceRef imageSource, ImageTarget::Options options, const std::string &extensionData )
+{
+	return ImageTargetRef( new ImageTargetFileQoi( dataTarget, imageSource, options, extensionData ) );
+}
+
+ImageTargetFileQoi::ImageTargetFileQoi( DataTargetRef dataTarget, ImageSourceRef imageSource, ImageTarget::Options options, const std::string &extensionData )
+	: mDataTarget( dataTarget )
+{
+	if( ! ( mDataTarget->providesFilePath() || mDataTarget->getStream() ) ) {
+		throw ImageIoExceptionFailedWrite( "No file path or stream provided" );
+	}
+
+	setSize( imageSource->getWidth(), imageSource->getHeight() );
+	ImageIo::ColorModel cm = options.isColorModelDefault() ? imageSource->getColorModel() : options.getColorModel();
+
+	switch( cm ) {
+		case ImageIo::ColorModel::CM_RGB:
+			mNumComponents = ( imageSource->hasAlpha() ) ? 4 : 3;
+			setColorModel( ImageIo::ColorModel::CM_RGB );
+			setChannelOrder( ( mNumComponents == 4 ) ? ImageIo::ChannelOrder::RGBA : ImageIo::ChannelOrder::RGB );
+		break;
+		default:
+			throw ImageIoExceptionIllegalColorModel( "QOI only supports RGB/RGBA color models" );
+	}
+
+	setDataType( ImageIo::DataType::UINT8 );
+	mRowBytes = mNumComponents * imageSource->getWidth();
+
+	if( mDataTarget->providesFilePath() ) {
+		mFilePath = dataTarget->getFilePath();
+	}
+
+	mData = std::unique_ptr<uint8_t[]>( new uint8_t[mHeight * mRowBytes] );
+}
+
+void* ImageTargetFileQoi::getRowPointer( int32_t row )
+{
+	return &mData.get()[row * mRowBytes];
+}
+
+void ImageTargetFileQoi::finalize()
+{
+	qoi_desc desc;
+	desc.width = (unsigned int)mWidth;
+	desc.height = (unsigned int)mHeight;
+	desc.channels = mNumComponents;
+	desc.colorspace = QOI_SRGB;
+
+	if( ! mFilePath.empty() ) {
+		if( ! qoi_write( mFilePath.string().c_str(), mData.get(), &desc ) )
+			throw ImageIoExceptionFailedWrite( "Failed to write QOI image" );
+	}
+	else {
+		// Encode to memory
+		int encodedSize = 0;
+		void *encoded = qoi_encode( mData.get(), &desc, &encodedSize );
+		if( ! encoded )
+			throw ImageIoExceptionFailedWrite( "Failed to encode QOI image" );
+
+		// Write to stream
+		OStream *stream = mDataTarget->getStream().get();
+		stream->writeData( encoded, static_cast<size_t>( encodedSize ) );
+
+		// Free the encoded buffer
+		free( encoded );
+	}
+}
+
+} // namespace cinder

--- a/src/cinder/app/android/PlatformAndroid.cpp
+++ b/src/cinder/app/android/PlatformAndroid.cpp
@@ -29,6 +29,8 @@
 #include "cinder/ImageSourceFileRadiance.h"
 #include "cinder/ImageSourceFileStbImage.h"
 #include "cinder/ImageTargetFileStbImage.h"
+#include "cinder/ImageSourceFileQoi.h"
+#include "cinder/ImageTargetFileQoi.h"
 
 #include "cinder/android/app/CinderNativeActivity.h"
 #include "cinder/android/hardware/Camera.h"
@@ -55,6 +57,8 @@ PlatformAndroid::PlatformAndroid()
 	ImageSourceFileRadiance::registerSelf();
 	ImageSourceFileStbImage::registerSelf();
 	ImageTargetFileStbImage::registerSelf();
+	ImageSourceFileQoi::registerSelf();
+	ImageTargetFileQoi::registerSelf();
 
 	dbg_app_log( "PlatformAndroid::PlatformAndroid" );
 

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -30,6 +30,8 @@
 #include "cinder/ImageTargetFileQuartz.h"
 #include "cinder/ImageSourceFileRadiance.h"
 #include "cinder/ImageFileTinyExr.h"
+#include "cinder/ImageSourceFileQoi.h"
+#include "cinder/ImageTargetFileQoi.h"
 
 #if defined( CINDER_MAC )
 	#import <Cocoa/Cocoa.h>
@@ -58,10 +60,12 @@ PlatformCocoa::PlatformCocoa()
 
 	// register default ImageSources and ImageTargets
 	ImageSourceFileQuartz::registerSelf();
-	ImageTargetFileQuartz::registerSelf();	
+	ImageTargetFileQuartz::registerSelf();
 	ImageSourceFileRadiance::registerSelf();
 	ImageSourceFileTinyExr::registerSelf();
 	ImageTargetFileTinyExr::registerSelf();
+	ImageSourceFileQoi::registerSelf();
+	ImageTargetFileQoi::registerSelf();
 }
 
 void PlatformCocoa::prepareLaunch()

--- a/src/cinder/app/linux/PlatformLinux.cpp
+++ b/src/cinder/app/linux/PlatformLinux.cpp
@@ -26,6 +26,8 @@
 #include "cinder/ImageSourceFileRadiance.h"
 #include "cinder/ImageSourceFileStbImage.h"
 #include "cinder/ImageTargetFileStbImage.h"
+#include "cinder/ImageSourceFileQoi.h"
+#include "cinder/ImageTargetFileQoi.h"
 #include "cinder/ImageFileTinyExr.h"
 #include "cinder/Utilities.h"
 #include "cinder/Log.h"
@@ -58,6 +60,8 @@ PlatformLinux::PlatformLinux()
 	ImageSourceFileRadiance::registerSelf();
 	ImageSourceFileStbImage::registerSelf();
 	ImageTargetFileStbImage::registerSelf();
+	ImageSourceFileQoi::registerSelf();
+	ImageTargetFileQoi::registerSelf();
 	ImageSourceFileTinyExr::registerSelf();
 	ImageTargetFileTinyExr::registerSelf();
 }

--- a/src/cinder/app/msw/PlatformMsw.cpp
+++ b/src/cinder/app/msw/PlatformMsw.cpp
@@ -32,6 +32,8 @@
 #include "cinder/ImageFileTinyExr.h"
 #include "cinder/ImageSourceFileStbImage.h"
 #include "cinder/ImageTargetFileStbImage.h"
+#include "cinder/ImageSourceFileQoi.h"
+#include "cinder/ImageTargetFileQoi.h"
 
 #include <windows.h>
 #include <Shlwapi.h>
@@ -73,6 +75,8 @@ PlatformMsw::PlatformMsw()
 	ImageTargetFileTinyExr::registerSelf();
 	ImageSourceFileStbImage::registerSelf();
 	ImageTargetFileStbImage::registerSelf();
+	ImageSourceFileQoi::registerSelf();
+	ImageTargetFileQoi::registerSelf();
 }
 
 DataSourceRef PlatformMsw::loadResource( const fs::path &resourcePath, int mswID, const std::string &mswType )


### PR DESCRIPTION
Implements `ImageSourceFileQoi` and `ImageTargetFileQoi` for loading and saving QOI (Quite OK Image) format. 
QOI is a widely supported (by FFmpeg and ImageMagick, among others) lossless image format that offers:
 - ~20-50x faster encoding than PNG
 - ~3-4x faster decoding than PNG
 - ~comparable compression ratios to PNG
 - Support for alpha channels
 - [Benchmarks](https://qoiformat.org/benchmark/)

We've used it at Rare Volume with great success to substantially improve asset load times on various projects. This implementation is based on the reference implementation at phoboslab/qoi@d749efc.

<img width="1504" height="1240" alt="image" src="https://github.com/user-attachments/assets/38432b54-1e1f-4b6b-b42a-47061ad52edf" />

