### PR TITLE
Fix the condition for Capture.cpp source file when disabling video

### DIFF
--- a/proj/cmake/libcinder_source_files.cmake
+++ b/proj/cmake/libcinder_source_files.cmake
@@ -66,7 +66,7 @@ list( APPEND SRC_SET_CINDER
 	${CINDER_SRC_DIR}/cinder/Xml.cpp
 )
 
-if( NOT CINDER_ANDROID )
+if( (NOT CINDER_ANDROID) AND (NOT CINDER_DISABLE_VIDEO) )
     list( APPEND SRC_SET_CINDER
         ${CINDER_SRC_DIR}/cinder/Capture.cpp
     )


### PR DESCRIPTION
Fix build fail that occurs when the CINDER_DISABLE_VIDEO option is enabled by conditionally removing `Capture.cpp`