### PR TITLE
Use CMake policy CMP0091 for MSVC runtime library selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
-cmake_minimum_required( VERSION 3.10 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.15 FATAL_ERROR )
 set( CMAKE_VERBOSE_MAKEFILE ON )
+
+if( POLICY CMP0091 )
+	cmake_policy( SET CMP0091 NEW )
+endif()
 
 # Configure the Android toolchain before the project start
 if( CINDER_TARGET )

--- a/proj/cmake/libcinder_configure.cmake
+++ b/proj/cmake/libcinder_configure.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.10 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.15 FATAL_ERROR )
 
 ci_log_v( "Building Cinder for ${CINDER_TARGET}" )
 

--- a/proj/cmake/modules/cinderMakeApp.cmake
+++ b/proj/cmake/modules/cinderMakeApp.cmake
@@ -110,17 +110,11 @@ function( ci_make_app )
 		endif()
 	elseif( CINDER_MSW )
 		if( MSVC )
-			# Override the default /MD with /MT
-			foreach(
-				flag_var
-				CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
-				CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
-			)
-				if( ${flag_var} MATCHES "/MD" )
-					string( REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}" )
-					set( "${flag_var}" "${${flag_var}}" PARENT_SCOPE )
-				endif()
-			endforeach()
+			# Default to static runtime (/MT) unless user specifies otherwise
+			if( NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY )
+				set( CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>" )
+			endif()
+
 			# Force synchronous PDB writes
 			add_compile_options( /FS )
 			# Force multiprocess compilation

--- a/proj/cmake/platform_msw.cmake
+++ b/proj/cmake/platform_msw.cmake
@@ -110,16 +110,11 @@ list( APPEND CINDER_INCLUDE_SYSTEM_PRIVATE
 list( APPEND CINDER_DEFINES "_LIB;UNICODE;_UNICODE;NOMINMAX;_WIN32_WINNT=0x0601;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS" )
 
 if( MSVC )
-	# Override the default /MD with /MT
-	foreach( 
-		flag_var
-		CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO 
-		CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO 
-	)
-		if( ${flag_var} MATCHES "/MD" )
-			string( REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}" )
-		endif()
-	endforeach()
+	# Default to static runtime (/MT) unless user specifies otherwise
+	if( NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY )
+		set( CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>" )
+	endif()
+
 	# Force synchronous PDB writes
 	add_compile_options( /FS )
 	# Force multiprocess compilation


### PR DESCRIPTION
## Summary
Modernize MSVC runtime library configuration using CMake policy [CMP0091](https://cmake.org/cmake/help/latest/policy/CMP0091.html) and the `CMAKE_MSVC_RUNTIME_LIBRARY` variable.

## Changes
- Bump minimum CMake version from 3.10 to 3.15
- Enable CMake policy CMP0091 for MSVC runtime library selection
- Replace manual `/MD` to `/MT` flag string manipulation with `CMAKE_MSVC_RUNTIME_LIBRARY`
- Apply changes to both Cinder library build and `ci_make_app()` macro

## Behavior
**Default:** Static runtime (`/MT` for Release, `/MTd` for Debug) - unchanged from previous behavior

**User override:** Set `CMAKE_MSVC_RUNTIME_LIBRARY` before including Cinder's CMake files, or via command line:
```bash
cmake -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDebugDLL" ..
```

## Testing
Tested all Debug/Release configurations with both static (`/MT`) and dynamic (`/MD`) runtimes. Verified correct runtime library selection via dumpbin and confirmed linker properly detects runtime mismatches.

Resolves #2117