### PR TITLE
Fix GLFW DPI scale when high-density framebuffers are disabled

### DIFF
--- a/src/cinder/app/glfw/WindowImplGlfw.cpp
+++ b/src/cinder/app/glfw/WindowImplGlfw.cpp
@@ -197,6 +197,10 @@ void WindowImplGlfw::show()
 
 float WindowImplGlfw::getContentScale() const
 {
+	if( ! mAppImpl->getApp()->isHighDensityDisplayEnabled() ) {
+		return 1.0f;
+	}
+
 	float xscale = 1.0f, yscale = 1.0f;
 	::glfwGetWindowContentScale( mGlfwWindow, &xscale, &yscale );
 	// Return the larger of the two scales (they should typically be the same)


### PR DESCRIPTION
This fixes a DPI/content-scale mismatch in the GLFW backend that caused ImGui and app rendering to shift (and sometimes disappear in fullscreen) during resize. Reproducible in the ImGui sample.

`WindowImplGlfw::getContentScale()` returned the monitor DPI scale even when high-density framebuffers were disabled. Code using `toPixels()` (including ImGui) then over-scaled coordinates relative to the actual framebuffer size.

Before the current GLFW rewrite, `Window::getContentScale()` returned `1.0f` for GLFW/Linux, which masked the mismatch.

Fix:
Gate GLFW content scale by the app’s high-density setting:
  - When `isHighDensityDisplayEnabled()` is false, return 1.0f
  - Otherwise, use `glfwGetWindowContentScale()` as before