### PR TITLE
Fix qtime palindrome loop for MacOS + user play rate on 1st play

### DIFF
--- a/include/cinder/app/cocoa/PlatformCocoa.h
+++ b/include/cinder/app/cocoa/PlatformCocoa.h
@@ -46,6 +46,8 @@
 typedef uint32_t CGDisplayChangeSummaryFlags;
 typedef uint32_t CGDirectDisplayID;
 
+struct GLFWmonitor;
+
 namespace cinder {
 #if defined( CINDER_MAC )
 	class DisplayMac;
@@ -151,6 +153,8 @@ class DisplayMac : public Display {
   public:
 	NSScreen*			getNsScreen() const;
 	CGDirectDisplayID	getCgDirectDisplayId() const { return mDirectDisplayId; }
+	//! Returns the GLFW monitor handle matching this display, or nullptr if none matches. Only meaningful when Cinder is built with the GLFW backend.
+	GLFWmonitor*		getGlfwMonitor() const;
 
 	std::string			getName() const override;
 

--- a/include/cinder/qtime/QuickTimeImplAvf.h
+++ b/include/cinder/qtime/QuickTimeImplAvf.h
@@ -137,6 +137,8 @@ class MovieBase {
 	 * Returns a boolean value indicating whether the rate value can be played (some media types cannot be played backwards)
 	 */
 	bool		setRate( float rate );
+    //! Gets the playback rate. It might be different from the one that was set because setRate failed or palindrome loop kicked off.
+    float       getRate() const;
 
 	//! Sets the audio playback volume ranging from [0 - 1.0]
 	void		setVolume( float volume );

--- a/include/cinder/qtime/QuickTimeImplAvf.h
+++ b/include/cinder/qtime/QuickTimeImplAvf.h
@@ -189,6 +189,7 @@ class MovieBase {
 	int32_t						mFrameCount;
 	float						mFrameRate;
 	float						mDuration;
+	float						mPlayRate;
 	std::atomic<bool>			mAssetLoaded;
 	bool						mLoaded, mPlayThroughOk, mPlayable, mProtected;
 	bool						mPlayingForward, mLoop, mPalindrome;

--- a/include/cinder/qtime/QuickTimeImplAvf.h
+++ b/include/cinder/qtime/QuickTimeImplAvf.h
@@ -32,6 +32,7 @@
 #include "cinder/Thread.h"
 #include "cinder/Url.h"
 
+#include <dispatch/dispatch.h>
 #include <string>
 
 typedef struct __CVBuffer *CVBufferRef;
@@ -200,6 +201,7 @@ class MovieBase {
 	AVPlayerItem*				mPlayerItem;
 	AVURLAsset*					mAsset;
 	AVPlayerItemVideoOutput*	mPlayerVideoOutput;
+	dispatch_queue_t			mOutputQueue;
 
 	std::mutex					mMutex;
 	

--- a/src/cinder/app/cocoa/PlatformCocoa.cpp
+++ b/src/cinder/app/cocoa/PlatformCocoa.cpp
@@ -44,6 +44,12 @@
 #include <execinfo.h>
 #include <pthread.h>
 
+#if defined( CINDER_GLFW )
+	#define GLFW_EXPOSE_NATIVE_COCOA
+	#include "glfw/glfw3.h"
+	#include "glfw/glfw3native.h"
+#endif
+
 using namespace std;
 
 namespace cinder { namespace app {
@@ -437,6 +443,19 @@ std::string getDisplayName( CGDirectDisplayID displayId )
 NSScreen* DisplayMac::getNsScreen() const
 {
 	return findNsScreenForCgDirectDisplayId( mDirectDisplayId );
+}
+
+GLFWmonitor* DisplayMac::getGlfwMonitor() const
+{
+#if defined( CINDER_GLFW )
+	int count = 0;
+	GLFWmonitor** monitors = ::glfwGetMonitors( &count );
+	for( int i = 0; i < count; ++i ) {
+		if( ::glfwGetCocoaMonitor( monitors[i] ) == mDirectDisplayId )
+			return monitors[i];
+	}
+#endif
+	return nullptr;
 }
 
 DisplayRef app::PlatformCocoa::findFromCgDirectDisplayId( CGDirectDisplayID displayId )

--- a/src/cinder/app/glfw/WindowImplGlfw.cpp
+++ b/src/cinder/app/glfw/WindowImplGlfw.cpp
@@ -32,6 +32,7 @@
 
 #if defined( CINDER_MAC )
 	#include "cinder/app/glfw/AppImplGlfwMac.h"
+	#include "cinder/app/cocoa/PlatformCocoa.h"
 #endif
 
 namespace cinder { namespace app {
@@ -75,10 +76,12 @@ WindowImplGlfw::WindowImplGlfw( const Window::Format &format, WindowImplGlfw *sh
 		auto windowSize = displayLinux->getSize();
 		mGlfwWindow = ::glfwCreateWindow( windowSize.x, windowSize.y, format.getTitle().c_str(), displayLinux->getGlfwMonitor(), sharedGlfwWindow );
 #elif defined( CINDER_MAC )
-		// On macOS, get the primary monitor for fullscreen
-		GLFWmonitor* primaryMonitor = ::glfwGetPrimaryMonitor();
+		auto* displayMac = dynamic_cast<cinder::DisplayMac*>( mDisplay.get() );
+		GLFWmonitor* monitor = displayMac ? displayMac->getGlfwMonitor() : nullptr;
+		if( ! monitor )
+			monitor = ::glfwGetPrimaryMonitor();
 		auto windowSize = mDisplay->getSize();
-		mGlfwWindow = ::glfwCreateWindow( windowSize.x, windowSize.y, format.getTitle().c_str(), primaryMonitor, sharedGlfwWindow );
+		mGlfwWindow = ::glfwCreateWindow( windowSize.x, windowSize.y, format.getTitle().c_str(), monitor, sharedGlfwWindow );
 #endif
 		mWindowedSize = format.getSize();
 		mWindowedPos = format.getPos();
@@ -140,8 +143,11 @@ void WindowImplGlfw::setFullScreen( bool fullScreen, const app::FullScreenOption
 		cinder::app::DisplayLinux* displayLinux = dynamic_cast<cinder::app::DisplayLinux*>( mDisplay.get() );
 		::glfwSetWindowMonitor( mGlfwWindow, displayLinux->getGlfwMonitor(), 0, 0, mDisplay->getWidth(), mDisplay->getHeight(), GLFW_DONT_CARE );
 #elif defined( CINDER_MAC )
-		GLFWmonitor* primaryMonitor = ::glfwGetPrimaryMonitor();
-		::glfwSetWindowMonitor( mGlfwWindow, primaryMonitor, 0, 0, mDisplay->getWidth(), mDisplay->getHeight(), GLFW_DONT_CARE );
+		auto* displayMac = dynamic_cast<cinder::DisplayMac*>( mDisplay.get() );
+		GLFWmonitor* monitor = displayMac ? displayMac->getGlfwMonitor() : nullptr;
+		if( ! monitor )
+			monitor = ::glfwGetPrimaryMonitor();
+		::glfwSetWindowMonitor( mGlfwWindow, monitor, 0, 0, mDisplay->getWidth(), mDisplay->getHeight(), GLFW_DONT_CARE );
 #endif
 	}
 	else {

--- a/src/cinder/qtime/QuickTimeImplAvf.mm
+++ b/src/cinder/qtime/QuickTimeImplAvf.mm
@@ -437,6 +437,14 @@ bool MovieBase::setRate( float rate )
 	return success;
 }
 
+float MovieBase::getRate() const
+{
+    if( ! mPlayer || ! mPlayerItem )
+        return 0.f;
+    
+    return mPlayer.rate;
+}
+
 void MovieBase::setVolume( float volume )
 {
 	if( ! mPlayer )

--- a/src/cinder/qtime/QuickTimeImplAvf.mm
+++ b/src/cinder/qtime/QuickTimeImplAvf.mm
@@ -183,6 +183,7 @@ MovieBase::MovieBase()
 	mPlayerItem( nil ),
 	mAsset( nil ),
 	mPlayerVideoOutput( nil ),
+	mOutputQueue( nil ),
 	mPlayerDelegate( nil ),
 	mResponder( nullptr ),
 	mAssetLoaded( false )
@@ -192,6 +193,21 @@ MovieBase::MovieBase()
 
 MovieBase::~MovieBase()
 {
+	// Stop the output delegate first and drain any in-flight background callback,
+	// e.g. outputSequenceWasFlushed.
+	if( mPlayerVideoOutput ) {
+		[mPlayerVideoOutput setDelegate:nil queue:nil];
+		if( mOutputQueue ) {
+			dispatch_sync( mOutputQueue, ^{} );
+		}
+		[mPlayerVideoOutput release];
+		mPlayerVideoOutput = nil;
+	}
+	if( mOutputQueue ) {
+		dispatch_release( mOutputQueue );
+		mOutputQueue = nil;
+	}
+
 	// remove all observers
 	removeObservers();
 	
@@ -207,9 +223,13 @@ MovieBase::~MovieBase()
 		[mAsset release];
 	}
 
-	if( mPlayerVideoOutput ) {
-		[mPlayerVideoOutput release];
+	if( mPlayerDelegate ) {
+		[mPlayerDelegate release];
+		mPlayerDelegate = nil;
 	}
+
+	delete mResponder;
+	mResponder = nullptr;
 }
 	
 float MovieBase::getPixelAspectRatio() const
@@ -703,8 +723,8 @@ void MovieBase::processAssetTracks( AVAsset* asset )
 void MovieBase::createPlayerItemOutput( const AVPlayerItem* playerItem )
 {
 	mPlayerVideoOutput = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:avPlayerItemOutputDictionary()];
-	dispatch_queue_t outputQueue = dispatch_queue_create("movieVideoOutputQueue", DISPATCH_QUEUE_SERIAL);
-	[mPlayerVideoOutput setDelegate:mPlayerDelegate queue:outputQueue];
+	mOutputQueue = dispatch_queue_create("movieVideoOutputQueue", DISPATCH_QUEUE_SERIAL);
+	[mPlayerVideoOutput setDelegate:mPlayerDelegate queue:mOutputQueue];
 	mPlayerVideoOutput.suppressesPlayerRendering = YES;
 	[playerItem addOutput:mPlayerVideoOutput];
 }

--- a/src/cinder/qtime/QuickTimeImplAvf.mm
+++ b/src/cinder/qtime/QuickTimeImplAvf.mm
@@ -410,6 +410,7 @@ bool MovieBase::setRate( float rate )
 	else
 		success = [mPlayerItem canPlaySlowForward];
 	
+	mPlayRate = rate;
 	[mPlayer setRate:rate];
 	
 	return success;
@@ -516,6 +517,7 @@ void MovieBase::init()
 	mHeight = -1;
 	mDuration = -1;
 	mFrameCount = -1;
+	mPlayRate = 1;
 }
 	
 void MovieBase::initFromUrl( const Url& url )
@@ -758,6 +760,7 @@ void MovieBase::playerReady()
 {
 	mSignalReady.emit();
 	
+	setRate(mPlayRate);  // previous setRate calls fail while the player is not ready
 	if( mPlaying )
 		play();
 }
@@ -765,9 +768,9 @@ void MovieBase::playerReady()
 void MovieBase::playerItemEnded()
 {
 	if( mPalindrome ) {
-		float rate = -[mPlayer rate];
-		mPlayingForward = (rate >= 0);
-		this->setRate( rate );
+		mPlayRate = -mPlayRate;
+		mPlayingForward = (mPlayRate >= 0);
+		this->setRate( mPlayRate );
 	}
 	else if( mLoop ) {
 		this->seekToStart();

--- a/src/cinder/qtime/QuickTimeImplAvf.mm
+++ b/src/cinder/qtime/QuickTimeImplAvf.mm
@@ -198,6 +198,7 @@ MovieBase::~MovieBase()
 	// release resources for AVF objects.
 	if( mPlayer ) {
 		[mPlayer cancelPendingPrerolls];
+		[mPlayer replaceCurrentItemWithPlayerItem:nil];
 		[mPlayer release];
 	}
 	


### PR DESCRIPTION
Fix palindrome:
Previous implementation relies on [mPlayer rate] at media end to play backward. But [mPlayer rate] == 0 at this point.
That's why I store the user play rate on a dedicated variable.

Fix set rate:
Set rate cannot be set too early on mPlayer => set it again when it's ready.