### PR TITLE
Windows-based support for ending a move/resize window interaction.

### DIFF
--- a/include/cinder/app/Window.h
+++ b/include/cinder/app/Window.h
@@ -404,6 +404,9 @@ class CI_API Window : public std::enable_shared_from_this<Window> {
 	EventSignalWindow&	getSignalResize() { return mSignalResize; }
 	void 				emitResize();
 
+	EventSignalWindow& getSignalPostResizeMove() { return mSignalPostResizeMove; }
+	void			   emitPostResizeMove();
+
 	EventSignalWindow&	getSignalDisplayChange() { return mSignalDisplayChange; }
 	void				emitDisplayChange();
 
@@ -478,7 +481,7 @@ class CI_API Window : public std::enable_shared_from_this<Window> {
 	EventSignalMouse		mSignalMouseDown, mSignalMouseDrag, mSignalMouseUp, mSignalMouseWheel, mSignalMouseMove;
 	EventSignalTouch		mSignalTouchesBegan, mSignalTouchesMoved, mSignalTouchesEnded;
 	EventSignalKey			mSignalKeyDown, mSignalKeyUp;
-	EventSignalWindow		mSignalDraw, mSignalPostDraw, mSignalMove, mSignalResize, mSignalDisplayChange, mSignalClose;
+	EventSignalWindow		mSignalDraw, mSignalPostDraw, mSignalMove, mSignalResize, mSignalPostResizeMove, mSignalDisplayChange, mSignalClose;
 	EventSignalFileDrop		mSignalFileDrop;
 	
 #if defined( CINDER_COCOA )

--- a/src/cinder/app/Window.cpp
+++ b/src/cinder/app/Window.cpp
@@ -306,6 +306,13 @@ void Window::emitResize()
 	getApp()->resize();
 }
 
+void Window::emitPostResizeMove()
+{
+	applyCurrentContext();
+
+	mSignalPostResizeMove.emit();
+}
+
 void Window::emitDisplayChange()
 {
 	applyCurrentContext();

--- a/src/cinder/app/msw/AppImplMsw.cpp
+++ b/src/cinder/app/msw/AppImplMsw.cpp
@@ -766,6 +766,13 @@ LRESULT CALLBACK WndProc(	HWND	mWnd,			// Handle For This Window
 			return 0;
 		}
 		break;
+		case WM_EXITSIZEMOVE: {
+			if( impl->getWindow() ) {
+				impl->getWindow()->emitPostResizeMove();
+			}
+			return 0;
+		}
+		break;
 		case WM_DROPFILES: {
 			HDROP dropH = (HDROP)wParam;
 			POINT dropPoint;


### PR DESCRIPTION
As this is my first contribution, I'll both apologize and in advance do my best to address necessary changes.

I've found a need to be able to tell if a resizing operation has ceased on windows, at which point I wish to re-render a windows content but not before. Determining this without the actual OS signal isn't straight-forward so I opted to add it in for the platform I'm working on. On Mac, admittedly, this will not trigger, and I'm a bit of a Mac novice, so testing it isn't so feasible for me at the moment.

An explicit test for a user interaction is a bit tricky, but I'm open to suggestions.